### PR TITLE
Fix destiny point cost for Formidable Bastion

### DIFF
--- a/Path to Glory - Blighted Wilds.cat
+++ b/Path to Glory - Blighted Wilds.cat
@@ -7457,7 +7457,7 @@ In addition, make the following changes to your Regiment Hero&apos;s warscroll:
                 <selectionEntry type="upgrade" import="true" name="Formidable Bastion" hidden="false" id="c219-5f9c-3067-b407" sortIndex="3">
                   <costs>
                     <cost name="pts" typeId="points" value="0"/>
-                    <cost name="Destiny Point Limit" typeId="bc33-05f5-8d3f-af43" value="-4"/>
+                    <cost name="Destiny Point Limit" typeId="bc33-05f5-8d3f-af43" value="-6"/>
                     <cost name="Force Category - PTG" typeId="e63c-79ff-93ba-c5eb" value="0"/>
                     <cost name="Force Category - GHB" typeId="de92-2099-fbf7-a156" value="0"/>
                   </costs>


### PR DESCRIPTION
Fixes the points cost for the Formidable Bastion option for the Landmark of Ghyran (should be 6, Artistan-Crafted Altar is the 4DP option).