### PR TITLE
fix myrmidon monster restrictions

### DIFF
--- a/Slaves to Darkness.cat
+++ b/Slaves to Darkness.cat
@@ -2497,12 +2497,6 @@ During the battle, the target gains **Dark Apotheosis** points as follows:
                 <localConditionGroup type="atLeast" value="1" scope="force" field="selections" includeChildSelections="true" includeChildForces="true" repeats="1">
                   <conditions>
                     <condition type="instanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
-                    <condition type="instanceOf" value="1" field="selections" scope="self" childId="2ea9-d799-4ed9-7920" shared="true"/>
-                  </conditions>
-                </localConditionGroup>
-                <localConditionGroup type="atLeast" value="1" scope="force" field="selections" includeChildSelections="true" includeChildForces="true" repeats="1">
-                  <conditions>
-                    <condition type="instanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
                     <condition type="instanceOf" value="1" field="selections" scope="self" childId="2332-5544-532f-b77b" shared="true"/>
                   </conditions>
                 </localConditionGroup>


### PR DESCRIPTION
Myrmidon still had a restriction on Fomoroid Crusher despite being any monster