### PR TITLE
Verminlord Warpseer has Wizard(1) but should be Wizard(2)

### DIFF
--- a/Skaven - Library.cat
+++ b/Skaven - Library.cat
@@ -833,7 +833,7 @@
         <categoryLink name="SKAVEN" hidden="false" id="9006-63af-edcf-7aae" targetId="cce6-9e5a-dd33-a755" primary="false"/>
         <categoryLink name="WARD (5+)" hidden="false" id="c293-7620-5f8d-b8ba" targetId="52cc-95fd-6cd3-8f72" primary="false"/>
         <categoryLink name="CHAOS" hidden="false" id="731a-af3d-7165-7f8e" targetId="319b-38ee-d10d-e800" primary="false"/>
-        <categoryLink name="WIZARD (1)" hidden="false" id="41c8-c03-98bc-aac" targetId="6f28-c3f6-4b1b-8aff" primary="false"/>
+        <categoryLink name="WIZARD (2)" hidden="false" id="41c8-c03-98bc-aac" targetId="6f28-c3f6-4b1b-8aff" primary="false"/>
         <categoryLink name="DAEMON" hidden="false" id="a168-1325-a118-1d72" targetId="dc0b-e417-51f4-10f0" primary="false"/>
         <categoryLink name="MASTERCLAN" hidden="false" id="63d1-8016-fbfa-4ac0" targetId="7974-c5a2-e00a-f98f" primary="false"/>
       </categoryLinks>


### PR DESCRIPTION
Issue #33 
Incorrect value in [Skaven-Library.cat line 836](https://github.com/BSData/age-of-sigmar-4th/blob/main/Skaven%20-%20Library.cat#L836)

Verminlord Warpseer's Wizard value should be 2.

**Screenshots**
![verminlord-warpseer-index-page](https://github.com/user-attachments/assets/1e298447-084e-4687-aba3-5560b79ecdff)