### PR TITLE
Update unit points to latest battle profile

### DIFF
--- a/Big Waaagh!.cat
+++ b/Big Waaagh!.cat
@@ -487,7 +487,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="1336-da82-54cb-f0b1" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="100"/>
+        <cost name="pts" typeId="points" value="90"/>
       </costs>
       <modifiers>
         <modifier type="set" value="Big Waaagh! rosters must have equal numbers of regiments led by IRONJAWZ and KRULEBOYZ HEROES." field="error">
@@ -744,7 +744,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="170"/>
+        <cost name="pts" typeId="points" value="160"/>
       </costs>
     </entryLink>
     <entryLink import="true" name="Ironskull&apos;s Boyz" hidden="false" id="ed2a-a101-de4f-77d5" type="selectionEntry" targetId="fd56-6594-4cd4-c765">
@@ -889,7 +889,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="240"/>
+        <cost name="pts" typeId="points" value="250"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="40b7-d17b-297b-a470" type="selectionEntryGroup" targetId="2c9a-a9ac-2c3e-6120"/>
@@ -910,7 +910,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="eb94-a81a-c6ce-8622" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="140"/>
+        <cost name="pts" typeId="points" value="130"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -1088,7 +1088,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="ec0c-1e17-4956-053c" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="250"/>
+        <cost name="pts" typeId="points" value="270"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -1248,7 +1248,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="100"/>
+        <cost name="pts" typeId="points" value="90"/>
       </costs>
       <constraints>
         <constraint type="max" value="-1" field="selections" scope="force" shared="true" id="24e8-aefd-d0ba-0bf0" includeChildSelections="true"/>
@@ -1347,7 +1347,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="140"/>
+        <cost name="pts" typeId="points" value="130"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Paths" hidden="false" id="be1e-15e9-766b-dc50" type="selectionEntryGroup" targetId="4f54-904a-d2f4-5695"/>
@@ -1642,7 +1642,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="160"/>
+        <cost name="pts" typeId="points" value="150"/>
       </costs>
       <constraints>
         <constraint type="max" value="-1" field="selections" scope="force" shared="true" id="9550-7464-a8e7-1f3c" includeChildSelections="true"/>
@@ -1957,7 +1957,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="155c-affc-0b1e-77f0" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="140"/>
+        <cost name="pts" typeId="points" value="130"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -2318,7 +2318,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="c6f1-f7b0-d177-8193" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="90"/>
+        <cost name="pts" typeId="points" value="80"/>
       </costs>
       <modifiers>
         <modifier type="set" value="Big Waaagh! rosters must have equal numbers of regiments led by IRONJAWZ and KRULEBOYZ HEROES." field="error">
@@ -2462,7 +2462,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="359b-2c97-0896-632a" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="200"/>
+        <cost name="pts" typeId="points" value="180"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -2570,7 +2570,7 @@
     </entryLink>
     <entryLink import="true" name="Swampboss Skumdrekk" hidden="false" id="771a-98a9-687b-128d" type="selectionEntry" targetId="57d2-f5d7-ec57-5d4a">
       <costs>
-        <cost name="pts" typeId="points" value="180"/>
+        <cost name="pts" typeId="points" value="150"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="f74e-c9f4-a640-71f5" type="selectionEntryGroup" targetId="2c9a-a9ac-2c3e-6120"/>

--- a/Blades of Khorne - Gorechosen Champions.cat
+++ b/Blades of Khorne - Gorechosen Champions.cat
@@ -304,7 +304,7 @@ For the rest of the battle, this unit cannot use the &apos;Hate-fuelled Killers&
     </entryLink>
     <entryLink import="true" name="Mighty Lord of Khorne" hidden="false" id="e5e1-2bc0-50ec-b9e9" type="selectionEntry" targetId="d9d9-55ad-2a9f-acf9">
       <costs>
-        <cost name="pts" typeId="points" value="130"/>
+        <cost name="pts" typeId="points" value="110"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Warlord" hidden="false" id="3b69-b92d-bb97-fba4" type="selectionEntry" targetId="bb28-fa4a-bf5f-f793"/>
@@ -424,7 +424,7 @@ For the rest of the battle, this unit cannot use the &apos;Hate-fuelled Killers&
     </entryLink>
     <entryLink import="true" name="Slaughterpriest" hidden="false" id="0967-415e-120a-d071" type="selectionEntry" targetId="d612-30cd-6166-f751">
       <costs>
-        <cost name="pts" typeId="points" value="130"/>
+        <cost name="pts" typeId="points" value="120"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Warlord" hidden="false" id="5bf5-a587-5e40-0422" type="selectionEntry" targetId="bb28-fa4a-bf5f-f793"/>
@@ -485,7 +485,7 @@ For the rest of the battle, this unit cannot use the &apos;Hate-fuelled Killers&
     </entryLink>
     <entryLink import="true" name="Bloodsecrator" hidden="false" id="9b10-e85f-fbfd-ed2b" type="selectionEntry" targetId="9943-f207-9aef-190c">
       <costs>
-        <cost name="pts" typeId="points" value="120"/>
+        <cost name="pts" typeId="points" value="110"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Heroic Traits" hidden="false" id="99b7-792f-5386-f1f0" type="selectionEntryGroup" targetId="f05b-52ed-36aa-1dee"/>
@@ -713,7 +713,7 @@ For the rest of the battle, this unit cannot use the &apos;Hate-fuelled Killers&
     </entryLink>
     <entryLink import="true" name="Realmgore Ritualist" hidden="false" id="5a07-7fae-3e77-2b54" type="selectionEntry" targetId="2592-295e-eed8-361b">
       <costs>
-        <cost name="pts" typeId="points" value="120"/>
+        <cost name="pts" typeId="points" value="110"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Warlord" hidden="false" id="980c-0039-8fd9-a942" type="selectionEntry" targetId="bb28-fa4a-bf5f-f793"/>
@@ -774,7 +774,7 @@ For the rest of the battle, this unit cannot use the &apos;Hate-fuelled Killers&
     </entryLink>
     <entryLink import="true" name="Deathbringer" hidden="false" id="b6c7-87da-e2fa-2b8e" type="selectionEntry" targetId="9c54-dbf9-f5be-a8b3">
       <costs>
-        <cost name="pts" typeId="points" value="130"/>
+        <cost name="pts" typeId="points" value="120"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Warlord" hidden="false" id="922a-8298-0863-3a77" type="selectionEntry" targetId="bb28-fa4a-bf5f-f793"/>

--- a/Blades of Khorne - The Baleful Lords.cat
+++ b/Blades of Khorne - The Baleful Lords.cat
@@ -447,7 +447,7 @@ That unit can move 2D6&quot;. It can end that move in combat with any units that
     </entryLink>
     <entryLink import="true" name="Skarbrand" hidden="false" id="6a65-cbef-a65f-0588" type="selectionEntry" targetId="b1a1-2377-3fa4-f264">
       <costs>
-        <cost name="pts" typeId="points" value="410"/>
+        <cost name="pts" typeId="points" value="430"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="3c41-3fb1-b626-e137" type="selectionEntryGroup" targetId="882a-6a96-e7a5-28bb"/>

--- a/Blades of Khorne.cat
+++ b/Blades of Khorne.cat
@@ -854,7 +854,7 @@ This unit can be affected by this ability multiple times and the effects are cum
     </entryLink>
     <entryLink import="true" name="Bloodsecrator" hidden="false" id="290e-14c1-e70b-667d" type="selectionEntry" targetId="9943-f207-9aef-190c">
       <costs>
-        <cost name="pts" typeId="points" value="120"/>
+        <cost name="pts" typeId="points" value="110"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Heroic Traits" hidden="false" id="8778-3d8a-1354-28a6" type="selectionEntryGroup" targetId="a357-4cbf-d348-1134"/>
@@ -1240,7 +1240,7 @@ This unit can be affected by this ability multiple times and the effects are cum
     </entryLink>
     <entryLink import="true" name="Mighty Lord of Khorne" hidden="false" id="e0c4-7af2-b0a2-4718" type="selectionEntry" targetId="d9d9-55ad-2a9f-acf9">
       <costs>
-        <cost name="pts" typeId="points" value="130"/>
+        <cost name="pts" typeId="points" value="110"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Heroic Traits" hidden="false" id="d93f-57d7-dbd9-6230" type="selectionEntryGroup" targetId="a357-4cbf-d348-1134"/>
@@ -1289,7 +1289,7 @@ This unit can be affected by this ability multiple times and the effects are cum
     </entryLink>
     <entryLink import="true" name="Realmgore Ritualist" hidden="false" id="73c8-9db7-15d-b03a" type="selectionEntry" targetId="2592-295e-eed8-361b">
       <costs>
-        <cost name="pts" typeId="points" value="120"/>
+        <cost name="pts" typeId="points" value="110"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Heroic Traits" hidden="false" id="7b10-553e-cadc-6720" type="selectionEntryGroup" targetId="a357-4cbf-d348-1134"/>
@@ -1336,7 +1336,7 @@ This unit can be affected by this ability multiple times and the effects are cum
     </entryLink>
     <entryLink import="true" name="Skarbrand" hidden="false" id="3b5f-188e-d4b6-f639" type="selectionEntry" targetId="b1a1-2377-3fa4-f264">
       <costs>
-        <cost name="pts" typeId="points" value="410"/>
+        <cost name="pts" typeId="points" value="430"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="4a19-3360-ffc9-1e26" type="selectionEntryGroup" targetId="6dcf-7de6-0f0f-bfc6"/>
@@ -1585,7 +1585,7 @@ This unit can be affected by this ability multiple times and the effects are cum
     </entryLink>
     <entryLink import="true" name="Slaughterpriest" hidden="false" id="5550-c14a-39b3-fd64" type="selectionEntry" targetId="d612-30cd-6166-f751">
       <costs>
-        <cost name="pts" typeId="points" value="130"/>
+        <cost name="pts" typeId="points" value="120"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Heroic Traits" hidden="false" id="1205-8319-fe01-85be" type="selectionEntryGroup" targetId="a357-4cbf-d348-1134"/>
@@ -1851,7 +1851,7 @@ This unit can be affected by this ability multiple times and the effects are cum
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="150"/>
+        <cost name="pts" typeId="points" value="130"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Paths" hidden="false" id="8d08-2f9a-4a98-1984" type="selectionEntryGroup" targetId="8e28-9445-463a-5883"/>
@@ -2273,7 +2273,7 @@ This unit can be affected by this ability multiple times and the effects are cum
     </entryLink>
     <entryLink import="true" name="Deathbringer" hidden="false" id="dca7-a51b-8501-6e91" type="selectionEntry" targetId="9c54-dbf9-f5be-a8b3">
       <costs>
-        <cost name="pts" typeId="points" value="130"/>
+        <cost name="pts" typeId="points" value="120"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Heroic Traits" hidden="false" id="f883-aab8-3fe4-e6c9" type="selectionEntryGroup" targetId="a357-4cbf-d348-1134"/>

--- a/Daughters of Khaine - Champions of the Arena.cat
+++ b/Daughters of Khaine - Champions of the Arena.cat
@@ -286,7 +286,7 @@
   <entryLinks>
     <entryLink import="true" name="Blood Hags" hidden="false" id="6230-c81e-f92a-5de9" type="selectionEntry" targetId="d65a-2556-6d7f-ad62">
       <costs>
-        <cost name="pts" typeId="points" value="140"/>
+        <cost name="pts" typeId="points" value="150"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Reinforced" hidden="false" id="d0d9-b121-6a99-645d" type="selectionEntry" targetId="1b37-82b8-c062-eb82"/>

--- a/Daughters of Khaine - The Croneseer's Pariahs.cat
+++ b/Daughters of Khaine - The Croneseer's Pariahs.cat
@@ -16,7 +16,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="cdaf-6662-4e50-60ca" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="130"/>
+        <cost name="pts" typeId="points" value="110"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -68,7 +68,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="76ab-dd1b-04a9-450e" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="330"/>
+        <cost name="pts" typeId="points" value="290"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -120,7 +120,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="b487-9eee-35d9-6f39" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="100"/>
+        <cost name="pts" typeId="points" value="120"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -198,7 +198,7 @@
         <categoryLink name="CRONESEER&apos;S PARIAHS" hidden="false" id="4f9a-1416-2152-ca25" targetId="b5ae-3746-e5a6-7010" primary="false"/>
       </categoryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="180"/>
+        <cost name="pts" typeId="points" value="220"/>
       </costs>
       <constraints>
         <constraint type="min" value="1" field="selections" scope="roster" shared="false" id="afe7-fb8-85c1-d4eb" includeChildForces="true" includeChildSelections="false"/>
@@ -313,7 +313,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="2e9b-1d1f-f078-2317" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="280"/>
+        <cost name="pts" typeId="points" value="300"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">

--- a/Daughters of Khaine - Zainthar Kai.cat
+++ b/Daughters of Khaine - Zainthar Kai.cat
@@ -360,7 +360,7 @@
         <entryLink import="true" name="Paths" hidden="false" id="b9f1-ad77-989f-c1ae" type="selectionEntryGroup" targetId="650c-7fc2-c254-767c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="280"/>
+        <cost name="pts" typeId="points" value="270"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -466,7 +466,7 @@
     </entryLink>
     <entryLink import="true" name="Morathi-Khaine" hidden="false" id="b247-8e6d-915d-0908" type="selectionEntry" targetId="cb92-4063-ab41-97d5">
       <costs>
-        <cost name="pts" typeId="points" value="730"/>
+        <cost name="pts" typeId="points" value="750"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -550,7 +550,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="140"/>
+        <cost name="pts" typeId="points" value="160"/>
       </costs>
       <categoryLinks>
         <categoryLink name="ZAINTHAR KAI" hidden="false" id="b695-af65-e355-426d" targetId="f865-2761-7458-d01b" primary="false"/>
@@ -612,7 +612,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="100"/>
+        <cost name="pts" typeId="points" value="110"/>
       </costs>
       <categoryLinks>
         <categoryLink name="ZAINTHAR KAI" hidden="false" id="05e8-eefe-fad3-e2d5" targetId="f865-2761-7458-d01b" primary="false"/>
@@ -772,7 +772,7 @@
         <entryLink import="true" name="Paths" hidden="false" id="43a2-6525-68c2-8ee6" type="selectionEntryGroup" targetId="650c-7fc2-c254-767c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="110"/>
+        <cost name="pts" typeId="points" value="140"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">

--- a/Daughters of Khaine.cat
+++ b/Daughters of Khaine.cat
@@ -860,7 +860,7 @@ Only one blood rite can be performed per unit destroyed.</characteristic>
         <entryLink import="true" name="Avatar of Khaine" hidden="false" id="51a0-3f1e-9af9-147e" type="selectionEntry" targetId="b4e1-75b3-227b-1a8d"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="280"/>
+        <cost name="pts" typeId="points" value="270"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -955,7 +955,7 @@ Only one blood rite can be performed per unit destroyed.</characteristic>
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="1b4c-1304-8064-1e71" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="280"/>
+        <cost name="pts" typeId="points" value="290"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -1161,7 +1161,7 @@ Only one blood rite can be performed per unit destroyed.</characteristic>
     </entryLink>
     <entryLink import="true" name="Morathi-Khaine" hidden="false" id="b371-6047-e6ef-f9f9" type="selectionEntry" targetId="cb92-4063-ab41-97d5">
       <costs>
-        <cost name="pts" typeId="points" value="730"/>
+        <cost name="pts" typeId="points" value="750"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -1268,7 +1268,7 @@ Only one blood rite can be performed per unit destroyed.</characteristic>
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="ceec-dc2b-46e8-6ae4" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="280"/>
+        <cost name="pts" typeId="points" value="300"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -1336,7 +1336,7 @@ Only one blood rite can be performed per unit destroyed.</characteristic>
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="140"/>
+        <cost name="pts" typeId="points" value="160"/>
       </costs>
       <categoryLinks>
         <categoryLink name="non-AELF" hidden="false" id="02e6-b98a-0e49-9647" targetId="ea04-345e-bd3b-607c" primary="false"/>
@@ -1489,7 +1489,7 @@ Only one blood rite can be performed per unit destroyed.</characteristic>
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="100"/>
+        <cost name="pts" typeId="points" value="110"/>
       </costs>
       <categoryLinks>
         <categoryLink name="non-AELF" hidden="false" id="4665-efab-c467-c7c6" targetId="ea04-345e-bd3b-607c" primary="false"/>
@@ -1755,7 +1755,7 @@ Only one blood rite can be performed per unit destroyed.</characteristic>
     </entryLink>
     <entryLink import="true" name="Blood Hags" hidden="false" id="6ded-92cd-e86b-0ee0" type="selectionEntry" targetId="d65a-2556-6d7f-ad62">
       <costs>
-        <cost name="pts" typeId="points" value="140"/>
+        <cost name="pts" typeId="points" value="150"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Reinforced" hidden="false" id="9221-8841-f5d5-69fd" type="selectionEntry" targetId="1b37-82b8-c062-eb82"/>
@@ -1930,7 +1930,7 @@ Only one blood rite can be performed per unit destroyed.</characteristic>
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="130"/>
+        <cost name="pts" typeId="points" value="100"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Paths" hidden="false" id="ece2-f122-24ed-ced6" type="selectionEntryGroup" targetId="a78f-4d81-534c-3aeb"/>

--- a/Disciples of Tzeentch - Change-cult Uprising.cat
+++ b/Disciples of Tzeentch - Change-cult Uprising.cat
@@ -280,7 +280,7 @@ If you picked a unit that has been destroyed, set up a replacement unit with hal
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="b4c3-df5a-d210-1a9b" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="150"/>
+        <cost name="pts" typeId="points" value="170"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -461,7 +461,7 @@ If you picked a unit that has been destroyed, set up a replacement unit with hal
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="52f6-60e5-ff39-488c" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="130"/>
+        <cost name="pts" typeId="points" value="110"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">

--- a/Disciples of Tzeentch - The Oracles of Fate.cat
+++ b/Disciples of Tzeentch - The Oracles of Fate.cat
@@ -247,7 +247,7 @@ During the battle, instead of making a roll from the list below for a friendly *
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="cba8-c410-6989-dbf8" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="130"/>
+        <cost name="pts" typeId="points" value="140"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -553,7 +553,7 @@ During the battle, instead of making a roll from the list below for a friendly *
     </entryLink>
     <entryLink import="true" name="The Changeling" hidden="false" id="0b6d-af21-af15-3b47" type="selectionEntry" targetId="be93-ef60-f866-2f4d">
       <costs>
