### PR TITLE
DoT - Update range of Tome of eye summon

### DIFF
--- a/Lores.cat
+++ b/Lores.cat
@@ -6369,7 +6369,7 @@ If the chanting roll was 10+, until the start of your next turn, add 1 to the Re
                 <characteristic name="Timing" typeId="de6f-d57b-248a-83be">Your Hero Phase</characteristic>
                 <characteristic name="Casting Value" typeId="9fc7-b0f6-d018-a608">5</characteristic>
                 <characteristic name="Declare" typeId="24f8-3803-4ab1-3b6c">If there is not a friendly **Tome of Eyes** on the battlefield, pick a friendly **^^Disciples of Tzeentch Wizard^^** to cast this spell, then make a casting roll of 2D6.</characteristic>
-                <characteristic name="Effect" typeId="1cb9-a-1345-907f">Set up a **Tome of Eyes** wholly within 12&quot; of the caster and visible to them.</characteristic>
+                <characteristic name="Effect" typeId="1cb9-a-1345-907f">Set up a **Tome of Eyes** wholly within 18&quot; of the caster and visible to them.</characteristic>
                 <characteristic name="Keywords" typeId="353f-565e-c351-1cf2">**^^Spell^^**, **^^Summon^^**</characteristic>
               </characteristics>
               <attributes>


### PR DESCRIPTION
According to the new BattleTome, the range of this summon is up to 18 instead of 12.