-        <cost name="pts" typeId="points" value="170"/>
+        <cost name="pts" typeId="points" value="140"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="68fc-8d8a-e158-8e61" type="selectionEntryGroup" targetId="f1ba-b8f9-dbd2-a3e1"/>
@@ -695,7 +695,7 @@ During the battle, instead of making a roll from the list below for a friendly *
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="110"/>
+        <cost name="pts" typeId="points" value="120"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Renown" hidden="false" id="1001-be35-0752-0137" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
@@ -793,7 +793,7 @@ During the battle, instead of making a roll from the list below for a friendly *
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="90"/>
+        <cost name="pts" typeId="points" value="80"/>
       </costs>
       <categoryLinks>
         <categoryLink name="ORACLES OF FATE" hidden="false" id="8c4e-04c5-d9aa-54bc" targetId="b484-7858-040a-0989" primary="false"/>

--- a/Disciples of Tzeentch.cat
+++ b/Disciples of Tzeentch.cat
@@ -763,7 +763,7 @@ If you remove 1 or more damage points from the damage pool of a friendly **^^Dis
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="f53d-e9fb-a12c-8638" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="130"/>
+        <cost name="pts" typeId="points" value="140"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -825,7 +825,7 @@ If you remove 1 or more damage points from the damage pool of a friendly **^^Dis
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="2832-f428-6452-29c0" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="150"/>
+        <cost name="pts" typeId="points" value="170"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -1233,7 +1233,7 @@ If you remove 1 or more damage points from the damage pool of a friendly **^^Dis
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="a173-aac0-628d-1265" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="130"/>
+        <cost name="pts" typeId="points" value="110"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -1286,7 +1286,7 @@ If you remove 1 or more damage points from the damage pool of a friendly **^^Dis
     </entryLink>
     <entryLink import="true" name="The Changeling" hidden="false" id="ac6e-a933-6887-ebb1" type="selectionEntry" targetId="be93-ef60-f866-2f4d">
       <costs>
-        <cost name="pts" typeId="points" value="170"/>
+        <cost name="pts" typeId="points" value="140"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="f72a-68f2-9844-b235" type="selectionEntryGroup" targetId="9f62-724e-720d-87ff"/>
@@ -1523,7 +1523,7 @@ If you remove 1 or more damage points from the damage pool of a friendly **^^Dis
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="110"/>
+        <cost name="pts" typeId="points" value="120"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Paths" hidden="false" id="3a5c-1947-b041-e21c" type="selectionEntryGroup" targetId="3fea-aadd-11d7-023d"/>
@@ -1639,7 +1639,7 @@ If you remove 1 or more damage points from the damage pool of a friendly **^^Dis
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="90"/>
+        <cost name="pts" typeId="points" value="80"/>
       </costs>
     </entryLink>
     <entryLink import="true" name="Tzaangor Enlightened on Foot" hidden="false" id="6c22-7ac4-a545-58d4" type="selectionEntry" targetId="7755-a49c-7014-3bd2">

--- a/Flesh-eater Courts - New Summercourt.cat
+++ b/Flesh-eater Courts - New Summercourt.cat
@@ -406,7 +406,7 @@ Once all of the standard bearers in the target unit have been slain, subtract 5 
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="38f2-d6b9-6b2d-46a0" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="120"/>
+        <cost name="pts" typeId="points" value="110"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -508,7 +508,7 @@ Once all of the standard bearers in the target unit have been slain, subtract 5 
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="e68f-5ad9-eb04-77fb" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="380"/>
+        <cost name="pts" typeId="points" value="400"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -559,7 +559,7 @@ Once all of the standard bearers in the target unit have been slain, subtract 5 
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="07f1-bead-66c0-2805" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="380"/>
+        <cost name="pts" typeId="points" value="400"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -610,7 +610,7 @@ Once all of the standard bearers in the target unit have been slain, subtract 5 
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="7f83-4e2a-ba6a-2c88" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="170"/>
+        <cost name="pts" typeId="points" value="150"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -1328,7 +1328,7 @@ Once all of the standard bearers in the target unit have been slain, subtract 5 
         <entryLink import="true" name="Paths" hidden="false" id="3d62-196a-88b0-77f3" type="selectionEntryGroup" targetId="1ede-6ff9-ad19-0057"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="180"/>
+        <cost name="pts" typeId="points" value="170"/>
       </costs>
       <modifierGroups>
         <modifierGroup type="and">

--- a/Flesh-eater Courts - The Equinox Feast.cat
+++ b/Flesh-eater Courts - The Equinox Feast.cat
@@ -487,7 +487,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="3a59-c132-7894-e5c2" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="120"/>
+        <cost name="pts" typeId="points" value="110"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -589,7 +589,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="6ac9-44d1-e846-062b" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="170"/>
+        <cost name="pts" typeId="points" value="150"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -995,7 +995,7 @@
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="99f8-6bf8-dc97-dade" type="selectionEntryGroup" targetId="d301-23dd-adc8-ffac"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="150"/>
+        <cost name="pts" typeId="points" value="140"/>
       </costs>
       <constraints>
         <constraint type="max" value="-1" field="selections" scope="force" shared="true" id="2bf9-8513-90ce-4bdb" includeChildSelections="true"/>

--- a/Flesh-eater Courts.cat
+++ b/Flesh-eater Courts.cat
@@ -12,7 +12,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="6f32-d708-452f-45a1" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="120"/>
+        <cost name="pts" typeId="points" value="110"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -61,7 +61,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="65a6-c968-115f-a2cb" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="380"/>
+        <cost name="pts" typeId="points" value="400"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -110,7 +110,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="c6fc-7364-504b-02e0" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="380"/>
+        <cost name="pts" typeId="points" value="400"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -158,7 +158,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="1d6c-07b8-5dd7-6474" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="170"/>
+        <cost name="pts" typeId="points" value="150"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -413,7 +413,7 @@
     </entryLink>
     <entryLink import="true" name="Grand Justice Gormayne" hidden="false" id="2bca-d174-5c9a-fe95" type="selectionEntry" targetId="52f6-b3c0-7891-bb69">
       <costs>
-        <cost name="pts" typeId="points" value="150"/>
+        <cost name="pts" typeId="points" value="130"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="4b33-2653-58eb-0f55" type="selectionEntryGroup" targetId="85f3-e7e9-83cc-73b9"/>
@@ -534,7 +534,7 @@
     </entryLink>
     <entryLink import="true" name="Nagash, Supreme Lord of the Undead" hidden="false" id="fa1b-28f9-fc38-f239" type="selectionEntry" targetId="4898-ff01-e50e-4325">
       <costs>
-        <cost name="pts" typeId="points" value="830"/>
+        <cost name="pts" typeId="points" value="750"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="f2e0-7420-c9d1-393f" type="selectionEntryGroup" targetId="85f3-e7e9-83cc-73b9"/>
@@ -1140,7 +1140,7 @@
         <entryLink import="true" name="Renown" hidden="false" id="789a-29ee-d6b0-b193" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="150"/>
+        <cost name="pts" typeId="points" value="140"/>
       </costs>
       <constraints>
         <constraint type="max" value="-1" field="selections" scope="force" shared="true" id="93f1-b8b7-f8dd-041f" includeChildSelections="true"/>
@@ -1306,7 +1306,7 @@
         <entryLink import="true" name="Renown" hidden="false" id="b5d8-b40e-ab0b-b63e" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="180"/>
+        <cost name="pts" typeId="points" value="170"/>
       </costs>
       <modifierGroups>
         <modifierGroup type="and">
@@ -1454,7 +1454,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="230"/>
+        <cost name="pts" typeId="points" value="240"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Paths" hidden="false" id="dcab-ae70-f918-9fe8" type="selectionEntryGroup" targetId="6607-5e8b-dd3c-0e38"/>
@@ -1520,7 +1520,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="250"/>
+        <cost name="pts" typeId="points" value="260"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Paths" hidden="false" id="3916-1e72-14b6-f01a" type="selectionEntryGroup" targetId="6607-5e8b-dd3c-0e38"/>

--- a/Fyreslayers - Lofnir Drothkeepers.cat
+++ b/Fyreslayers - Lofnir Drothkeepers.cat
@@ -78,7 +78,7 @@
         <categoryLink name="LOFNIR DROTHKEEPERS" hidden="false" id="2a3a-886c-2f59-a3f5" targetId="a895-7fd3-6fad-5410" primary="false"/>
       </categoryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="330"/>
+        <cost name="pts" typeId="points" value="320"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -145,7 +145,7 @@
         <categoryLink name="LOFNIR DROTHKEEPERS" hidden="false" id="14e1-8d57-ac9b-22b5" targetId="a895-7fd3-6fad-5410" primary="false"/>
       </categoryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="180"/>
+        <cost name="pts" typeId="points" value="160"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -196,7 +196,7 @@
         <categoryLink name="LOFNIR DROTHKEEPERS" hidden="false" id="2e22-1ca9-3115-c9b5" targetId="a895-7fd3-6fad-5410" primary="false"/>
       </categoryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="100"/>
+        <cost name="pts" typeId="points" value="90"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -246,7 +246,7 @@
         <categoryLink name="LOFNIR DROTHKEEPERS" hidden="false" id="b795-3108-8a98-5a42" targetId="a895-7fd3-6fad-5410" primary="false"/>
       </categoryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="300"/>
+        <cost name="pts" typeId="points" value="280"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -362,7 +362,7 @@
         <categoryLink name="LOFNIR DROTHKEEPERS" hidden="false" id="efb2-2e68-53b4-a135" targetId="a895-7fd3-6fad-5410" primary="false"/>
       </categoryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="250"/>
+        <cost name="pts" typeId="points" value="240"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -433,7 +433,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="160"/>
+        <cost name="pts" typeId="points" value="150"/>
       </costs>
       <categoryLinks>
         <categoryLink name="LOFNIR DROTHKEEPERS" hidden="false" id="4e1b-5db7-3d33-ec6c" targetId="a895-7fd3-6fad-5410" primary="false"/>

--- a/Fyreslayers.cat
+++ b/Fyreslayers.cat
@@ -799,7 +799,7 @@ For the rest of the battle round, friendly **^^Fyreslayers^^** units have **^^St
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="e111-092d-7680-e561" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="330"/>
+        <cost name="pts" typeId="points" value="320"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -863,7 +863,7 @@ For the rest of the battle round, friendly **^^Fyreslayers^^** units have **^^St
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="b5fa-b940-cb15-f7e3" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="180"/>
+        <cost name="pts" typeId="points" value="160"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -911,7 +911,7 @@ For the rest of the battle round, friendly **^^Fyreslayers^^** units have **^^St
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="39ca-d16d-d5f2-f82d" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="100"/>
+        <cost name="pts" typeId="points" value="90"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -959,7 +959,7 @@ For the rest of the battle round, friendly **^^Fyreslayers^^** units have **^^St
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="f07d-da60-7c55-601e" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="300"/>
+        <cost name="pts" typeId="points" value="280"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -1070,7 +1070,7 @@ For the rest of the battle round, friendly **^^Fyreslayers^^** units have **^^St
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="1641-1059-b659-f35b" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="250"/>
+        <cost name="pts" typeId="points" value="240"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -1338,7 +1338,7 @@ For the rest of the battle round, friendly **^^Fyreslayers^^** units have **^^St
         <entryLink import="true" name="Renown" hidden="false" id="c13e-c6b7-9fa7-408e" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="110"/>
+        <cost name="pts" typeId="points" value="100"/>
       </costs>
     </entryLink>
     <entryLink import="true" name="Hearthguard Berzerkers with Berzerker Broadaxes" hidden="false" id="e87a-97e2-a124-4a45" type="selectionEntry" targetId="d6c7-9adb-d1fd-2446">
@@ -1366,7 +1366,7 @@ For the rest of the battle round, friendly **^^Fyreslayers^^** units have **^^St
         <entryLink import="true" name="Renown" hidden="false" id="c226-4301-7857-402a" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="110"/>
+        <cost name="pts" typeId="points" value="100"/>
       </costs>
     </entryLink>
     <entryLink import="true" name="Hearthguard Berzerkers with Flamestrike Poleaxes" hidden="false" id="5a01-8370-ecc5-1297" type="selectionEntry" targetId="194c-db4d-bae8-1372">
@@ -1472,7 +1472,7 @@ For the rest of the battle round, friendly **^^Fyreslayers^^** units have **^^St
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="160"/>
+        <cost name="pts" typeId="points" value="150"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="39ac-f69f-8e9d-9298" type="selectionEntryGroup" targetId="a732-883c-6d30-955e"/>

--- a/Gloomspite Gitz - Da King's Gitz.cat
+++ b/Gloomspite Gitz - Da King's Gitz.cat
@@ -680,7 +680,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="68c7-f82b-1993-ae48" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="80"/>
+        <cost name="pts" typeId="points" value="70"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -813,7 +813,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="29aa-c9cd-cbfb-bdbd" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="150"/>
+        <cost name="pts" typeId="points" value="140"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -1112,7 +1112,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="120"/>
+        <cost name="pts" typeId="points" value="110"/>
       </costs>
       <categoryLinks>
         <categoryLink name="KING&apos;S GITZ" hidden="false" id="bb84-b587-f2f6-f4f3" targetId="3573-2154-d2f7-c352" primary="false"/>
@@ -1291,7 +1291,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="90"/>
+        <cost name="pts" typeId="points" value="80"/>
       </costs>
       <categoryLinks>
         <categoryLink name="KING&apos;S GITZ" hidden="false" id="c067-c347-bd6a-c15f" targetId="3573-2154-d2f7-c352" primary="false"/>
@@ -1409,7 +1409,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="160"/>
+        <cost name="pts" typeId="points" value="150"/>
       </costs>
       <categoryLinks>
         <categoryLink name="KING&apos;S GITZ" hidden="false" id="3cd6-4c24-4dfb-f8e9" targetId="3573-2154-d2f7-c352" primary="false"/>
@@ -1546,7 +1546,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="180"/>
+        <cost name="pts" typeId="points" value="170"/>
       </costs>
       <constraints>
         <constraint type="max" value="2" field="selections" scope="parent" shared="true" id="ce32-b0e1-2c82-f602"/>

--- a/Gloomspite Gitz - Droggz's Gitmob.cat
+++ b/Gloomspite Gitz - Droggz's Gitmob.cat
@@ -596,7 +596,7 @@
         <categoryLink name="Restrict General" hidden="false" id="700a-d1b7-c20d-6b2e" targetId="abcb-73d0-2b6c-4f17" primary="false"/>
       </categoryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="140"/>
+        <cost name="pts" typeId="points" value="130"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -706,7 +706,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="160"/>
+        <cost name="pts" typeId="points" value="150"/>
       </costs>
       <categoryLinks>
         <categoryLink name="DROGGZ&apos;S GITMOB" hidden="false" id="2b89-0bb4-7e2f-4643" targetId="310f-5467-15d1-15f7" primary="false"/>

--- a/Gloomspite Gitz - Trugg's Troggherd.cat
+++ b/Gloomspite Gitz - Trugg's Troggherd.cat
@@ -16,7 +16,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="4012-04ec-20b4-f967" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="220"/>
+        <cost name="pts" typeId="points" value="200"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -132,7 +132,7 @@
         <categoryLink name="TRUGG&apos;S TROGGHERD" hidden="false" id="5c79-a14c-26e0-17e2" targetId="d960-e20e-e995-7986" primary="false"/>
       </categoryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="360"/>
+        <cost name="pts" typeId="points" value="340"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="62f8-760f-5255-699b" type="selectionEntryGroup" targetId="6cf2-b737-c12a-a5b9"/>
@@ -197,7 +197,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="180"/>
+        <cost name="pts" typeId="points" value="170"/>
       </costs>
       <categoryLinks>
         <categoryLink name="TRUGG&apos;S TROGGHERD" hidden="false" id="e636-1aee-2f2d-ec57" targetId="d960-e20e-e995-7986" primary="false"/>

--- a/Gloomspite Gitz.cat
+++ b/Gloomspite Gitz.cat
@@ -544,7 +544,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="9821-0d3f-8e79-f00d" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="220"/>
+        <cost name="pts" typeId="points" value="200"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -696,7 +696,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="ef93-ed3e-8632-f5d5" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="80"/>
+        <cost name="pts" typeId="points" value="70"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -876,7 +876,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="8aa4-b758-716b-f20d" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="150"/>
+        <cost name="pts" typeId="points" value="140"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -1084,7 +1084,7 @@
     </entryLink>
     <entryLink import="true" name="Trugg, the Troggoth King" hidden="false" id="aa6c-cd1d-3eb-efbd" type="selectionEntry" targetId="94c-5126-509a-168f">
       <costs>
-        <cost name="pts" typeId="points" value="360"/>
+        <cost name="pts" typeId="points" value="340"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="7187-9ecd-cc6a-349e" type="selectionEntryGroup" targetId="9ee4-6545-911b-3cf6"/>
@@ -1183,7 +1183,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="8eed-befa-1edd-d7fc" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="250"/>
+        <cost name="pts" typeId="points" value="230"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -1309,7 +1309,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="230"/>
+        <cost name="pts" typeId="points" value="210"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Paths" hidden="false" id="5db2-1084-6f7e-1bd7" type="selectionEntryGroup" targetId="b182-942d-da44-5153"/>
@@ -1373,7 +1373,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="220"/>
+        <cost name="pts" typeId="points" value="200"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Paths" hidden="false" id="979f-3b60-958c-2c64" type="selectionEntryGroup" targetId="b182-942d-da44-5153"/>
@@ -1735,7 +1735,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="120"/>
+        <cost name="pts" typeId="points" value="110"/>
       </costs>
       <constraints>
         <constraint type="max" value="-1" field="selections" scope="force" shared="true" id="8b59-7da5-4778-dd08" includeChildSelections="true"/>
@@ -1940,7 +1940,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="180"/>
+        <cost name="pts" typeId="points" value="170"/>
       </costs>
       <constraints>
         <constraint type="max" value="-1" field="selections" scope="force" shared="true" id="fe89-7f79-cc48-4c0f" includeChildSelections="true"/>
@@ -2004,7 +2004,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="190"/>
+        <cost name="pts" typeId="points" value="180"/>
       </costs>
       <modifierGroups>
         <modifierGroup type="and">
@@ -2156,7 +2156,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="160"/>
+        <cost name="pts" typeId="points" value="150"/>
       </costs>
       <constraints>
         <constraint type="max" value="-1" field="selections" scope="force" shared="true" id="0e13-8362-7148-0e47" includeChildSelections="true"/>
@@ -2249,7 +2249,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="90"/>
+        <cost name="pts" typeId="points" value="80"/>
       </costs>
       <constraints>
         <constraint type="max" value="-1" field="selections" scope="force" shared="true" id="8a7b-20d2-0808-78d2" includeChildSelections="true"/>
@@ -3185,7 +3185,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="5fbc-6b7d-8adc-2f2b" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="140"/>
+        <cost name="pts" typeId="points" value="130"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -3638,7 +3638,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="160"/>
+        <cost name="pts" typeId="points" value="150"/>
       </costs>
     </entryLink>
     <entryLink import="true" name="Anvil of Apotheosis: Grot Hero" hidden="false" id="3d48-6c56-df2e-16da" type="selectionEntry" targetId="3ffe-7c86-f14a-985e">

--- a/Helsmiths of Hashut - Taar's Grand Forgehost.cat
+++ b/Helsmiths of Hashut - Taar's Grand Forgehost.cat
@@ -298,7 +298,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="6f83-409f-916f-9e9b" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="90"/>
+        <cost name="pts" typeId="points" value="80"/>
       </costs>
       <modifiers>
         <modifier type="set" value="true" field="hidden">
@@ -439,7 +439,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="100"/>
+        <cost name="pts" typeId="points" value="110"/>
       </costs>
       <categoryLinks>
         <categoryLink name="GRAND FORGEHOST" hidden="false" id="53d9-8f8e-bba9-7d9e" targetId="78e1-cf19-b339-bed2" primary="false"/>
@@ -470,7 +470,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="100"/>
+        <cost name="pts" typeId="points" value="90"/>
       </costs>
       <categoryLinks>
         <categoryLink name="GRAND FORGEHOST" hidden="false" id="be8f-878c-a29d-0d3c" targetId="78e1-cf19-b339-bed2" primary="false"/>
@@ -531,7 +531,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="170"/>
+        <cost name="pts" typeId="points" value="160"/>
       </costs>
       <categoryLinks>
         <categoryLink name="GRAND FORGEHOST" hidden="false" id="df91-6d14-0da9-eda4" targetId="78e1-cf19-b339-bed2" primary="false"/>
@@ -561,7 +561,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="160"/>
+        <cost name="pts" typeId="points" value="150"/>
       </costs>
       <categoryLinks>
         <categoryLink name="GRAND FORGEHOST" hidden="false" id="549a-e7e1-480f-1318" targetId="78e1-cf19-b339-bed2" primary="false"/>
@@ -608,7 +608,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="2790-db60-f179-f2e0" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="100"/>
+        <cost name="pts" typeId="points" value="80"/>
       </costs>
       <modifiers>
         <modifier type="set" value="true" field="hidden">

--- a/Helsmiths of Hashut - Ziggurat Stampede.cat
+++ b/Helsmiths of Hashut - Ziggurat Stampede.cat
@@ -360,7 +360,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="160"/>
+        <cost name="pts" typeId="points" value="150"/>
       </costs>
       <categoryLinks>
         <categoryLink name="ZIGGURAT STAMPEDE" hidden="false" id="d111-d032-b197-15d7" targetId="f459-121c-4a5e-a87a" primary="false"/>
@@ -390,7 +390,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="170"/>
+        <cost name="pts" typeId="points" value="160"/>
       </costs>
       <categoryLinks>
         <categoryLink name="ZIGGURAT STAMPEDE" hidden="false" id="7ebc-9a95-e6e8-d18e" targetId="f459-121c-4a5e-a87a" primary="false"/>

--- a/Helsmiths of Hashut.cat
+++ b/Helsmiths of Hashut.cat
@@ -792,7 +792,7 @@ Then, allocate your **daemonic power points** to friendly non-**^^Hobgrot Helsmi
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="d4b0-781c-92c9-45be" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="90"/>
+        <cost name="pts" typeId="points" value="80"/>
       </costs>
       <modifiers>
         <modifier type="set" value="true" field="hidden">
@@ -854,7 +854,7 @@ Then, allocate your **daemonic power points** to friendly non-**^^Hobgrot Helsmi
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="3283-a1f3-2b59-3e86" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="100"/>
+        <cost name="pts" typeId="points" value="80"/>
       </costs>
       <modifiers>
         <modifier type="set" value="true" field="hidden">
@@ -1048,7 +1048,7 @@ Then, allocate your **daemonic power points** to friendly non-**^^Hobgrot Helsmi
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="100"/>
+        <cost name="pts" typeId="points" value="90"/>
       </costs>
     </entryLink>
     <entryLink import="true" name="Bull Centaurs" hidden="false" id="69ba-bc37-ffb4-fc90" type="selectionEntry" targetId="e20f-a1a4-79f8-93af">
@@ -1188,7 +1188,7 @@ Then, allocate your **daemonic power points** to friendly non-**^^Hobgrot Helsmi
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="160"/>
+        <cost name="pts" typeId="points" value="150"/>
       </costs>
     </entryLink>
     <entryLink import="true" name="Dominator Engine with Immolation Cannons" hidden="false" id="0760-d077-48e8-5b79" type="selectionEntry" targetId="9c89-4ec9-71db-0026">
@@ -1216,7 +1216,7 @@ Then, allocate your **daemonic power points** to friendly non-**^^Hobgrot Helsmi
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="170"/>
+        <cost name="pts" typeId="points" value="160"/>
       </costs>
     </entryLink>
     <entryLink import="true" name="Anvil of Apotheosis: Helsmiths of Hashut Hero" hidden="false" id="89f8-d019-1a77-33f1" type="selectionEntry" targetId="4f90-3fa4-8f1e-1ef8">

--- a/Idoneth Deepkin - The First Phalanx of Ionrach.cat
+++ b/Idoneth Deepkin - The First Phalanx of Ionrach.cat
@@ -378,7 +378,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="170"/>
+        <cost name="pts" typeId="points" value="160"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Renown" hidden="false" id="c6b1-b2c4-830a-25ba" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
@@ -707,7 +707,7 @@
     </entryLink>
     <entryLink import="true" name="Volturnos, High King of the Deep" hidden="false" id="d0d8-fa41-bfbc-891c" type="selectionEntry" targetId="301e-efbe-65c3-bf78">
       <costs>
-        <cost name="pts" typeId="points" value="210"/>
+        <cost name="pts" typeId="points" value="190"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="cd37-b66a-7b29-4f7c" type="selectionEntryGroup" targetId="35f9-1f04-b6dd-21ed"/>

--- a/Idoneth Deepkin - Wardens of the Chorrileum.cat
+++ b/Idoneth Deepkin - Wardens of the Chorrileum.cat
@@ -648,7 +648,7 @@
         <entryLink import="true" name="Paths" hidden="false" id="c102-9243-9dbd-0595" type="selectionEntryGroup" targetId="e9b9-9c0e-9355-e53b"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="120"/>
+        <cost name="pts" typeId="points" value="110"/>
       </costs>
     </entryLink>
     <entryLink import="true" name="Ikon of the Storm" hidden="false" id="73e4-d927-368c-208b" type="selectionEntry" targetId="ef74-f822-eae2-d57c">

--- a/Idoneth Deepkin.cat
+++ b/Idoneth Deepkin.cat
@@ -1087,7 +1087,7 @@ In addition, add 2 to the next casting roll or banishment roll for this unit th
     </entryLink>
     <entryLink import="true" name="Volturnos, High King of the Deep" hidden="false" id="278b-c82c-70aa-ccc7" type="selectionEntry" targetId="301e-efbe-65c3-bf78">
       <costs>
-        <cost name="pts" typeId="points" value="210"/>
+        <cost name="pts" typeId="points" value="190"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="bc42-5c0c-7b18-7f2b" type="selectionEntryGroup" targetId="6690-4b92-7bcf-ecfd"/>
@@ -1147,7 +1147,7 @@ In addition, add 2 to the next casting roll or banishment roll for this unit th
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="170"/>
+        <cost name="pts" typeId="points" value="160"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Paths" hidden="false" id="810e-81be-daa2-a9e6" type="selectionEntryGroup" targetId="ffa1-0adf-78bb-b563"/>
@@ -1263,7 +1263,7 @@ In addition, add 2 to the next casting roll or banishment roll for this unit th
         <entryLink import="true" name="Renown" hidden="false" id="7773-3847-a128-12e9" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="120"/>
+        <cost name="pts" typeId="points" value="110"/>
       </costs>
     </entryLink>
     <entryLink import="true" name="Namarti Thralls" hidden="false" id="6b15-b693-651b-805e" type="selectionEntry" targetId="719d-2822-d67a-2ec8">

--- a/Ironjawz - Ironsunz [LEGENDS].cat
+++ b/Ironjawz - Ironsunz [LEGENDS].cat
@@ -612,7 +612,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="1181-090f-44dd-b091" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="140"/>
+        <cost name="pts" typeId="points" value="130"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -823,7 +823,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="100"/>
+        <cost name="pts" typeId="points" value="90"/>
       </costs>
       <categoryLinks>
         <categoryLink name="IRONSUNZ" hidden="false" id="c670-ab89-9d83-e86b" targetId="06cf-b407-5418-b6aa" primary="false"/>
@@ -969,7 +969,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="100"/>
+        <cost name="pts" typeId="points" value="90"/>
       </costs>
       <modifierGroups>
         <modifierGroup type="and">
@@ -1072,7 +1072,7 @@
         <constraint type="max" value="0" field="selections" scope="roster" shared="true" id="6077-c7a5-3838-9dd0" includeChildSelections="true" includeChildForces="true"/>
       </constraints>
       <costs>
-        <cost name="pts" typeId="points" value="240"/>
+        <cost name="pts" typeId="points" value="250"/>
       </costs>
       <categoryLinks>
         <categoryLink name="IRONSUNZ" hidden="false" id="4822-8e97-0c00-e77a" targetId="06cf-b407-5418-b6aa" primary="false"/>
@@ -1113,7 +1113,7 @@
         <constraint type="max" value="0" field="selections" scope="roster" shared="true" id="0067-b997-4168-7825" includeChildSelections="true" includeChildForces="true"/>
       </constraints>
       <costs>
-        <cost name="pts" typeId="points" value="170"/>
+        <cost name="pts" typeId="points" value="160"/>
       </costs>
       <categoryLinks>
         <categoryLink name="IRONSUNZ" hidden="false" id="516f-f94c-4954-7b44" targetId="06cf-b407-5418-b6aa" primary="false"/>

--- a/Ironjawz - Krazogg's Grunta Stampede.cat
+++ b/Ironjawz - Krazogg's Grunta Stampede.cat
@@ -15,7 +15,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="19bf-f9a7-068c-5c8f" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="250"/>
+        <cost name="pts" typeId="points" value="270"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -100,7 +100,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="240"/>
+        <cost name="pts" typeId="points" value="250"/>
       </costs>
       <categoryLinks>
         <categoryLink name="GRUNTA STAMPEDE" hidden="false" id="50a9-f75f-fc23-eb1c" targetId="b64f-85cf-cc50-4197" primary="false"/>
@@ -136,7 +136,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="170"/>
+        <cost name="pts" typeId="points" value="160"/>
       </costs>
       <categoryLinks>
         <categoryLink name="GRUNTA STAMPEDE" hidden="false" id="4815-6a5b-2423-26e2" targetId="b64f-85cf-cc50-4197" primary="false"/>

--- a/Ironjawz - Zoggrok's Ironmongerz.cat
+++ b/Ironjawz - Zoggrok's Ironmongerz.cat
@@ -79,7 +79,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="d5aa-efa4-87fb-f698" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="100"/>
+        <cost name="pts" typeId="points" value="90"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -285,7 +285,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="4b37-cb06-81a3-afc2" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="140"/>
+        <cost name="pts" typeId="points" value="130"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -441,7 +441,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="100"/>
+        <cost name="pts" typeId="points" value="90"/>
       </costs>
       <categoryLinks>
         <categoryLink name="ZOGGROK&apos;S IRONMONGERS" hidden="false" id="e0c2-ee4a-96fd-0c99" targetId="5e66-6f7f-4033-aca2" primary="false"/>

--- a/Ironjawz.cat
+++ b/Ironjawz.cat
@@ -624,7 +624,7 @@ If there are no friendly **Megabosses** on the battlefield, roll a dice. On a 3+
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="8b35-ce9b-fd1e-5696" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="100"/>
+        <cost name="pts" typeId="points" value="90"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -814,7 +814,7 @@ If there are no friendly **Megabosses** on the battlefield, roll a dice. On a 3+
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="9870-a788-d0ee-d8cf" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="140"/>
+        <cost name="pts" typeId="points" value="130"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -927,7 +927,7 @@ If there are no friendly **Megabosses** on the battlefield, roll a dice. On a 3+
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="f403-1a49-ed6e-a040" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="250"/>
+        <cost name="pts" typeId="points" value="270"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -1196,7 +1196,7 @@ If there are no friendly **Megabosses** on the battlefield, roll a dice. On a 3+
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="170"/>
+        <cost name="pts" typeId="points" value="160"/>
       </costs>
     </entryLink>
     <entryLink import="true" name="Maw-grunta Gougers" hidden="false" id="7a13-c98e-7c9b-55b8" type="selectionEntry" targetId="ce75-dedf-3b6f-9a7c">
@@ -1246,7 +1246,7 @@ If there are no friendly **Megabosses** on the battlefield, roll a dice. On a 3+
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="240"/>
+        <cost name="pts" typeId="points" value="250"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="a6db-ebce-5360-542a" type="selectionEntryGroup" targetId="8979-6e56-a44b-dce1"/>
@@ -1430,7 +1430,7 @@ If there are no friendly **Megabosses** on the battlefield, roll a dice. On a 3+
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="100"/>
+        <cost name="pts" typeId="points" value="90"/>
       </costs>
     </entryLink>
   </entryLinks>

--- a/Kharadron Overlords - Grundstok Expeditionary Force.cat
+++ b/Kharadron Overlords - Grundstok Expeditionary Force.cat
@@ -198,7 +198,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="4640-9947-5b05-95cc" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="150"/>
+        <cost name="pts" typeId="points" value="140"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -264,7 +264,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="e29c-3dcf-0ef5-ddd8" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="90"/>
+        <cost name="pts" typeId="points" value="80"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -330,7 +330,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="c8e6-e09c-a002-c795" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="110"/>
+        <cost name="pts" typeId="points" value="100"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -440,7 +440,7 @@
         <constraint type="max" value="-1" field="selections" scope="force" shared="true" id="4aa3-9dd4-1863-004f" includeChildSelections="true"/>
       </constraints>
       <costs>
-        <cost name="pts" typeId="points" value="150"/>
+        <cost name="pts" typeId="points" value="140"/>
       </costs>
       <categoryLinks>
         <categoryLink name="EXPEDITIONARY FORCE" hidden="false" id="19ac-dbb8-5deb-1e9" targetId="d143-5973-f856-3384" primary="false"/>

--- a/Kharadron Overlords - Pioneer Outpost.cat
+++ b/Kharadron Overlords - Pioneer Outpost.cat
@@ -459,7 +459,7 @@
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="c896-f3ec-497a-3dfd" type="selectionEntryGroup" targetId="9d27-541d-c393-5b45"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="90"/>
+        <cost name="pts" typeId="points" value="80"/>
       </costs>
       <categoryLinks>
         <categoryLink name="PIONEER" hidden="false" id="732c-5315-f0fb-f79c" targetId="5bd1-c828-0657-2a56" primary="false"/>
@@ -561,7 +561,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="110"/>
+        <cost name="pts" typeId="points" value="100"/>
       </costs>
       <categoryLinks>
         <categoryLink name="PIONEER" hidden="false" id="ca7e-f127-ea80-29c6" targetId="5bd1-c828-0657-2a56" primary="false"/>
@@ -594,7 +594,7 @@
         <constraint type="max" value="-1" field="selections" scope="force" shared="true" id="0b49-f5c7-ee46-dc66" includeChildSelections="true"/>
       </constraints>
       <costs>
-        <cost name="pts" typeId="points" value="150"/>
+        <cost name="pts" typeId="points" value="140"/>
       </costs>
       <modifierGroups>
         <modifierGroup type="and">
@@ -881,7 +881,7 @@
         </modifierGroup>
       </modifierGroups>
       <costs>
-        <cost name="pts" typeId="points" value="120"/>
+        <cost name="pts" typeId="points" value="110"/>
       </costs>
       <categoryLinks>
         <categoryLink name="PIONEER" hidden="false" id="0593-c0bb-8f8d-6a4c" targetId="5bd1-c828-0657-2a56" primary="false"/>

--- a/Kharadron Overlords - The Magnate's Crew.cat
+++ b/Kharadron Overlords - The Magnate's Crew.cat
@@ -339,7 +339,7 @@ The target(s) cannot use **^^Charge^^** abilities for the rest of the turn.</cha
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="eb1e-1246-0941-718d" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="150"/>
+        <cost name="pts" typeId="points" value="140"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -650,7 +650,7 @@ The target(s) cannot use **^^Charge^^** abilities for the rest of the turn.</cha
         <constraint type="max" value="-1" field="selections" scope="force" shared="true" id="5cef-8716-1bdd-8565" includeChildSelections="true"/>
       </constraints>
       <costs>
-        <cost name="pts" typeId="points" value="150"/>
+        <cost name="pts" typeId="points" value="140"/>
       </costs>
       <modifierGroups>
         <modifierGroup type="and">
@@ -862,7 +862,7 @@ The target(s) cannot use **^^Charge^^** abilities for the rest of the turn.</cha
         </modifierGroup>
       </modifierGroups>
       <costs>
-        <cost name="pts" typeId="points" value="120"/>
+        <cost name="pts" typeId="points" value="110"/>
       </costs>
       <categoryLinks>
         <categoryLink name="MAGNATE&apos;S CREW" hidden="false" id="384f-7337-a1d5-e2b0" targetId="f6a3-f0dc-a863-aba3" primary="false"/>
@@ -962,7 +962,7 @@ The target(s) cannot use **^^Charge^^** abilities for the rest of the turn.</cha
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="110"/>
+        <cost name="pts" typeId="points" value="100"/>
       </costs>
       <categoryLinks>
         <categoryLink name="MAGNATE&apos;S CREW" hidden="false" id="c6b5-a4f3-1b85-7288" targetId="f6a3-f0dc-a863-aba3" primary="false"/>

--- a/Kharadron Overlords.cat
+++ b/Kharadron Overlords.cat
@@ -820,7 +820,7 @@ This unit can use this ability more than once per phase but you can only roll on
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="2914-0239-0acd-b106" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="110"/>
+        <cost name="pts" typeId="points" value="100"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -1036,7 +1036,7 @@ This unit can use this ability more than once per phase but you can only roll on
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="09ea-99fa-365e-0f01" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="90"/>
+        <cost name="pts" typeId="points" value="80"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -1142,7 +1142,7 @@ This unit can use this ability more than once per phase but you can only roll on
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="1445-7857-31b3-99e0" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="150"/>
+        <cost name="pts" typeId="points" value="140"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -1519,7 +1519,7 @@ This unit can use this ability more than once per phase but you can only roll on
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="110"/>
+        <cost name="pts" typeId="points" value="100"/>
       </costs>
     </entryLink>
     <entryLink import="true" name="Grundstok Gunhauler" hidden="false" id="2f7d-b7b4-e14a-b240" type="selectionEntry" targetId="66fa-6ab8-35c3-beef">
@@ -1550,7 +1550,7 @@ This unit can use this ability more than once per phase but you can only roll on
         <constraint type="max" value="-1" field="selections" scope="force" shared="true" id="3765-e0a6-3fea-a2b1" includeChildSelections="true"/>
       </constraints>
       <costs>
-        <cost name="pts" typeId="points" value="150"/>
+        <cost name="pts" typeId="points" value="140"/>
       </costs>
       <modifierGroups>
         <modifierGroup type="and">
@@ -2024,7 +2024,7 @@ This unit can use this ability more than once per phase but you can only roll on
         </modifierGroup>
       </modifierGroups>
       <costs>
-        <cost name="pts" typeId="points" value="120"/>
+        <cost name="pts" typeId="points" value="110"/>
       </costs>
     </entryLink>
     <entryLink import="true" name="Vongrim Harpoon Crew" hidden="false" id="54b0-df0d-569c-85ca" type="selectionEntry" targetId="b38b-f2bc-47a8-658e">

--- a/Kruleboyz - Murkvast Menagerie.cat
+++ b/Kruleboyz - Murkvast Menagerie.cat
@@ -297,7 +297,7 @@ While an enemy unit is contesting an objective that is **infested with bugs**:
         <categoryLink name="MURKVAST MENAGERIE" hidden="false" id="75c1-d543-1248-73b7" targetId="e8b6-8b10-412d-699e" primary="false"/>
       </categoryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="180"/>
+        <cost name="pts" typeId="points" value="150"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="c95f-d09a-6482-b49e" type="selectionEntryGroup" targetId="77c2-c505-074d-237f"/>
@@ -352,7 +352,7 @@ While an enemy unit is contesting an objective that is **infested with bugs**:
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="bcd6-faac-bcf7-c1c5" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="200"/>
+        <cost name="pts" typeId="points" value="180"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -818,7 +818,7 @@ While an enemy unit is contesting an objective that is **infested with bugs**:
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="160"/>
+        <cost name="pts" typeId="points" value="150"/>
       </costs>
       <constraints>
         <constraint type="max" value="0" field="selections" scope="roster" shared="true" id="d66d-bcd2-2259-a0e1" includeChildSelections="true" includeChildForces="true"/>

--- a/Kruleboyz.cat
+++ b/Kruleboyz.cat
@@ -901,7 +901,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="5915-6775-0db9-f674" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="140"/>
+        <cost name="pts" typeId="points" value="130"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -1069,7 +1069,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="86e2-0845-59ea-ed24" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="90"/>
+        <cost name="pts" typeId="points" value="80"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -1192,7 +1192,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="7b70-0215-eeee-e7a2" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="200"/>
+        <cost name="pts" typeId="points" value="180"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -1282,7 +1282,7 @@
     </entryLink>
     <entryLink import="true" name="Swampboss Skumdrekk" hidden="false" id="7a6e-dc55-4eae-4d5e" type="selectionEntry" targetId="57d2-f5d7-ec57-5d4a">
       <costs>
-        <cost name="pts" typeId="points" value="180"/>
+        <cost name="pts" typeId="points" value="150"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="e4d6-e924-0524-c8ba" type="selectionEntryGroup" targetId="b922-1cb1-893c-dec2"/>
@@ -1347,7 +1347,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="140"/>
+        <cost name="pts" typeId="points" value="130"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Paths" hidden="false" id="9ea8-f8b4-195f-e797" type="selectionEntryGroup" targetId="f73e-97bd-1805-3b18"/>
@@ -1435,7 +1435,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="160"/>
+        <cost name="pts" typeId="points" value="150"/>
       </costs>
       <constraints>
         <constraint type="max" value="-1" field="selections" scope="force" shared="true" id="0e27-abaf-a66f-5665" includeChildSelections="true"/>

--- a/Legions of Nagash [LEGENDS].cat
+++ b/Legions of Nagash [LEGENDS].cat
@@ -620,7 +620,7 @@ If you picked **sacrificial pawn**, instead of making a casting roll for the nex
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="68e8-c7da-cd17-1db1" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="120"/>
+        <cost name="pts" typeId="points" value="110"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -672,7 +672,7 @@ If you picked **sacrificial pawn**, instead of making a casting roll for the nex
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="e4fd-3968-5523-dcb6" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="380"/>
+        <cost name="pts" typeId="points" value="400"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -724,7 +724,7 @@ If you picked **sacrificial pawn**, instead of making a casting roll for the nex
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="e0c8-fce3-9ec8-84d7" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="380"/>
+        <cost name="pts" typeId="points" value="400"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -776,7 +776,7 @@ If you picked **sacrificial pawn**, instead of making a casting roll for the nex
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="977c-8496-2729-6c2b" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="170"/>
+        <cost name="pts" typeId="points" value="150"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -1621,7 +1621,7 @@ If you picked **sacrificial pawn**, instead of making a casting roll for the nex
         <entryLink import="true" name="Renown" hidden="false" id="9c92-083b-b692-0daf" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="150"/>
+        <cost name="pts" typeId="points" value="140"/>
       </costs>
       <constraints>
         <constraint type="max" value="-1" field="selections" scope="force" shared="true" id="cf63-7b3e-3cc0-9053" includeChildSelections="true"/>
@@ -1793,7 +1793,7 @@ If you picked **sacrificial pawn**, instead of making a casting roll for the nex
         <entryLink import="true" name="Renown" hidden="false" id="f68e-1f41-4b20-d698" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="180"/>
+        <cost name="pts" typeId="points" value="170"/>
       </costs>
       <modifierGroups>
         <modifierGroup type="and">
@@ -1947,7 +1947,7 @@ If you picked **sacrificial pawn**, instead of making a casting roll for the nex
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="230"/>
+        <cost name="pts" typeId="points" value="240"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Paths" hidden="false" id="4320-1544-bbb7-c9cb" type="selectionEntryGroup" targetId="4843-40b6-f8e8-5f51"/>
@@ -2015,7 +2015,7 @@ If you picked **sacrificial pawn**, instead of making a casting roll for the nex
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="250"/>
+        <cost name="pts" typeId="points" value="260"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Paths" hidden="false" id="8550-0481-87d6-cdd4" type="selectionEntryGroup" targetId="4843-40b6-f8e8-5f51"/>
@@ -2367,7 +2367,7 @@ If you picked **sacrificial pawn**, instead of making a casting roll for the nex
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="d144-b162-bd0d-6c88" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="110"/>
+        <cost name="pts" typeId="points" value="100"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -2577,7 +2577,7 @@ If you picked **sacrificial pawn**, instead of making a casting roll for the nex
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="281d-8dd3-e915-bff2" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="170"/>
+        <cost name="pts" typeId="points" value="160"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -2645,7 +2645,7 @@ If you picked **sacrificial pawn**, instead of making a casting roll for the nex
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="2658-6b9a-8ace-dcd7" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="120"/>
+        <cost name="pts" typeId="points" value="110"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -2911,7 +2911,7 @@ If you picked **sacrificial pawn**, instead of making a casting roll for the nex
         <constraint type="max" value="-1" field="selections" scope="force" shared="true" id="a031-5b5e-58c3-91cb"/>
       </constraints>
       <costs>
-        <cost name="pts" typeId="points" value="220"/>
+        <cost name="pts" typeId="points" value="200"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="f388-a7ee-f174-a806" type="selectionEntryGroup" targetId="90e2-1d1f-c379-4db3"/>
@@ -2947,7 +2947,7 @@ If you picked **sacrificial pawn**, instead of making a casting roll for the nex
         <entryLink import="true" name="Renown" hidden="false" id="4e9f-0b02-4255-2264" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="210"/>
+        <cost name="pts" typeId="points" value="200"/>
       </costs>
       <categoryLinks>
         <categoryLink name="LEGIONS OF NAGASH" hidden="false" id="47af-e90d-47d9-041a" targetId="0f04-639f-d2c0-912d" primary="false"/>
@@ -3101,7 +3101,7 @@ If you picked **sacrificial pawn**, instead of making a casting roll for the nex
         <entryLink import="true" name="Renown" hidden="false" id="7a1e-b5d6-be9b-e860" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="200"/>
+        <cost name="pts" typeId="points" value="190"/>
       </costs>
       <categoryLinks>
         <categoryLink name="LEGIONS OF NAGASH" hidden="false" id="856e-03da-161a-c706" targetId="0f04-639f-d2c0-912d" primary="false"/>
@@ -3163,7 +3163,7 @@ If you picked **sacrificial pawn**, instead of making a casting roll for the nex
         <entryLink import="true" name="Renown" hidden="false" id="b4f7-b76d-87d6-0f93" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="200"/>
+        <cost name="pts" typeId="points" value="190"/>
       </costs>
       <categoryLinks>
         <categoryLink name="LEGIONS OF NAGASH" hidden="false" id="d85c-f68c-20cf-5977" targetId="0f04-639f-d2c0-912d" primary="false"/>
@@ -3640,7 +3640,7 @@ If you picked **sacrificial pawn**, instead of making a casting roll for the nex
         <entryLink import="true" name="Renown" hidden="false" id="28c7-60bb-5116-8521" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="260"/>
+        <cost name="pts" typeId="points" value="250"/>
       </costs>
       <categoryLinks>
         <categoryLink name="LEGIONS OF NAGASH" hidden="false" id="6e0b-838d-ffa4-77a2" targetId="0f04-639f-d2c0-912d" primary="false"/>
@@ -3671,7 +3671,7 @@ If you picked **sacrificial pawn**, instead of making a casting roll for the nex
         <entryLink import="true" name="Renown" hidden="false" id="9de5-4811-67d3-140c" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="250"/>
+        <cost name="pts" typeId="points" value="240"/>
       </costs>
       <categoryLinks>
         <categoryLink name="LEGIONS OF NAGASH" hidden="false" id="0111-48b3-f58a-a21a" targetId="0f04-639f-d2c0-912d" primary="false"/>
@@ -3746,7 +3746,7 @@ If you picked **sacrificial pawn**, instead of making a casting roll for the nex
         <entryLink import="true" name="Renown" hidden="false" id="ced7-79e9-2a0b-d35f" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="140"/>
+        <cost name="pts" typeId="points" value="130"/>
       </costs>
       <categoryLinks>
         <categoryLink name="LEGIONS OF NAGASH" hidden="false" id="dc33-b05d-9e63-8d29" targetId="0f04-639f-d2c0-912d" primary="false"/>
@@ -3919,7 +3919,7 @@ If you picked **sacrificial pawn**, instead of making a casting roll for the nex
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="68df-3a25-29e4-ec08" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="150"/>
+        <cost name="pts" typeId="points" value="140"/>
       </costs>
       <modifiers>
         <modifier type="set" value="true" field="hidden">
@@ -3971,7 +3971,7 @@ If you picked **sacrificial pawn**, instead of making a casting roll for the nex
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="eb46-9eb9-a36f-b532" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="130"/>
+        <cost name="pts" typeId="points" value="120"/>
       </costs>
       <modifiers>
         <modifier type="set" value="true" field="hidden">
@@ -4106,7 +4106,7 @@ If you picked **sacrificial pawn**, instead of making a casting roll for the nex
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="4747-27e9-bc1b-775a" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="230"/>
+        <cost name="pts" typeId="points" value="210"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -4216,7 +4216,7 @@ If you picked **sacrificial pawn**, instead of making a casting roll for the nex
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="170"/>
+        <cost name="pts" typeId="points" value="150"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Paths" hidden="false" id="8350-7af0-0633-0717" type="selectionEntryGroup" targetId="4843-40b6-f8e8-5f51"/>
@@ -4252,7 +4252,7 @@ If you picked **sacrificial pawn**, instead of making a casting roll for the nex
         <entryLink import="true" name="Renown" hidden="false" id="8880-f61d-6bb6-9cae" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="90"/>
+        <cost name="pts" typeId="points" value="110"/>
       </costs>
       <categoryLinks>
         <categoryLink name="LEGIONS OF NAGASH" hidden="false" id="41b5-3b09-eb43-5932" targetId="0f04-639f-d2c0-912d" primary="false"/>
@@ -4314,7 +4314,7 @@ If you picked **sacrificial pawn**, instead of making a casting roll for the nex
         <entryLink import="true" name="Renown" hidden="false" id="06d0-dc40-d6e2-9491" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="200"/>
+        <cost name="pts" typeId="points" value="190"/>
       </costs>
       <categoryLinks>
         <categoryLink name="LEGIONS OF NAGASH" hidden="false" id="3d9c-a537-cc0f-7bc0" targetId="0f04-639f-d2c0-912d" primary="false"/>
@@ -4484,7 +4484,7 @@ If you picked **sacrificial pawn**, instead of making a casting roll for the nex
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="969c-a257-00d0-2abe" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="120"/>
+        <cost name="pts" typeId="points" value="110"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -4637,7 +4637,7 @@ If you picked **sacrificial pawn**, instead of making a casting roll for the nex
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="365a-6c28-77e7-335a" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="220"/>
+        <cost name="pts" typeId="points" value="200"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -4948,7 +4948,7 @@ If you picked **sacrificial pawn**, instead of making a casting roll for the nex
         <entryLink import="true" name="Renown" hidden="false" id="467d-ed72-7ea6-d51c" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="130"/>
+        <cost name="pts" typeId="points" value="120"/>
       </costs>
       <categoryLinks>
         <categoryLink name="LEGIONS OF NAGASH" hidden="false" id="6835-e473-ac5c-b25f" targetId="0f04-639f-d2c0-912d" primary="false"/>
@@ -5199,7 +5199,7 @@ If you picked **sacrificial pawn**, instead of making a casting roll for the nex
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="f48b-5936-71c0-9a5e" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="190"/>
+        <cost name="pts" typeId="points" value="180"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -5324,7 +5324,7 @@ If you picked **sacrificial pawn**, instead of making a casting roll for the nex
         <entryLink import="true" name="Renown" hidden="false" id="827a-f9b8-f591-aae6" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="190"/>
+        <cost name="pts" typeId="points" value="180"/>
       </costs>
       <categoryLinks>
         <categoryLink name="LEGIONS OF NAGASH" hidden="false" id="7fb5-2bd7-aa7b-c707" targetId="0f04-639f-d2c0-912d" primary="false"/>

--- a/Lumineth Realm-lords - Aelementiri Conclave.cat
+++ b/Lumineth Realm-lords - Aelementiri Conclave.cat
@@ -317,7 +317,7 @@ You can have a maximum of 6 of each type of rune in your **library**.</character
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="efaf-3258-fcc2-2471" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="130"/>
+        <cost name="pts" typeId="points" value="120"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -360,7 +360,7 @@ You can have a maximum of 6 of each type of rune in your **library**.</character
     </entryLink>
     <entryLink import="true" name="Avalenor, the Stoneheart King" hidden="false" id="4aaa-cd89-a41f-ed9c" type="selectionEntry" targetId="f6dc-5ecd-a783-3fa4">
       <costs>
-        <cost name="pts" typeId="points" value="420"/>
+        <cost name="pts" typeId="points" value="400"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="2652-ec98-825d-ec49" type="selectionEntryGroup" targetId="69d2-7b4b-7659-2cbb"/>
@@ -457,7 +457,7 @@ You can have a maximum of 6 of each type of rune in your **library**.</character
     </entryLink>
     <entryLink import="true" name="Sevireth, Lord of the Seventh Wind" hidden="false" id="0953-b3fa-22c5-9610" type="selectionEntry" targetId="880-ddff-1e6d-916f">
       <costs>
-        <cost name="pts" typeId="points" value="340"/>
+        <cost name="pts" typeId="points" value="350"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="1dc2-be11-a39b-480c" type="selectionEntryGroup" targetId="69d2-7b4b-7659-2cbb"/>
@@ -524,7 +524,7 @@ You can have a maximum of 6 of each type of rune in your **library**.</character
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="340"/>
+        <cost name="pts" typeId="points" value="310"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Renown" hidden="false" id="701e-0d81-b924-476f" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
@@ -613,7 +613,7 @@ You can have a maximum of 6 of each type of rune in your **library**.</character
         <constraint type="max" value="-1" field="selections" scope="force" shared="true" id="5db3-5025-0fd5-e967"/>
       </constraints>
       <costs>
-        <cost name="pts" typeId="points" value="140"/>
+        <cost name="pts" typeId="points" value="150"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Renown" hidden="false" id="fe42-ddef-d93a-9ca0" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
@@ -680,7 +680,7 @@ You can have a maximum of 6 of each type of rune in your **library**.</character
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="160"/>
+        <cost name="pts" typeId="points" value="170"/>
       </costs>
       <categoryLinks>
         <categoryLink name="AELEMENTIRI CONCLAVE" hidden="false" id="9843-1cbb-8b3f-5942" targetId="cab3-36a3-4dfd-908b" primary="false"/>
@@ -794,7 +794,7 @@ You can have a maximum of 6 of each type of rune in your **library**.</character
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="1dcb-9811-b00d-daf7" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="130"/>
+        <cost name="pts" typeId="points" value="150"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">

--- a/Lumineth Realm-lords - Vanari Paragons.cat
+++ b/Lumineth Realm-lords - Vanari Paragons.cat
@@ -288,7 +288,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="2def-4291-4a8c-a8d8" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="140"/>
+        <cost name="pts" typeId="points" value="130"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -487,7 +487,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="120"/>
+        <cost name="pts" typeId="points" value="100"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Renown" hidden="false" id="91b7-ee2f-3e1b-fb49" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
@@ -554,7 +554,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="140"/>
+        <cost name="pts" typeId="points" value="150"/>
       </costs>
       <categoryLinks>
         <categoryLink name="VANARI PARAGONS" hidden="false" id="0ecc-a52c-aefa-e403" targetId="b420-5ced-1234-236d" primary="false"/>
@@ -585,7 +585,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="180"/>
+        <cost name="pts" typeId="points" value="200"/>
       </costs>
       <categoryLinks>
         <categoryLink name="VANARI PARAGONS" hidden="false" id="a074-0ada-768a-7e9d" targetId="b420-5ced-1234-236d" primary="false"/>

--- a/Lumineth Realm-lords.cat
+++ b/Lumineth Realm-lords.cat
@@ -759,7 +759,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="cde9-9ac0-32f1-fbfd" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="130"/>
+        <cost name="pts" typeId="points" value="120"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -841,7 +841,7 @@
     </entryLink>
     <entryLink import="true" name="Avalenor, the Stoneheart King" hidden="false" id="3f82-ac47-1ba2-a307" type="selectionEntry" targetId="f6dc-5ecd-a783-3fa4">
       <costs>
-        <cost name="pts" typeId="points" value="420"/>
+        <cost name="pts" typeId="points" value="400"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="ccce-c4c8-0ffc-ef45" type="selectionEntryGroup" targetId="8248-f1f1-6202-dbe2"/>
@@ -884,7 +884,7 @@
     </entryLink>
     <entryLink import="true" name="Ellania and Ellathor, Eclipsian Warsages" hidden="false" id="9caa-6acd-54b7-1ca7" type="selectionEntry" targetId="a494-b23a-e95e-ed3f">
       <costs>
-        <cost name="pts" typeId="points" value="290"/>
+        <cost name="pts" typeId="points" value="310"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="340c-a101-639e-070b" type="selectionEntryGroup" targetId="8248-f1f1-6202-dbe2"/>
@@ -975,7 +975,7 @@
     </entryLink>
     <entryLink import="true" name="Lyrior Uthralle, Warden of Ymetrica" hidden="false" id="e5c5-abb9-481b-461e" type="selectionEntry" targetId="17ab-ba44-9593-e3d4">
       <costs>
-        <cost name="pts" typeId="points" value="250"/>
+        <cost name="pts" typeId="points" value="260"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="05af-0320-c2ec-0445" type="selectionEntryGroup" targetId="8248-f1f1-6202-dbe2"/>
@@ -1176,7 +1176,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="116a-62f6-48a1-a99e" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="140"/>
+        <cost name="pts" typeId="points" value="130"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -1216,7 +1216,7 @@
     </entryLink>
     <entryLink import="true" name="Sevireth, Lord of the Seventh Wind" hidden="false" id="2cfd-546b-46db-5798" type="selectionEntry" targetId="880-ddff-1e6d-916f">
       <costs>
-        <cost name="pts" typeId="points" value="340"/>
+        <cost name="pts" typeId="points" value="350"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="065a-7ce5-b8ab-b5af" type="selectionEntryGroup" targetId="8248-f1f1-6202-dbe2"/>
@@ -1451,7 +1451,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="340"/>
+        <cost name="pts" typeId="points" value="310"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="dc38-abb7-8dc5-3c69" type="selectionEntryGroup" targetId="8248-f1f1-6202-dbe2"/>
@@ -1537,7 +1537,7 @@
         <constraint type="max" value="-1" field="selections" scope="force" shared="true" id="2b4e-1c18-6de5-5c89"/>
       </constraints>
       <costs>
-        <cost name="pts" typeId="points" value="140"/>
+        <cost name="pts" typeId="points" value="150"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="9883-4f90-cc81-ffb8" type="selectionEntryGroup" targetId="8248-f1f1-6202-dbe2"/>
@@ -1601,7 +1601,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="160"/>
+        <cost name="pts" typeId="points" value="170"/>
       </costs>
     </entryLink>
     <entryLink import="true" name="Hurakan Spirit of the Wind" hidden="false" id="98bd-19f6-d8ec-9be7" type="selectionEntry" targetId="4f9b-c3fa-a07b-59b0">
@@ -1686,7 +1686,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="180"/>
+        <cost name="pts" typeId="points" value="200"/>
       </costs>
     </entryLink>
     <entryLink import="true" name="Vanari Auralan Sentinels" hidden="false" id="82a1-6346-2f76-633e" type="selectionEntry" targetId="49b1-940c-50a1-24c9">
@@ -1715,7 +1715,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="140"/>
+        <cost name="pts" typeId="points" value="150"/>
       </costs>
     </entryLink>
     <entryLink import="true" name="Vanari Auralan Wardens" hidden="false" id="5458-8e15-1e45-badf" type="selectionEntry" targetId="b62e-acea-4717-14bd">
@@ -1766,7 +1766,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="120"/>
+        <cost name="pts" typeId="points" value="100"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="0cee-994a-2c25-bad1" type="selectionEntryGroup" targetId="8248-f1f1-6202-dbe2"/>
@@ -1931,7 +1931,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="275c-73cd-6390-6616" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="140"/>
+        <cost name="pts" typeId="points" value="130"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -2053,7 +2053,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="4115-e1a6-23bd-34c7" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="130"/>
+        <cost name="pts" typeId="points" value="150"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -2102,7 +2102,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="698a-e258-3f50-a7f2" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="140"/>
+        <cost name="pts" typeId="points" value="160"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">

--- a/Maggotkin of Nurgle - Cycle of Corruption.cat
+++ b/Maggotkin of Nurgle - Cycle of Corruption.cat
@@ -320,7 +320,7 @@ If there are no friendly **Feculent Gnarlmaws** on the battlefield, you can set 
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="30fd-af42-0423-75ba" type="selectionEntryGroup" targetId="a45f-bae4-1a8b-9d8d"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="130"/>
+        <cost name="pts" typeId="points" value="140"/>
       </costs>
       <categoryLinks>
         <categoryLink name="CYCLE OF CORRUPTION" hidden="false" id="a551-86aa-9b3a-e7ff" targetId="bb0d-ce53-6e33-9053" primary="false"/>
@@ -404,7 +404,7 @@ If there are no friendly **Feculent Gnarlmaws** on the battlefield, you can set 
         <entryLink import="true" name="Paths" hidden="false" id="0df1-72b7-1faa-bdfd" type="selectionEntryGroup" targetId="1eef-ae4d-3c08-f468"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="100"/>
+        <cost name="pts" typeId="points" value="110"/>
       </costs>
       <categoryLinks>
         <categoryLink name="CYCLE OF CORRUPTION" hidden="false" id="4faf-d485-b73b-5811" targetId="bb0d-ce53-6e33-9053" primary="false"/>
@@ -466,7 +466,7 @@ If there are no friendly **Feculent Gnarlmaws** on the battlefield, you can set 
         <entryLink import="true" name="Paths" hidden="false" id="5939-6e4d-91df-ba90" type="selectionEntryGroup" targetId="1eef-ae4d-3c08-f468"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="200"/>
+        <cost name="pts" typeId="points" value="210"/>
       </costs>
       <categoryLinks>
         <categoryLink name="CYCLE OF CORRUPTION" hidden="false" id="6f75-ec97-74bd-f09d" targetId="bb0d-ce53-6e33-9053" primary="false"/>
@@ -723,7 +723,7 @@ If there are no friendly **Feculent Gnarlmaws** on the battlefield, you can set 
         <entryLink import="true" name="Paths" hidden="false" id="1b9d-69a7-9aae-e2a8" type="selectionEntryGroup" targetId="1eef-ae4d-3c08-f468"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="200"/>
+        <cost name="pts" typeId="points" value="190"/>
       </costs>
       <categoryLinks>
         <categoryLink name="CYCLE OF CORRUPTION" hidden="false" id="66d9-24ce-33bc-d4aa" targetId="bb0d-ce53-6e33-9053" primary="false"/>
@@ -926,7 +926,7 @@ If there are no friendly **Feculent Gnarlmaws** on the battlefield, you can set 
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="4522-a6cd-b43a-5b1b" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="100"/>
+        <cost name="pts" typeId="points" value="120"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -1148,7 +1148,7 @@ If there are no friendly **Feculent Gnarlmaws** on the battlefield, you can set 
     </entryLink>
     <entryLink import="true" name="Gutrot Spume" hidden="false" id="f925-69db-e59f-d189" type="selectionEntry" targetId="5586-2cfb-7451-aedc">
       <costs>
-        <cost name="pts" typeId="points" value="120"/>
+        <cost name="pts" typeId="points" value="100"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="51bd-e6c8-8eb1-668c" type="selectionEntryGroup" targetId="a45f-bae4-1a8b-9d8d"/>

--- a/Maggotkin of Nurgle - The Gardeners of Nurgle.cat
+++ b/Maggotkin of Nurgle - The Gardeners of Nurgle.cat
@@ -311,7 +311,7 @@
     </entryLink>
     <entryLink import="true" name="Great Unclean One" hidden="false" id="6d21-77d3-aa68-7eb2" type="selectionEntry" targetId="bbb9-4b05-be8a-af89">
       <costs>
-        <cost name="pts" typeId="points" value="400"/>
+        <cost name="pts" typeId="points" value="380"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Artefacts of Power" hidden="false" id="fef8-ce75-6e49-eb35" type="selectionEntryGroup" targetId="c69c-2b45-5320-e4c5"/>
@@ -464,7 +464,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="e6ae-a003-e0cc-7978" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="100"/>
+        <cost name="pts" typeId="points" value="90"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -585,7 +585,7 @@
     </entryLink>
     <entryLink import="true" name="Beast of Nurgle" hidden="false" id="1c98-4416-bc35-dfd8" type="selectionEntry" targetId="8197-2f04-e647-f5c">
       <costs>
-        <cost name="pts" typeId="points" value="110"/>
+        <cost name="pts" typeId="points" value="100"/>
       </costs>
       <modifiers>
         <modifier type="set" value="true" field="hidden">
@@ -845,7 +845,7 @@
         </modifierGroup>
       </modifierGroups>
       <costs>
-        <cost name="pts" typeId="points" value="200"/>
+        <cost name="pts" typeId="points" value="180"/>
       </costs>
       <categoryLinks>
         <categoryLink name="GARDENERS OF NURGLE" hidden="false" id="8c1e-3c12-c977-5f50" targetId="6094-8e56-5809-99a9" primary="false"/>
@@ -898,7 +898,7 @@
         </modifierGroup>
       </modifierGroups>
       <costs>
-        <cost name="pts" typeId="points" value="220"/>
+        <cost name="pts" typeId="points" value="200"/>
       </costs>
       <categoryLinks>
         <categoryLink name="GARDENERS OF NURGLE" hidden="false" id="280d-3df7-73be-776f" targetId="6094-8e56-5809-99a9" primary="false"/>

--- a/Maggotkin of Nurgle.cat
+++ b/Maggotkin of Nurgle.cat
@@ -685,7 +685,7 @@ the move.</characteristic>
     </entryLink>
     <entryLink import="true" name="Great Unclean One" hidden="false" id="4a18-bdb4-644e-3ab4" type="selectionEntry" targetId="bbb9-4b05-be8a-af89">
       <costs>
-        <cost name="pts" typeId="points" value="400"/>
+        <cost name="pts" typeId="points" value="380"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Artefacts of Power" hidden="false" id="8ca4-9189-8426-9230" type="selectionEntryGroup" targetId="6ce9-d284-339d-1e9b"/>
@@ -733,7 +733,7 @@ the move.</characteristic>
     </entryLink>
     <entryLink import="true" name="Gutrot Spume" hidden="false" id="3ed8-5faa-c6e5-24d" type="selectionEntry" targetId="5586-2cfb-7451-aedc">
       <costs>
-        <cost name="pts" typeId="points" value="120"/>
+        <cost name="pts" typeId="points" value="100"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Paths" hidden="false" id="94bf-c216-f589-470e" type="selectionEntryGroup" targetId="980a-fb59-b159-7706"/>
@@ -983,7 +983,7 @@ the move.</characteristic>
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="9a77-a8fb-1ebf-453f" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="100"/>
+        <cost name="pts" typeId="points" value="120"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -1282,7 +1282,7 @@ the move.</characteristic>
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="318c-8669-d31f-0786" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="100"/>
+        <cost name="pts" typeId="points" value="90"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -1439,7 +1439,7 @@ the move.</characteristic>
     </entryLink>
     <entryLink import="true" name="Beast of Nurgle" hidden="false" id="7ea9-910a-ce67-7f" type="selectionEntry" targetId="8197-2f04-e647-f5c">
       <costs>
-        <cost name="pts" typeId="points" value="110"/>
+        <cost name="pts" typeId="points" value="100"/>
       </costs>
       <modifiers>
         <modifier type="set" value="true" field="hidden">
@@ -1581,7 +1581,7 @@ the move.</characteristic>
         <entryLink import="true" name="Renown" hidden="false" id="c4e3-4f61-9f9e-16c5" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="200"/>
+        <cost name="pts" typeId="points" value="190"/>
       </costs>
     </entryLink>
     <entryLink import="true" name="Pusgoyle Blightlords" hidden="false" id="db15-9dfc-14d9-9289" type="selectionEntry" targetId="fef0-a956-3083-4cf3">
@@ -1926,7 +1926,7 @@ the move.</characteristic>
         </modifierGroup>
       </modifierGroups>
       <costs>
-        <cost name="pts" typeId="points" value="200"/>
+        <cost name="pts" typeId="points" value="180"/>
       </costs>
     </entryLink>
     <entryLink import="true" name="Gelgus Pust, the Prince of Sores" hidden="false" id="b321-d8fd-8273-31df" type="selectionEntry" targetId="5fef-f075-9e25-ee6a">
@@ -1971,7 +1971,7 @@ the move.</characteristic>
         </modifierGroup>
       </modifierGroups>
       <costs>
-        <cost name="pts" typeId="points" value="220"/>
+        <cost name="pts" typeId="points" value="200"/>
       </costs>
     </entryLink>
     <entryLink import="true" name="Shaman Foulhoof" hidden="false" id="5c96-b078-14ad-0cca" type="selectionEntry" targetId="e676-1e6d-0d6e-f9de">
@@ -2145,7 +2145,7 @@ the move.</characteristic>
         <entryLink import="true" name="Renown" hidden="false" id="3276-119d-0450-cce9" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="100"/>
+        <cost name="pts" typeId="points" value="110"/>
       </costs>
     </entryLink>
     <entryLink import="true" name="Sloven Knights" hidden="false" id="fd62-4ee3-f07a-9a49" type="selectionEntry" targetId="16b5-3022-8c0f-976e">
@@ -2201,7 +2201,7 @@ the move.</characteristic>
         <entryLink import="true" name="Renown" hidden="false" id="f746-0a6c-400a-49a6" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="200"/>
+        <cost name="pts" typeId="points" value="210"/>
       </costs>
     </entryLink>
     <entryLink import="true" name="Pestigors" hidden="false" id="1d95-e378-cddf-abf4" type="selectionEntry" targetId="63e1-62af-0f98-29f4">
@@ -2229,7 +2229,7 @@ the move.</characteristic>
         <entryLink import="true" name="Renown" hidden="false" id="1162-63bc-e136-ed08" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="130"/>
+        <cost name="pts" typeId="points" value="140"/>
       </costs>
     </entryLink>
     <entryLink import="true" name="Anvil of Apotheosis: Maggotkin of Nurgle Hero" hidden="false" id="d7ae-9eb1-d446-2bc3" type="selectionEntry" targetId="9f03-3365-5802-14e6">

--- a/Nighthaunt - The Clattering Procession.cat
+++ b/Nighthaunt - The Clattering Procession.cat
@@ -281,7 +281,7 @@
         <constraint type="max" value="1" field="selections" scope="roster" shared="false" id="95dd-c3d1-027b-824d" includeChildForces="true"/>
       </constraints>
       <costs>
-        <cost name="pts" typeId="points" value="220"/>
+        <cost name="pts" typeId="points" value="200"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Renown" hidden="false" id="c04c-f107-6854-b7c7" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
@@ -322,7 +322,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="220"/>
+        <cost name="pts" typeId="points" value="200"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Renown" hidden="false" id="597c-28b3-810c-50f2" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>

--- a/Nighthaunt - The Eternal Nightmare.cat
+++ b/Nighthaunt - The Eternal Nightmare.cat
@@ -349,7 +349,7 @@
         <entryLink import="true" name="Paths" hidden="false" id="0978-b60f-a3a5-7d47" type="selectionEntryGroup" targetId="8f39-989b-e420-3c93"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="210"/>
+        <cost name="pts" typeId="points" value="200"/>
       </costs>
       <categoryLinks>
         <categoryLink name="ETERNAL NIGHTMARE" hidden="false" id="2b9b-88c3-d482-5085" targetId="d96a-d8e4-8dbe-eb17" primary="false"/>
@@ -537,7 +537,7 @@
         <entryLink import="true" name="Paths" hidden="false" id="1661-9ede-67a4-37e0" type="selectionEntryGroup" targetId="8f39-989b-e420-3c93"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="200"/>
+        <cost name="pts" typeId="points" value="190"/>
       </costs>
       <categoryLinks>
         <categoryLink name="ETERNAL NIGHTMARE" hidden="false" id="b01b-d490-de5e-53e4" targetId="d96a-d8e4-8dbe-eb17" primary="false"/>
@@ -568,7 +568,7 @@
         <entryLink import="true" name="Paths" hidden="false" id="d3db-7ed7-b55c-759d" type="selectionEntryGroup" targetId="8f39-989b-e420-3c93"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="200"/>
+        <cost name="pts" typeId="points" value="190"/>
       </costs>
       <categoryLinks>
         <categoryLink name="ETERNAL NIGHTMARE" hidden="false" id="d7ef-c95f-e9a9-3809" targetId="d96a-d8e4-8dbe-eb17" primary="false"/>
@@ -585,7 +585,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="f1db-0f63-2fe2-5e9a" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="110"/>
+        <cost name="pts" typeId="points" value="100"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -739,7 +739,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="8ace-3afe-2daa-6d06" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="170"/>
+        <cost name="pts" typeId="points" value="160"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -893,7 +893,7 @@
     </entryLink>
     <entryLink import="true" name="Nagash, Supreme Lord of the Undead" hidden="false" id="c9e4-e994-0400-ac81" type="selectionEntry" targetId="fb77-fec9-42ed-a7fd">
       <costs>
-        <cost name="pts" typeId="points" value="840"/>
+        <cost name="pts" typeId="points" value="750"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="7846-885f-ad3d-d0d0" type="selectionEntryGroup" targetId="ec74-ffee-da0a-55fb"/>
@@ -978,7 +978,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="63a9-760c-dfdb-d5f4" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="120"/>
+        <cost name="pts" typeId="points" value="110"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">

--- a/Nighthaunt.cat
+++ b/Nighthaunt.cat
@@ -630,7 +630,7 @@
   <entryLinks>
     <entryLink import="true" name="Awlrach the Drowner" hidden="false" id="e5fd-27bc-4ac3-4825" type="selectionEntry" targetId="d8ef-7494-db04-b1a9">
       <costs>
-        <cost name="pts" typeId="points" value="130"/>
+        <cost name="pts" typeId="points" value="110"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="5461-77ac-eabd-2d2c" type="selectionEntryGroup" targetId="1cb4-1572-5a03-ef40"/>
@@ -745,7 +745,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="28a6-efe4-8b86-3628" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="110"/>
+        <cost name="pts" typeId="points" value="100"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -1023,7 +1023,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="c8a9-d07e-33fa-533d" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="170"/>
+        <cost name="pts" typeId="points" value="160"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -1078,7 +1078,7 @@
     </entryLink>
     <entryLink import="true" name="Nagash, Supreme Lord of the Undead" hidden="false" id="5b02-b841-9c31-b69c" type="selectionEntry" targetId="fb77-fec9-42ed-a7fd">
       <costs>
-        <cost name="pts" typeId="points" value="840"/>
+        <cost name="pts" typeId="points" value="750"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="e85b-8da5-d3bf-6288" type="selectionEntryGroup" targetId="1cb4-1572-5a03-ef40"/>
@@ -1171,7 +1171,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="912b-ccf7-f6b2-2c37" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="120"/>
+        <cost name="pts" typeId="points" value="110"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -1425,7 +1425,7 @@
         <constraint type="max" value="-1" field="selections" scope="force" shared="true" id="5383-844c-da86-b7bd"/>
       </constraints>
       <costs>
-        <cost name="pts" typeId="points" value="220"/>
+        <cost name="pts" typeId="points" value="200"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="7520-66b8-e174-5656" type="selectionEntryGroup" targetId="1cb4-1572-5a03-ef40"/>
@@ -1458,7 +1458,7 @@
         <entryLink import="true" name="Renown" hidden="false" id="6560-242b-3b9f-951a" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="210"/>
+        <cost name="pts" typeId="points" value="200"/>
       </costs>
     </entryLink>
     <entryLink import="true" name="Chainghasts" hidden="false" id="89e-e44e-1563-a04a" type="selectionEntry" targetId="4550-ab13-9a71-205c">
@@ -1597,7 +1597,7 @@
         <entryLink import="true" name="Renown" hidden="false" id="7dfa-e2e7-a7f6-c9c7" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="200"/>
+        <cost name="pts" typeId="points" value="190"/>
       </costs>
     </entryLink>
     <entryLink import="true" name="Glaivewraith Stalkers" hidden="false" id="4489-e8a7-ddcb-2e42" type="selectionEntry" targetId="43ee-d90-fdd8-e998">
@@ -1653,7 +1653,7 @@
         <entryLink import="true" name="Renown" hidden="false" id="552a-30da-ec97-3e82" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="200"/>
+        <cost name="pts" typeId="points" value="190"/>
       </costs>
     </entryLink>
     <entryLink import="true" name="Hexwraiths" hidden="false" id="134b-dda7-eda7-4b9a" type="selectionEntry" targetId="66a0-f02f-2616-3c62">

--- a/Ossiarch Bonereapers - Petrifex Elite [LEGENDS].cat
+++ b/Ossiarch Bonereapers - Petrifex Elite [LEGENDS].cat
@@ -279,7 +279,7 @@ This unit has **^^Strike-last**^^ for the rest of the turn.</characteristic>
         <entryLink import="true" name="Renown" hidden="false" id="1573-9563-eff6-6b70" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="250"/>
+        <cost name="pts" typeId="points" value="240"/>
       </costs>
       <categoryLinks>
         <categoryLink name="PETRIFEX ELITE" hidden="false" id="9c7e-2404-3097-7d3b" targetId="a534-eef1-69d3-c0c3" primary="false"/>
@@ -395,7 +395,7 @@ This unit has **^^Strike-last**^^ for the rest of the turn.</characteristic>
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="ba74-4f3a-79c5-186a" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="150"/>
+        <cost name="pts" typeId="points" value="140"/>
       </costs>
       <modifiers>
         <modifier type="add" value="abcb-73d0-2b6c-4f17" field="category">
@@ -457,7 +457,7 @@ This unit has **^^Strike-last**^^ for the rest of the turn.</characteristic>
         <entryLink import="true" name="Renown" hidden="false" id="c1de-2fb0-ad71-8d90" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="140"/>
+        <cost name="pts" typeId="points" value="130"/>
       </costs>
       <categoryLinks>
         <categoryLink name="PETRIFEX ELITE" hidden="false" id="4df2-e490-233d-aa6b" targetId="a534-eef1-69d3-c0c3" primary="false"/>

--- a/Ossiarch Bonereapers - The Lance of Ossia.cat
+++ b/Ossiarch Bonereapers - The Lance of Ossia.cat
@@ -397,7 +397,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="42a8-d009-b0c7-556f" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="230"/>
+        <cost name="pts" typeId="points" value="210"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -480,7 +480,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="170"/>
+        <cost name="pts" typeId="points" value="150"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Renown" hidden="false" id="4f78-d357-684e-afd0" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>

--- a/Ossiarch Bonereapers - The Null Myriad.cat
+++ b/Ossiarch Bonereapers - The Null Myriad.cat
@@ -383,7 +383,7 @@
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="4aaa-6c3c-fecf-035c" type="selectionEntryGroup" targetId="8289-7e0e-d732-5294" collapsible="false"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="260"/>
+        <cost name="pts" typeId="points" value="250"/>
       </costs>
       <categoryLinks>
         <categoryLink name="NULL MYRIAD" hidden="false" id="43dd-c214-5591-a387" targetId="4270-b1fd-ce98-4ee2" primary="false"/>
@@ -414,7 +414,7 @@
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="19c0-0ba3-e95b-1222" type="selectionEntryGroup" targetId="8289-7e0e-d732-5294" collapsible="false"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="250"/>
+        <cost name="pts" typeId="points" value="240"/>
       </costs>
       <categoryLinks>
         <categoryLink name="NULL MYRIAD" hidden="false" id="f5cd-2bb2-8d22-ec49" targetId="4270-b1fd-ce98-4ee2" primary="false"/>
@@ -445,7 +445,7 @@
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="b631-57bc-ce34-9356" type="selectionEntryGroup" targetId="8289-7e0e-d732-5294" collapsible="false"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="140"/>
+        <cost name="pts" typeId="points" value="130"/>
       </costs>
       <categoryLinks>
         <categoryLink name="NULL MYRIAD" hidden="false" id="8108-e926-0bc7-61f6" targetId="4270-b1fd-ce98-4ee2" primary="false"/>
@@ -614,7 +614,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="05d3-db0a-5105-b34a" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="150"/>
+        <cost name="pts" typeId="points" value="140"/>
       </costs>
       <modifiers>
         <modifier type="set" value="true" field="hidden">
@@ -665,7 +665,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="7e83-e9af-07b6-97f9" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="130"/>
+        <cost name="pts" typeId="points" value="120"/>
       </costs>
       <modifiers>
         <modifier type="set" value="true" field="hidden">
@@ -845,7 +845,7 @@
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="fa50-7769-b63a-7dcf" type="selectionEntryGroup" targetId="8289-7e0e-d732-5294" collapsible="false"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="90"/>
+        <cost name="pts" typeId="points" value="110"/>
       </costs>
       <categoryLinks>
         <categoryLink name="NULL MYRIAD" hidden="false" id="b46c-0e96-d57a-d3d9" targetId="4270-b1fd-ce98-4ee2" primary="false"/>

--- a/Ossiarch Bonereapers.cat
+++ b/Ossiarch Bonereapers.cat
@@ -187,7 +187,7 @@
         <entryLink import="true" name="Renown" hidden="false" id="46e9-23a8-da46-d367" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="260"/>
+        <cost name="pts" typeId="points" value="250"/>
       </costs>
     </entryLink>
     <entryLink import="true" name="Morghast Harbingers" hidden="false" id="b29b-b55b-b127-9e92" type="selectionEntry" targetId="16b9-87fe-ea6d-c02c">
@@ -215,7 +215,7 @@
         <entryLink import="true" name="Renown" hidden="false" id="cd1c-1646-da05-9289" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="250"/>
+        <cost name="pts" typeId="points" value="240"/>
       </costs>
     </entryLink>
     <entryLink import="true" name="Mortek Crawler" hidden="false" id="1833-eb75-431d-56ec" type="selectionEntry" targetId="8073-6b0a-5c59-fb6">
@@ -284,7 +284,7 @@
         <entryLink import="true" name="Renown" hidden="false" id="cb23-6e72-3189-0cd4" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="140"/>
+        <cost name="pts" typeId="points" value="130"/>
       </costs>
     </entryLink>
     <entryLink import="true" name="Arch-Kavalos Zandtos" hidden="false" id="f251-90be-5e0d-e76e" type="selectionEntry" targetId="3d7d-bb9a-b450-8a47">
@@ -387,7 +387,7 @@
     </entryLink>
     <entryLink import="true" name="Katakros, Mortarch of the Necropolis" hidden="false" id="4587-ae29-90ef-4bbb" type="selectionEntry" targetId="9294-b53c-e996-198c">
       <costs>
-        <cost name="pts" typeId="points" value="500"/>
+        <cost name="pts" typeId="points" value="470"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="bab2-a253-e105-b1d3" type="selectionEntryGroup" targetId="6fa6-ec1d-cf81-982d" collapsible="false"/>
@@ -688,7 +688,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="8927-1a65-f5e1-4efc" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="150"/>
+        <cost name="pts" typeId="points" value="140"/>
       </costs>
       <modifiers>
         <modifier type="set" value="true" field="hidden">
@@ -736,7 +736,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="68cc-425c-11fc-011b" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="130"/>
+        <cost name="pts" typeId="points" value="120"/>
       </costs>
       <modifiers>
         <modifier type="set" value="true" field="hidden">
@@ -890,7 +890,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="e4dd-6b7b-396a-5016" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="230"/>
+        <cost name="pts" typeId="points" value="210"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -1036,7 +1036,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="170"/>
+        <cost name="pts" typeId="points" value="150"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Paths" hidden="false" id="c78f-982d-6de0-4b51" type="selectionEntryGroup" targetId="70cc-ca33-377e-3078"/>
@@ -1069,7 +1069,7 @@
         <entryLink import="true" name="Renown" hidden="false" id="193a-dfe4-fdda-a800" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="90"/>
+        <cost name="pts" typeId="points" value="110"/>
       </costs>
     </entryLink>
     <entryLink import="true" name="Mortek Triaxes" hidden="false" id="27cc-d92f-7164-e072" type="selectionEntry" targetId="5809-fc53-2b72-a16f">

--- a/Seraphon.cat
+++ b/Seraphon.cat
@@ -645,7 +645,7 @@
   <entryLinks>
     <entryLink import="true" name="Lord Kroak" hidden="false" id="b137-2ba4-aec4-ee33" type="selectionEntry" targetId="df01-5aa1-a502-7a0c">
       <costs>
-        <cost name="pts" typeId="points" value="440"/>
+        <cost name="pts" typeId="points" value="410"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="8ac5-786c-8838-4083" type="selectionEntryGroup" targetId="c566-6b60-fe90-0b24"/>
@@ -746,7 +746,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="4688-9c54-4451-5053" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="120"/>
+        <cost name="pts" typeId="points" value="100"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -857,7 +857,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="0f2e-6eec-2da0-82ac" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="240"/>
+        <cost name="pts" typeId="points" value="220"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -1004,7 +1004,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="b500-dd27-0bb3-34ef" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="210"/>
+        <cost name="pts" typeId="points" value="200"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -1128,7 +1128,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="c0e8-621b-39f5-28f1" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="160"/>
+        <cost name="pts" typeId="points" value="140"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">

--- a/Skaven - Thanquol's Mutated Menagerie.cat
+++ b/Skaven - Thanquol's Mutated Menagerie.cat
@@ -263,7 +263,7 @@ After this ability has been resolved, this unit cannot use any other **^^Rampage
         <categoryLink name="MUTATED MENAGERIE" hidden="false" id="c4d9-8de2-20dc-31c3" targetId="420f-2e14-2ae1-222c" primary="false"/>
       </categoryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="330"/>
+        <cost name="pts" typeId="points" value="310"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="957a-34e1-a832-90a1" type="selectionEntryGroup" targetId="3c9e-96df-fcd3-acc5"/>
@@ -448,7 +448,7 @@ After this ability has been resolved, this unit cannot use any other **^^Rampage
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="230"/>
+        <cost name="pts" typeId="points" value="220"/>
       </costs>
       <categoryLinks>
         <categoryLink name="MUTATED MENAGERIE" hidden="false" id="2b88-5333-12a4-9b97" targetId="420f-2e14-2ae1-222c" primary="false"/>
@@ -484,7 +484,7 @@ After this ability has been resolved, this unit cannot use any other **^^Rampage
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="240"/>
+        <cost name="pts" typeId="points" value="230"/>
       </costs>
       <categoryLinks>
         <categoryLink name="MUTATED MENAGERIE" hidden="false" id="c6f0-9996-08ee-05e4" targetId="420f-2e14-2ae1-222c" primary="false"/>

--- a/Skaven - The Great-grand Gnawhorde.cat
+++ b/Skaven - The Great-grand Gnawhorde.cat
@@ -413,7 +413,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="230"/>
+        <cost name="pts" typeId="points" value="220"/>
       </costs>
       <categoryLinks>
         <categoryLink name="GNAWHORDE" hidden="false" id="23e6-21ef-8eaa-6280" targetId="84cc-ef1d-62cd-3fd9" primary="false"/>
@@ -1107,7 +1107,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="240"/>
+        <cost name="pts" typeId="points" value="230"/>
       </costs>
       <categoryLinks>
         <categoryLink name="GNAWHORDE" hidden="false" id="b051-b50b-b328-aff7" targetId="84cc-ef1d-62cd-3fd9" primary="false"/>
@@ -1158,7 +1158,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="1fa8-19f6-0ba2-7cd9" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="280"/>
+        <cost name="pts" typeId="points" value="260"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -1536,7 +1536,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="120"/>
+        <cost name="pts" typeId="points" value="100"/>
       </costs>
       <categoryLinks>
         <categoryLink name="GNAWHORDE" hidden="false" id="3f9d-82e3-4890-340a" targetId="84cc-ef1d-62cd-3fd9" primary="false"/>
@@ -1635,7 +1635,7 @@
         </modifierGroup>
       </modifierGroups>
       <costs>
-        <cost name="pts" typeId="points" value="130"/>
+        <cost name="pts" typeId="points" value="120"/>
       </costs>
       <categoryLinks>
         <categoryLink name="GNAWHORDE" hidden="false" id="4736-2831-0254-d715" targetId="84cc-ef1d-62cd-3fd9" primary="false"/>

--- a/Skaven.cat
+++ b/Skaven.cat
@@ -955,7 +955,7 @@ of the unit using the ‘Redeploy’ command to be the targets. Each target mus
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="a1f0-5188-a508-07b3" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="130"/>
+        <cost name="pts" typeId="points" value="120"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -1258,7 +1258,7 @@ of the unit using the ‘Redeploy’ command to be the targets. Each target mus
     </entryLink>
     <entryLink import="true" name="Thanquol on Boneripper" hidden="false" id="88c9-115c-3714-e884" type="selectionEntry" targetId="63ad-17ef-38e1-210a">
       <costs>
-        <cost name="pts" typeId="points" value="330"/>
+        <cost name="pts" typeId="points" value="310"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="d695-650c-ed9f-de62" type="selectionEntryGroup" targetId="462c-2914-b583-1688"/>
@@ -1309,7 +1309,7 @@ of the unit using the ‘Redeploy’ command to be the targets. Each target mus
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="d925-366a-3181-5a0a" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="280"/>
+        <cost name="pts" typeId="points" value="260"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -1404,7 +1404,7 @@ of the unit using the ‘Redeploy’ command to be the targets. Each target mus
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="50ca-4c41-1e5e-2801" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="280"/>
+        <cost name="pts" typeId="points" value="260"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -2155,7 +2155,7 @@ of the unit using the ‘Redeploy’ command to be the targets. Each target mus
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="240"/>
+        <cost name="pts" typeId="points" value="230"/>
       </costs>
     </entryLink>
     <entryLink import="true" name="Stormvermin" hidden="false" id="b88a-4c27-88ab-6a7d" type="selectionEntry" targetId="fed2-4975-ae44-473">
@@ -2315,7 +2315,7 @@ of the unit using the ‘Redeploy’ command to be the targets. Each target mus
         </modifierGroup>
       </modifierGroups>
       <costs>
-        <cost name="pts" typeId="points" value="130"/>
+        <cost name="pts" typeId="points" value="120"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Reinforced" hidden="false" id="8130-faa6-f5c0-9b26" type="selectionEntry" targetId="1b37-82b8-c062-eb82"/>
@@ -2530,7 +2530,7 @@ of the unit using the ‘Redeploy’ command to be the targets. Each target mus
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="230"/>
+        <cost name="pts" typeId="points" value="220"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Paths" hidden="false" id="76ac-935b-9187-4bef" type="selectionEntryGroup" targetId="9e59-94d3-7bfe-3534"/>
@@ -2736,7 +2736,7 @@ of the unit using the ‘Redeploy’ command to be the targets. Each target mus
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="120"/>
+        <cost name="pts" typeId="points" value="100"/>
       </costs>
       <constraints>
         <constraint type="max" value="-1" field="selections" scope="force" shared="true" id="a51b-4937-5f73-9038"/>
@@ -3003,7 +3003,7 @@ of the unit using the ‘Redeploy’ command to be the targets. Each target mus
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="160"/>
+        <cost name="pts" typeId="points" value="150"/>
       </costs>
     </entryLink>
     <entryLink import="true" name="Deathmaster Crixxit" hidden="false" id="534b-3d02-8d52-0b53" type="selectionEntry" targetId="d07c-20ca-d61f-40d7">

--- a/Slaves to Darkness - Legion of the First Prince.cat
+++ b/Slaves to Darkness - Legion of the First Prince.cat
@@ -1252,7 +1252,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="c245-aae4-3204-8092" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="250"/>
+        <cost name="pts" typeId="points" value="230"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -1318,7 +1318,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="180"/>
+        <cost name="pts" typeId="points" value="160"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="807e-5dd9-806c-9595" type="selectionEntryGroup" targetId="30aa-ebc9-444f-7be3"/>
@@ -1363,7 +1363,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="310"/>
+        <cost name="pts" typeId="points" value="300"/>
       </costs>
       <categoryLinks>
         <categoryLink name="LEGION OF THE FIRST PRINCE" hidden="false" id="4d13-02a1-dc84-c813" targetId="5942-b473-e229-37cd" primary="false"/>

--- a/Slaves to Darkness - The Swords of Chaos.cat
+++ b/Slaves to Darkness - The Swords of Chaos.cat
@@ -347,7 +347,7 @@
         <categoryLink name="SWORDS OF CHAOS" hidden="false" id="5519-2142-b7d3-4958" targetId="cfc-7031-d4b4-c4b6" primary="false"/>
       </categoryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="310"/>
+        <cost name="pts" typeId="points" value="300"/>
       </costs>
     </entryLink>
     <entryLink import="true" name="Nexus Chaotica" hidden="false" id="0857-2f7f-1082-4635" type="selectionEntry" targetId="22a9-a618-90cf-5bc7" defaultAmount="1"/>

--- a/Slaves to Darkness - Tribes of the Snow Peaks.cat
+++ b/Slaves to Darkness - Tribes of the Snow Peaks.cat
@@ -377,7 +377,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="34d3-a44a-0c22-2e21" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="100"/>
+        <cost name="pts" typeId="points" value="90"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -640,7 +640,7 @@
         <entryLink import="true" name="Renown" hidden="false" id="ca34-a536-ee4b-e232" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="140"/>
+        <cost name="pts" typeId="points" value="130"/>
       </costs>
     </entryLink>
     <entryLink import="true" name="Darkoath Marauders" hidden="false" id="cc7e-b2b9-9749-bb5d" type="selectionEntry" targetId="32a0-6285-a243-3a38">
@@ -732,7 +732,7 @@
         <entryLink import="true" name="Renown" hidden="false" id="1ac8-9bdd-420e-636e" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="130"/>
+        <cost name="pts" typeId="points" value="120"/>
       </costs>
     </entryLink>
     <entryLink import="true" name="The Gnarlspirit Pack" hidden="false" id="7f2c-f5d6-843e-250f" type="selectionEntry" targetId="8046-a145-5d79-aa66">

--- a/Slaves to Darkness.cat
+++ b/Slaves to Darkness.cat
@@ -1096,7 +1096,7 @@ During the battle, the target gains **Dark Apotheosis** points as follows:
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="a836-0fa0-5f12-683b" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="140"/>
+        <cost name="pts" typeId="points" value="130"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -1416,7 +1416,7 @@ During the battle, the target gains **Dark Apotheosis** points as follows:
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="96d4-c659-e074-1f7d" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="250"/>
+        <cost name="pts" typeId="points" value="230"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -1527,7 +1527,7 @@ During the battle, the target gains **Dark Apotheosis** points as follows:
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="8be9-a5ba-c426-ad28" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="100"/>
+        <cost name="pts" typeId="points" value="90"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -1631,7 +1631,7 @@ During the battle, the target gains **Dark Apotheosis** points as follows:
     </entryLink>
     <entryLink import="true" name="Eternus, Blade of the First Prince" hidden="false" id="2216-442a-cba-5a67" type="selectionEntry" targetId="de49-6e72-d443-42c0">
       <costs>
-        <cost name="pts" typeId="points" value="180"/>
+        <cost name="pts" typeId="points" value="160"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="a186-4ed0-bd28-1e86" type="selectionEntryGroup" targetId="20bb-e408-9d25-ffc6"/>
@@ -2040,7 +2040,7 @@ During the battle, the target gains **Dark Apotheosis** points as follows:
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="270"/>
+        <cost name="pts" typeId="points" value="250"/>
       </costs>
     </entryLink>
     <entryLink import="true" name="Chaos Furies" hidden="false" id="8056-31ae-f57d-1b5c" type="selectionEntry" targetId="cdb1-4aba-7c64-aa4d">
@@ -2097,7 +2097,7 @@ During the battle, the target gains **Dark Apotheosis** points as follows:
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="250"/>
+        <cost name="pts" typeId="points" value="240"/>
       </costs>
     </entryLink>
     <entryLink import="true" name="Chaos Legionnaires" hidden="false" id="4cc1-e1ce-25e8-65f" type="selectionEntry" targetId="82e2-c548-4d0f-3f1e">
@@ -2209,7 +2209,7 @@ During the battle, the target gains **Dark Apotheosis** points as follows:
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="140"/>
+        <cost name="pts" typeId="points" value="130"/>
       </costs>
     </entryLink>
     <entryLink import="true" name="Darkoath Marauders" hidden="false" id="c038-eb60-9450-b164" type="selectionEntry" targetId="32a0-6285-a243-3a38">
@@ -2494,7 +2494,7 @@ During the battle, the target gains **Dark Apotheosis** points as follows:
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="160"/>
+        <cost name="pts" typeId="points" value="150"/>
       </costs>
     </entryLink>
     <entryLink import="true" name="Darkoath Wilderfiend" hidden="false" id="bae3-1a88-42b-65d6" type="selectionEntry" targetId="43ac-9228-ce2c-b739">
@@ -2516,7 +2516,7 @@ During the battle, the target gains **Dark Apotheosis** points as follows:
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="130"/>
+        <cost name="pts" typeId="points" value="120"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="62ca-f580-1a7a-f258" type="selectionEntryGroup" targetId="20bb-e408-9d25-ffc6"/>
@@ -2946,7 +2946,7 @@ During the battle, the target gains **Dark Apotheosis** points as follows:
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="310"/>
+        <cost name="pts" typeId="points" value="300"/>
       </costs>
     </entryLink>
     <entryLink import="true" name="Nexus Chaotica" hidden="false" id="2bdb-6f98-a878-96b7" type="selectionEntry" targetId="22a9-a618-90cf-5bc7" defaultAmount="1"/>

--- a/Sons of Behemat - King Brodd's Stomp.cat
+++ b/Sons of Behemat - King Brodd's Stomp.cat
@@ -196,7 +196,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="f225-e8f9-5d07-2886" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="430"/>
+        <cost name="pts" typeId="points" value="410"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">

--- a/Sons of Behemat.cat
+++ b/Sons of Behemat.cat
@@ -286,7 +286,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="4893-84ed-f1a8-2ad4" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="430"/>
+        <cost name="pts" typeId="points" value="410"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">

--- a/Soulblight Gravelords - Barrow Legion.cat
+++ b/Soulblight Gravelords - Barrow Legion.cat
@@ -739,7 +739,7 @@ For the rest of the battle, each time an attack targets this unit, if the attack
         <entryLink import="true" name="Renown" hidden="false" id="5751-67f4-253b-0b22" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="200"/>
+        <cost name="pts" typeId="points" value="190"/>
       </costs>
       <categoryLinks>
         <categoryLink name="BARROW LEGION" hidden="false" id="4ac0-2d0d-6e6e-619a" targetId="07ad-5d9a-db7f-270d" primary="false"/>

--- a/Soulblight Gravelords - Knights of the Crimson Keep.cat
+++ b/Soulblight Gravelords - Knights of the Crimson Keep.cat
@@ -314,7 +314,7 @@ At the start of the next turn, remove all this unit&apos;s **martial prowess tok
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="56b8-6954-936b-e6aa" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="190"/>
+        <cost name="pts" typeId="points" value="180"/>
       </costs>
       <modifiers>
         <modifier type="add" value="abcb-73d0-2b6c-4f17" field="category">
@@ -374,7 +374,7 @@ At the start of the next turn, remove all this unit&apos;s **martial prowess tok
         <entryLink import="true" name="Renown" hidden="false" id="fd5f-79ad-3249-488a" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="190"/>
+        <cost name="pts" typeId="points" value="180"/>
       </costs>
       <categoryLinks>
         <categoryLink name="CRIMSON KEEP" hidden="false" id="3e78-1c05-240a-5d35" targetId="9e1f-bc4f-fd30-d770" primary="false"/>

--- a/Soulblight Gravelords - Scions of Nulahmia.cat
+++ b/Soulblight Gravelords - Scions of Nulahmia.cat
@@ -426,7 +426,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="d85b-4173-5872-9b96" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="190"/>
+        <cost name="pts" typeId="points" value="180"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">

--- a/Soulblight Gravelords.cat
+++ b/Soulblight Gravelords.cat
@@ -26,12 +26,12 @@
         <entryLink import="true" name="Renown" hidden="false" id="a11c-79f0-cf98-958c" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="200"/>
+        <cost name="pts" typeId="points" value="190"/>
       </costs>
     </entryLink>
     <entryLink import="true" name="Belladamma Volga, First of the Vyrkos" hidden="false" id="5e27-2bac-efb3-646f" type="selectionEntry" targetId="2438-c0b5-e74f-8ad6">
       <costs>
-        <cost name="pts" typeId="points" value="220"/>
+        <cost name="pts" typeId="points" value="200"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="5be5-f07c-637b-3948" type="selectionEntryGroup" targetId="c63e-2ce9-4f0c-92f8"/>
@@ -445,7 +445,7 @@
     </entryLink>
     <entryLink import="true" name="Lauka Vai, Mother of Nightmares" hidden="false" id="ba08-b71c-f43f-a49" type="selectionEntry" targetId="33c3-992f-3564-9407">
       <costs>
-        <cost name="pts" typeId="points" value="220"/>
+        <cost name="pts" typeId="points" value="200"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="6469-bb5c-7971-38cc" type="selectionEntryGroup" targetId="c63e-2ce9-4f0c-92f8"/>
@@ -487,7 +487,7 @@
     </entryLink>
     <entryLink import="true" name="Mannfred von Carstein, Mortarch of Night" hidden="false" id="de97-1acc-4e95-389c" type="selectionEntry" targetId="d749-d136-18ba-1a2">
       <costs>
-        <cost name="pts" typeId="points" value="430"/>
+        <cost name="pts" typeId="points" value="410"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="9687-e92e-cf97-62c6" type="selectionEntryGroup" targetId="c63e-2ce9-4f0c-92f8"/>
@@ -576,7 +576,7 @@
     </entryLink>
     <entryLink import="true" name="Nagash, Supreme Lord of the Undead" hidden="false" id="e128-d724-f729-fdb1" type="selectionEntry" targetId="1823-b6fb-a27f-a7ee">
       <costs>
-        <cost name="pts" typeId="points" value="780"/>
+        <cost name="pts" typeId="points" value="750"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="9b3b-0ea9-737b-6c8d" type="selectionEntryGroup" targetId="c63e-2ce9-4f0c-92f8"/>
@@ -627,7 +627,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="b4f8-6343-f3f3-acd0" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="120"/>
+        <cost name="pts" typeId="points" value="110"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -1060,7 +1060,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="6096-2d3c-854c-263d" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="220"/>
+        <cost name="pts" typeId="points" value="200"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -1403,7 +1403,7 @@
         <entryLink import="true" name="Renown" hidden="false" id="54e5-2655-fb55-6c28" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="130"/>
+        <cost name="pts" typeId="points" value="120"/>
       </costs>
     </entryLink>
     <entryLink import="true" name="Dire Wolves" hidden="false" id="905d-66f0-1307-f557" type="selectionEntry" targetId="663e-ba88-e7a3-e042">
@@ -1757,7 +1757,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="b589-43f8-6e10-6909" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="190"/>
+        <cost name="pts" typeId="points" value="180"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -1874,7 +1874,7 @@
         <entryLink import="true" name="Renown" hidden="false" id="37fd-c19b-8e2d-54c4" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="190"/>
+        <cost name="pts" typeId="points" value="180"/>
       </costs>
     </entryLink>
     <entryLink import="true" name="Cursed Sepulchre" hidden="false" id="4800-8046-8238-08c9" type="selectionEntry" targetId="4ab6-d0f5-d7b0-1b38" defaultAmount="1"/>
@@ -1917,7 +1917,7 @@
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="0931-0ebd-a9ac-2479" type="selectionEntryGroup" targetId="c63e-2ce9-4f0c-92f8"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="290"/>
+        <cost name="pts" typeId="points" value="270"/>
       </costs>
       <modifiers>
         <modifier type="set" value="0" field="00b3-b74e-3858-8433">

--- a/Stormcast Eternals - Astral Templars.cat
+++ b/Stormcast Eternals - Astral Templars.cat
@@ -858,7 +858,7 @@ At the end of the turn, any unspent **charmed fate points** are lost.</character
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="210"/>
+        <cost name="pts" typeId="points" value="200"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Reinforced" hidden="false" id="d6c8-bc32-865a-16aa" type="selectionEntry" targetId="1b37-82b8-c062-eb82"/>
@@ -1114,7 +1114,7 @@ At the end of the turn, any unspent **charmed fate points** are lost.</character
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="200"/>
+        <cost name="pts" typeId="points" value="190"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Reinforced" hidden="false" id="835b-11f5-b886-a55a" type="selectionEntry" targetId="1b37-82b8-c062-eb82"/>
@@ -3170,7 +3170,7 @@ At the end of the turn, any unspent **charmed fate points** are lost.</character
         <categoryLink name="ASTRAL TEMPLARS" hidden="false" id="ea01-a7c9-8c17-ddc1" targetId="7798-5a27-372a-c0e8" primary="false"/>
       </categoryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="160"/>
+        <cost name="pts" typeId="points" value="150"/>
       </costs>
       <modifiers>
         <modifier type="decrement" value="1" field="1e6d-6f7f-3195-251a">
@@ -3246,7 +3246,7 @@ At the end of the turn, any unspent **charmed fate points** are lost.</character
         <categoryLink name="ASTRAL TEMPLARS" hidden="false" id="c128-4105-8f91-9249" targetId="7798-5a27-372a-c0e8" primary="false"/>
       </categoryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="480"/>
+        <cost name="pts" typeId="points" value="490"/>
       </costs>
       <modifiers>
         <modifier type="decrement" value="1" field="8196-3b0c-cb79-b39c">
@@ -3814,7 +3814,7 @@ At the end of the turn, any unspent **charmed fate points** are lost.</character
         <categoryLink name="ASTRAL TEMPLARS" hidden="false" id="29a0-be5e-b09f-ac95" targetId="7798-5a27-372a-c0e8" primary="false"/>
       </categoryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="140"/>
+        <cost name="pts" typeId="points" value="120"/>
       </costs>
       <modifiers>
         <modifier type="decrement" value="1" field="5629-23e5-30a5-7ed4">
@@ -4741,7 +4741,7 @@ At the end of the turn, any unspent **charmed fate points** are lost.</character
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="250"/>
+        <cost name="pts" typeId="points" value="260"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Reinforced" hidden="false" id="b87c-852b-2dc4-b6c5" type="selectionEntry" targetId="1b37-82b8-c062-eb82"/>
@@ -5150,7 +5150,7 @@ At the end of the turn, any unspent **charmed fate points** are lost.</character
         <categoryLink name="ASTRAL TEMPLARS" hidden="false" id="186b-d65d-5002-d407" targetId="7798-5a27-372a-c0e8" primary="false"/>
       </categoryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="180"/>
+        <cost name="pts" typeId="points" value="160"/>
       </costs>
       <modifiers>
         <modifier type="decrement" value="1" field="40c5-d5bb-c895-6ce1">
@@ -5272,7 +5272,7 @@ At the end of the turn, any unspent **charmed fate points** are lost.</character
         <constraint type="max" value="0" field="selections" scope="roster" shared="true" id="d1ab-ca0b-56d7-81d9" includeChildSelections="true" includeChildForces="true"/>
       </constraints>
       <costs>
-        <cost name="pts" typeId="points" value="120"/>
+        <cost name="pts" typeId="points" value="110"/>
       </costs>
       <categoryLinks>
         <categoryLink name="ASTRAL TEMPLARS" hidden="false" id="a2aa-07f5-127e-1091" targetId="7798-5a27-372a-c0e8" primary="false"/>

--- a/Stormcast Eternals - Draconith Skywing.cat
+++ b/Stormcast Eternals - Draconith Skywing.cat
@@ -268,7 +268,7 @@
         <categoryLink name="DRACONITH SKYWING" hidden="false" id="c375-641a-b4a5-125b" targetId="7159-6f7a-df4f-7e88" primary="false"/>
       </categoryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="360"/>
+        <cost name="pts" typeId="points" value="340"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="fdf7-2abe-bbda-94a6" type="selectionEntryGroup" targetId="b95c-4cad-8a89-8ae4"/>
@@ -312,7 +312,7 @@
         <categoryLink name="DRACONITH SKYWING" hidden="false" id="cb30-3ef4-1c1d-58a3" targetId="7159-6f7a-df4f-7e88" primary="false"/>
       </categoryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="500"/>
+        <cost name="pts" typeId="points" value="480"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="b1dd-1f44-db3c-4c69" type="selectionEntryGroup" targetId="b95c-4cad-8a89-8ae4"/>
@@ -356,7 +356,7 @@
         <categoryLink name="DRACONITH SKYWING" hidden="false" id="e83a-fed8-aa36-a248" targetId="7159-6f7a-df4f-7e88" primary="false"/>
       </categoryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="440"/>
+        <cost name="pts" typeId="points" value="420"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="8521-2959-50bf-30fb" type="selectionEntryGroup" targetId="b95c-4cad-8a89-8ae4"/>

--- a/Stormcast Eternals - Heroes of the First-Forged.cat
+++ b/Stormcast Eternals - Heroes of the First-Forged.cat
@@ -437,7 +437,7 @@
         <categoryLink name="FIRST-FORGED" hidden="false" id="4ec4-85d5-d6ad-f1db" targetId="5683-b46f-65e6-4b48" primary="false"/>
       </categoryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="250"/>
+        <cost name="pts" typeId="points" value="240"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="9b9a-ae83-e6c8-d434" type="selectionEntryGroup" targetId="139c-16a1-6f0d-0dd1"/>
@@ -667,7 +667,7 @@
         <categoryLink name="FIRST-FORGED" hidden="false" id="8664-b799-0ab4-2853" targetId="5683-b46f-65e6-4b48" primary="false"/>
       </categoryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="440"/>
+        <cost name="pts" typeId="points" value="420"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="930e-26ad-6867-a106" type="selectionEntryGroup" targetId="139c-16a1-6f0d-0dd1"/>
@@ -1175,7 +1175,7 @@
         <categoryLink name="FIRST-FORGED" hidden="false" id="5168-be85-2757-bf88" targetId="5683-b46f-65e6-4b48" primary="false"/>
       </categoryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="500"/>
+        <cost name="pts" typeId="points" value="480"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="aca6-5b2b-ffe5-cdb0" type="selectionEntryGroup" targetId="139c-16a1-6f0d-0dd1"/>

--- a/Stormcast Eternals - Ruination Brotherhood.cat
+++ b/Stormcast Eternals - Ruination Brotherhood.cat
@@ -358,7 +358,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="cebf-6a3f-2e0c-15ce" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="180"/>
+        <cost name="pts" typeId="points" value="160"/>
       </costs>
       <categoryLinks>
         <categoryLink name="RUINATION BROTHERHOOD" hidden="false" id="48e3-6531-7cb7-56e7" targetId="1e61-44e3-e572-a097" primary="false"/>
@@ -413,7 +413,7 @@
         <categoryLink name="RUINATION BROTHERHOOD" hidden="false" id="d6bf-4f0b-e2a7-cba3" targetId="1e61-44e3-e572-a097" primary="false"/>
       </categoryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="140"/>
+        <cost name="pts" typeId="points" value="120"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -1972,7 +1972,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="7cf6-b33c-2553-9557" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="120"/>
+        <cost name="pts" typeId="points" value="110"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -2103,7 +2103,7 @@
         <categoryLink name="RUINATION BROTHERHOOD" hidden="false" id="732e-a353-f886-ae77" targetId="1e61-44e3-e572-a097" primary="false"/>
       </categoryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="360"/>
+        <cost name="pts" typeId="points" value="340"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="8deb-0246-ab96-1407" type="selectionEntryGroup" targetId="17e9-ff38-847e-b2d2"/>

--- a/Stormcast Eternals.cat
+++ b/Stormcast Eternals.cat
@@ -210,7 +210,7 @@
     </entryLink>
     <entryLink import="true" name="Celestant-Prime, Hammer of Sigmar" hidden="false" id="0014-ab3b-f147-1395" type="selectionEntry" targetId="ed87-8b4f-7c45-42a5">
       <costs>
-        <cost name="pts" typeId="points" value="250"/>
+        <cost name="pts" typeId="points" value="240"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="5967-cfbb-c272-42ff" type="selectionEntryGroup" targetId="148c-ca2b-6414-7eca"/>
@@ -415,7 +415,7 @@
     </entryLink>
     <entryLink import="true" name="Ionus Cryptborn, Warden of Lost Souls" hidden="false" id="3aff-9913-2e5b-b3d2" type="selectionEntry" targetId="f96a-5448-b667-1ed5">
       <costs>
-        <cost name="pts" typeId="points" value="360"/>
+        <cost name="pts" typeId="points" value="340"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="358c-363a-d733-90fd" type="selectionEntryGroup" targetId="148c-ca2b-6414-7eca"/>
@@ -457,7 +457,7 @@
     </entryLink>
     <entryLink import="true" name="Karazai the Scarred" hidden="false" id="5bfb-040c-0265-ed6d" type="selectionEntry" targetId="c6c-d912-2899-5073">
       <costs>
-        <cost name="pts" typeId="points" value="440"/>
+        <cost name="pts" typeId="points" value="420"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="56a8-80d5-c92d-a8ee" type="selectionEntryGroup" targetId="148c-ca2b-6414-7eca"/>
@@ -1054,7 +1054,7 @@
     </entryLink>
     <entryLink import="true" name="Krondys, Son of Dracothion" hidden="false" id="793b-0fff-26f8-7337" type="selectionEntry" targetId="9c0f-13c7-e2c1-55a">
       <costs>
-        <cost name="pts" typeId="points" value="500"/>
+        <cost name="pts" typeId="points" value="480"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="1ff9-d8cc-6e5d-89ac" type="selectionEntryGroup" targetId="148c-ca2b-6414-7eca"/>
@@ -1437,7 +1437,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="a00c-19f9-d274-a0b6" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="160"/>
+        <cost name="pts" typeId="points" value="150"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -1485,7 +1485,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="b981-78b5-24f2-cef8" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="480"/>
+        <cost name="pts" typeId="points" value="490"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -1849,7 +1849,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="d46e-85da-3d09-2122" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="140"/>
+        <cost name="pts" typeId="points" value="120"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -2006,7 +2006,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="210"/>
+        <cost name="pts" typeId="points" value="200"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Reinforced" hidden="false" id="b093-d700-43fb-3509" type="selectionEntry" targetId="1b37-82b8-c062-eb82"/>
@@ -2390,7 +2390,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="200"/>
+        <cost name="pts" typeId="points" value="190"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Reinforced" hidden="false" id="a9dd-3acd-5e9f-6da4" type="selectionEntry" targetId="1b37-82b8-c062-eb82"/>
@@ -3497,7 +3497,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="250"/>
+        <cost name="pts" typeId="points" value="260"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Reinforced" hidden="false" id="f1cf-9be3-e4f4-c970" type="selectionEntry" targetId="1b37-82b8-c062-eb82"/>
@@ -4017,7 +4017,7 @@
         <entryLink import="true" name="Renown" hidden="false" id="dff3-c165-5d67-aac2" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="120"/>
+        <cost name="pts" typeId="points" value="110"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -4079,7 +4079,7 @@
         <entryLink import="true" name="Renown" hidden="false" id="ae78-c25d-4710-b752" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="180"/>
+        <cost name="pts" typeId="points" value="160"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">

--- a/Sylvaneth - Lords of the Clan.cat
+++ b/Sylvaneth - Lords of the Clan.cat
@@ -442,7 +442,7 @@ Then, remove that friendly **Awakened Wyldwood** from the battlefield.</characte
     </entryLink>
     <entryLink import="true" name="Treelord" hidden="false" id="5cb1-e211-4ee5-46e5" type="selectionEntry" targetId="a896-d266-a881-f920">
       <costs>
-        <cost name="pts" typeId="points" value="260"/>
+        <cost name="pts" typeId="points" value="240"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Renown" hidden="false" id="2447-cd1b-8d18-23db" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
@@ -546,7 +546,7 @@ Then, remove that friendly **Awakened Wyldwood** from the battlefield.</characte
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="200"/>
+        <cost name="pts" typeId="points" value="190"/>
       </costs>
       <categoryLinks>
         <categoryLink name="LORDS OF THE CLAN" hidden="false" id="e7ec-955d-3348-ded8" targetId="cef8-80ee-19a7-ad9b" primary="false"/>
@@ -577,7 +577,7 @@ Then, remove that friendly **Awakened Wyldwood** from the battlefield.</characte
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="200"/>
+        <cost name="pts" typeId="points" value="210"/>
       </costs>
       <categoryLinks>
         <categoryLink name="LORDS OF THE CLAN" hidden="false" id="04e2-1185-0dd3-caad" targetId="cef8-80ee-19a7-ad9b" primary="false"/>
@@ -608,7 +608,7 @@ Then, remove that friendly **Awakened Wyldwood** from the battlefield.</characte
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="190"/>
+        <cost name="pts" typeId="points" value="200"/>
       </costs>
       <categoryLinks>
         <categoryLink name="LORDS OF THE CLAN" hidden="false" id="e96f-3132-4073-3f83" targetId="cef8-80ee-19a7-ad9b" primary="false"/>

--- a/Sylvaneth - Soulpod Guardians.cat
+++ b/Sylvaneth - Soulpod Guardians.cat
@@ -335,7 +335,7 @@ Once you have done so, for the rest of the battle, the 3 tree miniatures join to
   <entryLinks>
     <entryLink import="true" name="Arch-Revenant" hidden="false" id="f12a-c1ab-feda-3ff3" type="selectionEntry" targetId="c21d-479c-e8ef-b406">
       <costs>
-        <cost name="pts" typeId="points" value="130"/>
+        <cost name="pts" typeId="points" value="110"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Artefacts of Power" hidden="false" id="7e72-a4ac-8a58-8b56" type="selectionEntryGroup" targetId="ead6-5ba5-5e71-c683"/>
@@ -450,7 +450,7 @@ Once you have done so, for the rest of the battle, the 3 tree miniatures join to
     </entryLink>
     <entryLink import="true" name="Warsong Revenant" hidden="false" id="fed5-ad1a-be11-9e37" type="selectionEntry" targetId="438e-768a-7545-d329">
       <costs>
-        <cost name="pts" typeId="points" value="150"/>
+        <cost name="pts" typeId="points" value="170"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Warlord" hidden="false" id="ff14-40bc-0b65-17d2" type="selectionEntry" targetId="bb28-fa4a-bf5f-f793"/>
@@ -559,7 +559,7 @@ Once you have done so, for the rest of the battle, the 3 tree miniatures join to
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="80"/>
+        <cost name="pts" typeId="points" value="100"/>
       </costs>
       <categoryLinks>
         <categoryLink name="SOULPOD GUARDIANS" hidden="false" id="4a51-f405-6db9-5279" targetId="8f96-39c7-3b67-9686" primary="false"/>
@@ -590,7 +590,7 @@ Once you have done so, for the rest of the battle, the 3 tree miniatures join to
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="220"/>
+        <cost name="pts" typeId="points" value="230"/>
       </costs>
       <categoryLinks>
         <categoryLink name="SOULPOD GUARDIANS" hidden="false" id="0b07-c0e7-dfc2-ddbe" targetId="8f96-39c7-3b67-9686" primary="false"/>
@@ -615,7 +615,7 @@ Once you have done so, for the rest of the battle, the 3 tree miniatures join to
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="120"/>
+        <cost name="pts" typeId="points" value="140"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Renown" hidden="false" id="e192-5045-2011-be14" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>

--- a/Sylvaneth - The Evergreen Hunt.cat
+++ b/Sylvaneth - The Evergreen Hunt.cat
@@ -30,7 +30,7 @@
         <categoryLink name="EVERGREEN HUNT" hidden="false" id="1a1b-5895-1527-225b" targetId="637b-b903-6980-34cf" primary="false"/>
       </categoryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="350"/>
+        <cost name="pts" typeId="points" value="290"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="7418-72fa-977c-ab94" type="selectionEntryGroup" targetId="1c26-b91a-37b0-0d54"/>
@@ -180,7 +180,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="190"/>
+        <cost name="pts" typeId="points" value="230"/>
       </costs>
       <categoryLinks>
         <categoryLink name="EVERGREEN HUNT" hidden="false" id="9b89-262a-a71-974b" targetId="637b-b903-6980-34cf" primary="false"/>
@@ -211,7 +211,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="200"/>
+        <cost name="pts" typeId="points" value="180"/>
       </costs>
       <categoryLinks>
         <categoryLink name="EVERGREEN HUNT" hidden="false" id="c3bd-5b4b-fc96-a9c3" targetId="637b-b903-6980-34cf" primary="false"/>
@@ -242,7 +242,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="190"/>
+        <cost name="pts" typeId="points" value="200"/>
       </costs>
       <categoryLinks>
         <categoryLink name="EVERGREEN HUNT" hidden="false" id="da02-4f52-6221-d67a" targetId="637b-b903-6980-34cf" primary="false"/>
@@ -304,7 +304,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="200"/>
+        <cost name="pts" typeId="points" value="190"/>
       </costs>
       <categoryLinks>
         <categoryLink name="EVERGREEN HUNT" hidden="false" id="5c1a-4d5a-ac3d-a20f" targetId="637b-b903-6980-34cf" primary="false"/>

--- a/Sylvaneth.cat
+++ b/Sylvaneth.cat
@@ -646,7 +646,7 @@ If this unit is not a ^^**Wizard^^**, it can use the &apos;Unbind&apos; ability 
   <entryLinks>
     <entryLink import="true" name="Arch-Revenant" hidden="false" id="1baa-e7d7-61a1-95f3" type="selectionEntry" targetId="c21d-479c-e8ef-b406">
       <costs>
-        <cost name="pts" typeId="points" value="130"/>
+        <cost name="pts" typeId="points" value="110"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Artefacts of Power" hidden="false" id="7b32-a5c2-5631-b1bf" type="selectionEntryGroup" targetId="4994-cf8a-db5d-b87d"/>
@@ -930,7 +930,7 @@ If this unit is not a ^^**Wizard^^**, it can use the &apos;Unbind&apos; ability 
     </entryLink>
     <entryLink import="true" name="Treelord" hidden="false" id="a53e-d251-9986-28ac" type="selectionEntry" targetId="a896-d266-a881-f920">
       <costs>
-        <cost name="pts" typeId="points" value="260"/>
+        <cost name="pts" typeId="points" value="240"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="b577-6c04-f29c-93bf" type="selectionEntryGroup" targetId="4b15-3fca-7be1-1fbb"/>
@@ -1000,7 +1000,7 @@ If this unit is not a ^^**Wizard^^**, it can use the &apos;Unbind&apos; ability 
     </entryLink>
     <entryLink import="true" name="Warsong Revenant" hidden="false" id="3028-82cb-fce4-4cf9" type="selectionEntry" targetId="438e-768a-7545-d329">
       <costs>
-        <cost name="pts" typeId="points" value="150"/>
+        <cost name="pts" typeId="points" value="170"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Artefacts of Power" hidden="false" id="4aa6-a8cb-8f87-74c9" type="selectionEntryGroup" targetId="4994-cf8a-db5d-b87d"/>
@@ -1075,7 +1075,7 @@ If this unit is not a ^^**Wizard^^**, it can use the &apos;Unbind&apos; ability 
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="90"/>
+        <cost name="pts" typeId="points" value="100"/>
       </costs>
     </entryLink>
     <entryLink import="true" name="Gossamid Archers" hidden="false" id="5d21-41ae-45c5-7c8f" type="selectionEntry" targetId="7395-623b-7652-b8c6">
@@ -1131,7 +1131,7 @@ If this unit is not a ^^**Wizard^^**, it can use the &apos;Unbind&apos; ability 
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="200"/>
+        <cost name="pts" typeId="points" value="190"/>
       </costs>
     </entryLink>
     <entryLink import="true" name="Kurnoth Hunters with Kurnoth Greatswords" hidden="false" id="d3f7-d5b1-579c-94dc" type="selectionEntry" targetId="7403-c67e-a2d-a1af">
@@ -1159,7 +1159,7 @@ If this unit is not a ^^**Wizard^^**, it can use the &apos;Unbind&apos; ability 
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="200"/>
+        <cost name="pts" typeId="points" value="210"/>
       </costs>
     </entryLink>
     <entryLink import="true" name="Kurnoth Hunters with Kurnoth Scythes" hidden="false" id="88ec-28ce-99da-cbc4" type="selectionEntry" targetId="577a-d471-c08e-6ff4">
@@ -1187,7 +1187,7 @@ If this unit is not a ^^**Wizard^^**, it can use the &apos;Unbind&apos; ability 
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="190"/>
+        <cost name="pts" typeId="points" value="200"/>
       </costs>
     </entryLink>
     <entryLink import="true" name="Revenant Seekers" hidden="false" id="965-51e3-4beb-db4e" type="selectionEntry" targetId="766a-54f1-440b-b878">
@@ -1243,7 +1243,7 @@ If this unit is not a ^^**Wizard^^**, it can use the &apos;Unbind&apos; ability 
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="80"/>
+        <cost name="pts" typeId="points" value="100"/>
       </costs>
     </entryLink>
     <entryLink import="true" name="Spiterider Lancers" hidden="false" id="95bf-7814-c6f0-e91a" type="selectionEntry" targetId="8d4f-cdc2-f74f-daac">
@@ -1271,7 +1271,7 @@ If this unit is not a ^^**Wizard^^**, it can use the &apos;Unbind&apos; ability 
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="220"/>
+        <cost name="pts" typeId="points" value="230"/>
       </costs>
     </entryLink>
     <entryLink import="true" name="The Twistweald" hidden="false" id="686d-2413-5026-1343" type="selectionEntry" targetId="64d1-d8c8-5bff-506c">
@@ -1293,7 +1293,7 @@ If this unit is not a ^^**Wizard^^**, it can use the &apos;Unbind&apos; ability 
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="120"/>
+        <cost name="pts" typeId="points" value="140"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="3775-8947-129a-b784" type="selectionEntryGroup" targetId="4b15-3fca-7be1-1fbb"/>
@@ -1478,7 +1478,7 @@ If this unit is not a ^^**Wizard^^**, it can use the &apos;Unbind&apos; ability 
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="600"/>
+        <cost name="pts" typeId="points" value="620"/>
       </costs>
       <modifierGroups>
         <modifierGroup type="and">

--- a/The Duardin Ascendant [LEGENDS].cat
+++ b/The Duardin Ascendant [LEGENDS].cat
@@ -411,7 +411,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="3e20-508b-f673-56ab" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="110"/>
+        <cost name="pts" typeId="points" value="100"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -867,7 +867,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="8456-b2da-ef26-3961" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="90"/>
+        <cost name="pts" typeId="points" value="80"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -971,7 +971,7 @@
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="c2fc-eb48-9804-f095" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="150"/>
+        <cost name="pts" typeId="points" value="140"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -1105,7 +1105,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="110"/>
+        <cost name="pts" typeId="points" value="100"/>
       </costs>
       <categoryLinks>
         <categoryLink name="DUARDIN ASCENDANT" hidden="false" id="ea53-4492-abad-1467" targetId="c57c-7a43-906e-4f33" primary="false"/>
@@ -1138,7 +1138,7 @@
         <constraint type="max" value="-1" field="selections" scope="force" shared="true" id="4c1d-c9a1-080a-11a3" includeChildSelections="true"/>
       </constraints>
       <costs>
-        <cost name="pts" typeId="points" value="150"/>
+        <cost name="pts" typeId="points" value="140"/>
       </costs>
       <categoryLinks>
         <categoryLink name="DUARDIN ASCENDANT" hidden="false" id="5372-064b-31c9-a7b5" targetId="c57c-7a43-906e-4f33" primary="false"/>
@@ -1295,7 +1295,7 @@
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="160"/>
+        <cost name="pts" typeId="points" value="150"/>
       </costs>
       <categoryLinks>
         <categoryLink name="DUARDIN ASCENDANT" hidden="false" id="d4b7-d5bb-8469-d6b0" targetId="c57c-7a43-906e-4f33" primary="false"/>
@@ -1377,7 +1377,7 @@
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="de4b-080b-e90c-9bb9" type="selectionEntryGroup" targetId="8b61-58c5-cef8-e89a"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="110"/>
+        <cost name="pts" typeId="points" value="100"/>
       </costs>
       <categoryLinks>
         <categoryLink name="DUARDIN ASCENDANT" hidden="false" id="4fda-b408-3192-7602" targetId="c57c-7a43-906e-4f33" primary="false"/>
@@ -1445,7 +1445,7 @@
         <categoryLink name="Restrict General" hidden="false" id="7bdd-6809-26e2-2ea5" targetId="abcb-73d0-2b6c-4f17" primary="false"/>
       </categoryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="330"/>
+        <cost name="pts" typeId="points" value="320"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -1508,7 +1508,7 @@
         <categoryLink name="Restrict General" hidden="false" id="6c3d-98d8-c66a-f894" targetId="abcb-73d0-2b6c-4f17" primary="false"/>
       </categoryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="180"/>
+        <cost name="pts" typeId="points" value="160"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -1555,7 +1555,7 @@
         <categoryLink name="Restrict General" hidden="false" id="538e-ecbd-fc8e-0f9a" targetId="abcb-73d0-2b6c-4f17" primary="false"/>
       </categoryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="100"/>
+        <cost name="pts" typeId="points" value="90"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -1601,7 +1601,7 @@
         <categoryLink name="Restrict General" hidden="false" id="dd67-f7c1-0a51-e937" targetId="abcb-73d0-2b6c-4f17" primary="false"/>
       </categoryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="300"/>
+        <cost name="pts" typeId="points" value="280"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -1709,7 +1709,7 @@
         <categoryLink name="Restrict General" hidden="false" id="da76-fb20-bbc1-a581" targetId="abcb-73d0-2b6c-4f17" primary="false"/>
       </categoryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="250"/>
+        <cost name="pts" typeId="points" value="240"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -2025,7 +2025,7 @@
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="eba2-c0c8-e3e5-e2b9" type="selectionEntryGroup" targetId="8b61-58c5-cef8-e89a"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="110"/>
+        <cost name="pts" typeId="points" value="100"/>
       </costs>
       <categoryLinks>
         <categoryLink name="DUARDIN ASCENDANT" hidden="false" id="962c-6548-5e54-6ac4" targetId="c57c-7a43-906e-4f33" primary="false"/>
@@ -2791,7 +2791,7 @@
         </modifierGroup>
       </modifierGroups>
       <costs>
-        <cost name="pts" typeId="points" value="120"/>
+        <cost name="pts" typeId="points" value="110"/>
       </costs>
     </entryLink>
     <entryLink import="true" name="Vongrim Harpoon Crew" hidden="false" id="5459-433a-71cf-5506" type="selectionEntry" targetId="b38b-f2bc-47a8-658e">


### PR DESCRIPTION
Sync all unit points to the latest battleprofile.json across the repo: 421 cost updates spanning 191 distinct units (the remainder are the same prices propagated into subfaction/Army of Renown files and the grand-alliance legends packs to keep every roster source consistent).

- 182 main battletome + 184 subfaction/AoR + 55 cross-pack (Legions of Nagash, Big Waaagh!, Duardin Ascendant) lines.
- Matched on effective name so sub-size variants ((1 model)/(2 models)), legends namesakes, and slight misnames (e.g. Kurnoth Greatbows/Scythes -> Greatbows/Greatscythes) resolve to the correct profile.
- Left untouched where the source has no data: Regiments of Renown (totals only, no per-member breakdown), Scourge of Aqshy units with no catalogue counterpart, named legends characters absent from the BP, and Path to Glory. Manifestations already matched.