### PR TITLE
SoA (Chaos): Slaves to Darkness enhancements

### DIFF
--- a/Blades of Khorne.cat
+++ b/Blades of Khorne.cat
@@ -434,6 +434,93 @@ This unit can be affected by this ability multiple times and the effects are cum
         <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6a56-27c2-e72a-8045"/>
       </constraints>
     </selectionEntryGroup>
+    <selectionEntryGroup name="Brazen Mutations" id="6072-5cbd-ebb3-a76a" hidden="false">
+      <selectionEntryGroups>
+        <selectionEntryGroup name="Brazen Mutations" id="e85c-357b-e216-0eeb" hidden="true" publicationId="9e18-bb03-7b60-d4ff">
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Brass Flesh" hidden="false" id="c82f-3041-0063-90cd">
+              <profiles>
+                <profile name="Brass Flesh" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="09ea-8035-8a85-f939">
+                  <characteristics>
+                    <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
+                    <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">Unmodified save rolls of 5+ for this unit cannot fail.</characteristic>
+                  </characteristics>
+                  <attributes>
+                    <attribute typeId="50fe-4f29-6bc3-dcc6" name="Color">Green</attribute>
+                    <attribute typeId="bf11-4e10-3ab1-06f4" name="Type">Defensive</attribute>
+                    <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
+                  </attributes>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="6ff1-24af-d783-1bd6" includeChildSelections="true"/>
+              </constraints>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Blade-Limbs" hidden="false" id="c1a3-84ec-a924-fc39">
+              <profiles>
+                <profile name="Blade-Limbs" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="0af5-0e0a-bee6-6995">
+                  <characteristics>
+                    <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
+                    <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">Each time this unit is picked to use the ‘Eruption of Fury’ ability, for each unmodified hit roll of 6 for the attacks made as part of that ability, inflict an additional 3 mortal damage on each enemy unit in combat with this unit instead of D3.</characteristic>
+                  </characteristics>
+                  <attributes>
+                    <attribute typeId="50fe-4f29-6bc3-dcc6" name="Color">Purple</attribute>
+                    <attribute typeId="bf11-4e10-3ab1-06f4" name="Type">Offensive</attribute>
+                    <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
+                  </attributes>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="8858-a007-fe1d-46dc" includeChildSelections="true"/>
+              </constraints>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Scorpion Tails" hidden="false" id="4ee7-efee-cde9-bf31">
+              <profiles>
+                <profile name="Scorpion Tails" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="dc9d-3a49-8734-5f56">
+                  <characteristics>
+                    <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Any Combat Phase</characteristic>
+                    <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick an enemy unit in combat with this unit to be the target.</characteristic>
+                    <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">• Inflict D3 mortal damage on the target.
+• If the target unit’s starting size was 1, subtract 1 from wound rolls for its combat attacks for the rest of the turn.</characteristic>
+                    <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+                    <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+                  </characteristics>
+                  <attributes>
+                    <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Red</attribute>
+                    <attribute typeId="6d16-c86b-2698-85a4" name="Type">Special</attribute>
+                    <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+                  </attributes>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="9c85-9a95-5f54-f067" includeChildSelections="true"/>
+              </constraints>
+            </selectionEntry>
+          </selectionEntries>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="78a1-f6c2-71b8-270a" shared="true"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="0151-9c5b-2f1e-32d4" shared="true" childName="✦ General&apos;s Handbook 2026-27"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <rules>
+            <rule name="Enhancement Restrictions" id="a63d-a93b-204b-47e7" hidden="true">
+              <description>Brazen Mutations are unique enhancements that can be given to non-**^^Hero^^** **^^Blades of Khorne^^** **^^Infantry^^** or **^^Cavalry^^** units. A unit can only have 1 Brazen Mutation.</description>
+            </rule>
+          </rules>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <constraints>
+        <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="867c-9097-7bbc-0f4e" includeChildSelections="true"/>
+        <constraint type="max" value="1" field="selections" scope="root-entry" shared="true" id="3c4b-0952-9fbc-78bf"/>
+      </constraints>
+    </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <sharedSelectionEntries>
     <selectionEntry type="upgrade" import="true" name="Battle Traits: Blades of Khorne" hidden="false" id="1c5d-907-fd0c-c8a4">
@@ -1641,6 +1728,7 @@ This unit can be affected by this ability multiple times and the effects are cum
         <entryLink import="true" name="Paths" hidden="false" id="a60c-0b7d-b91d-d046" type="selectionEntryGroup" targetId="8e28-9445-463a-5883"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="cd72-9525-4ef5-1ef7" type="selectionEntryGroup" targetId="6dcf-7de6-0f0f-bfc6"/>
         <entryLink import="true" name="Renown" hidden="false" id="41f2-953b-7b05-37d8" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Brazen Mutations" hidden="false" id="b9a8-7627-18f4-75e2" type="selectionEntryGroup" targetId="6072-5cbd-ebb3-a76a"/>
       </entryLinks>
       <modifiers>
         <modifier type="multiply" value="2" field="points">
@@ -1669,6 +1757,7 @@ This unit can be affected by this ability multiple times and the effects are cum
         <entryLink import="true" name="Paths" hidden="false" id="1a62-ed76-ff9a-117a" type="selectionEntryGroup" targetId="8e28-9445-463a-5883"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="962d-3647-8426-5488" type="selectionEntryGroup" targetId="6dcf-7de6-0f0f-bfc6"/>
         <entryLink import="true" name="Renown" hidden="false" id="f5c4-a5b2-d3db-a90f" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Brazen Mutations" hidden="false" id="13dd-c20c-cd72-a9f9" type="selectionEntryGroup" targetId="6072-5cbd-ebb3-a76a"/>
       </entryLinks>
       <modifiers>
         <modifier type="multiply" value="2" field="points">
@@ -1714,6 +1803,7 @@ This unit can be affected by this ability multiple times and the effects are cum
         <entryLink import="true" name="Paths" hidden="false" id="e4ed-ad4e-22e6-4f6b" type="selectionEntryGroup" targetId="8e28-9445-463a-5883"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="e164-9295-84af-e1c6" type="selectionEntryGroup" targetId="6dcf-7de6-0f0f-bfc6"/>
         <entryLink import="true" name="Renown" hidden="false" id="95cb-c92e-4ebd-ab26" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Brazen Mutations" hidden="false" id="5c09-aca8-406b-b45e" type="selectionEntryGroup" targetId="6072-5cbd-ebb3-a76a"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="130"/>
@@ -1745,6 +1835,7 @@ This unit can be affected by this ability multiple times and the effects are cum
         <entryLink import="true" name="Paths" hidden="false" id="0650-6d29-f310-f34d" type="selectionEntryGroup" targetId="8e28-9445-463a-5883"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="1028-7cef-38ef-e0ed" type="selectionEntryGroup" targetId="6dcf-7de6-0f0f-bfc6"/>
         <entryLink import="true" name="Renown" hidden="false" id="d4fc-1131-a27b-75cb" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Brazen Mutations" hidden="false" id="b020-743e-4e7f-f37f" type="selectionEntryGroup" targetId="6072-5cbd-ebb3-a76a"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="150"/>
@@ -1773,6 +1864,7 @@ This unit can be affected by this ability multiple times and the effects are cum
         <entryLink import="true" name="Paths" hidden="false" id="c0a3-3fdf-3d87-3952" type="selectionEntryGroup" targetId="8e28-9445-463a-5883"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="b66d-1f76-fb04-f9a7" type="selectionEntryGroup" targetId="6dcf-7de6-0f0f-bfc6"/>
         <entryLink import="true" name="Renown" hidden="false" id="69f2-ab9f-1a8a-a9ec" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Brazen Mutations" hidden="false" id="b8d0-8e55-d860-db0f" type="selectionEntryGroup" targetId="6072-5cbd-ebb3-a76a"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="150"/>
@@ -1801,6 +1893,7 @@ This unit can be affected by this ability multiple times and the effects are cum
         <entryLink import="true" name="Paths" hidden="false" id="54d7-2d47-423e-484d" type="selectionEntryGroup" targetId="8e28-9445-463a-5883"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="77f5-d6a9-4ae6-2837" type="selectionEntryGroup" targetId="6dcf-7de6-0f0f-bfc6"/>
         <entryLink import="true" name="Renown" hidden="false" id="9a76-7931-a690-e598" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Brazen Mutations" hidden="false" id="a622-b2d8-33ec-5b6e" type="selectionEntryGroup" targetId="6072-5cbd-ebb3-a76a"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="80"/>
@@ -1886,6 +1979,7 @@ This unit can be affected by this ability multiple times and the effects are cum
         <entryLink import="true" name="Paths" hidden="false" id="741b-6ee6-7309-7ba8" type="selectionEntryGroup" targetId="8e28-9445-463a-5883"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="864b-a8bb-ebac-a157" type="selectionEntryGroup" targetId="6dcf-7de6-0f0f-bfc6"/>
         <entryLink import="true" name="Renown" hidden="false" id="0d3c-32ab-18ba-736d" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Brazen Mutations" hidden="false" id="f81e-6667-aed0-b0c4" type="selectionEntryGroup" targetId="6072-5cbd-ebb3-a76a"/>
       </entryLinks>
     </entryLink>
     <entryLink import="true" name="Skull Cannon" hidden="false" id="99c7-f450-6c36-87de" type="selectionEntry" targetId="597f-3928-bede-9c43">
@@ -1938,6 +2032,7 @@ This unit can be affected by this ability multiple times and the effects are cum
         <entryLink import="true" name="Paths" hidden="false" id="ec1c-0a8c-6858-8f93" type="selectionEntryGroup" targetId="8e28-9445-463a-5883"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="12a3-30f2-bcb7-64d8" type="selectionEntryGroup" targetId="6dcf-7de6-0f0f-bfc6"/>
         <entryLink import="true" name="Renown" hidden="false" id="4e98-a34c-1b8a-c355" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Brazen Mutations" hidden="false" id="9100-5a53-9864-a324" type="selectionEntryGroup" targetId="6072-5cbd-ebb3-a76a"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="170"/>
@@ -1966,6 +2061,7 @@ This unit can be affected by this ability multiple times and the effects are cum
         <entryLink import="true" name="Paths" hidden="false" id="48ba-7073-1aef-ce6c" type="selectionEntryGroup" targetId="8e28-9445-463a-5883"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="00ef-311f-5639-da4f" type="selectionEntryGroup" targetId="6dcf-7de6-0f0f-bfc6"/>
         <entryLink import="true" name="Renown" hidden="false" id="6233-9f59-1674-3343" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Brazen Mutations" hidden="false" id="ed4f-d0c3-89e3-3082" type="selectionEntryGroup" targetId="6072-5cbd-ebb3-a76a"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="200"/>
@@ -2080,6 +2176,7 @@ This unit can be affected by this ability multiple times and the effects are cum
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="3d66-27b3-2d5f-322f" type="selectionEntryGroup" targetId="6dcf-7de6-0f0f-bfc6"/>
+        <entryLink import="true" name="Brazen Mutations" hidden="false" id="5b35-024e-05f5-0cbf" type="selectionEntryGroup" targetId="6072-5cbd-ebb3-a76a"/>
       </entryLinks>
     </entryLink>
     <entryLink import="true" name="Gorechosen of Dromm" hidden="false" id="8db5-601a-0363-5818" type="selectionEntry" targetId="a5a3-d0d5-fc50-9020">
@@ -2106,6 +2203,7 @@ This unit can be affected by this ability multiple times and the effects are cum
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="e7fe-928d-38dd-193b" type="selectionEntryGroup" targetId="6dcf-7de6-0f0f-bfc6"/>
         <entryLink import="true" name="Renown" hidden="false" id="e8cd-3b95-08c1-bef0" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Brazen Mutations" hidden="false" id="056c-a02f-265e-63da" type="selectionEntryGroup" targetId="6072-5cbd-ebb3-a76a"/>
       </entryLinks>
     </entryLink>
     <entryLink import="true" name="Magore&apos;s Fiends" hidden="false" id="1f77-c326-fb05-20ea" type="selectionEntry" targetId="e17c-89f4-8d3a-a652">
@@ -2132,6 +2230,7 @@ This unit can be affected by this ability multiple times and the effects are cum
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="3151-b9db-2a62-ee22" type="selectionEntryGroup" targetId="6dcf-7de6-0f0f-bfc6"/>
         <entryLink import="true" name="Renown" hidden="false" id="d13e-e218-4479-fcec" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Brazen Mutations" hidden="false" id="5a81-1cb4-945c-4410" type="selectionEntryGroup" targetId="6072-5cbd-ebb3-a76a"/>
       </entryLinks>
     </entryLink>
     <entryLink import="true" name="Wrathmongers" hidden="false" id="d279-8ae8-f8e8-1be1" type="selectionEntry" targetId="8aed-ea87-e4c8-97ea">
@@ -2157,6 +2256,7 @@ This unit can be affected by this ability multiple times and the effects are cum
         <entryLink import="true" name="Paths" hidden="false" id="a2b2-1506-49c3-92c4" type="selectionEntryGroup" targetId="8e28-9445-463a-5883"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="fe95-afa7-87df-e038" type="selectionEntryGroup" targetId="6dcf-7de6-0f0f-bfc6"/>
         <entryLink import="true" name="Renown" hidden="false" id="b175-6321-3d39-ec6f" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Brazen Mutations" hidden="false" id="7bd5-b455-a09c-355c" type="selectionEntryGroup" targetId="6072-5cbd-ebb3-a76a"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="130"/>
@@ -2186,6 +2286,7 @@ This unit can be affected by this ability multiple times and the effects are cum
         <entryLink import="true" name="Paths" hidden="false" id="c2b8-8234-4cb1-df41" type="selectionEntryGroup" targetId="8e28-9445-463a-5883"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="59fe-24fb-18d9-be96" type="selectionEntryGroup" targetId="6dcf-7de6-0f0f-bfc6"/>
         <entryLink import="true" name="Renown" hidden="false" id="03b7-ddd1-c706-d256" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Brazen Mutations" hidden="false" id="d618-bee7-31d0-b59f" type="selectionEntryGroup" targetId="6072-5cbd-ebb3-a76a"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="150"/>
@@ -2458,6 +2559,7 @@ This unit can be affected by this ability multiple times and the effects are cum
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="cc6c-10cc-3971-fc5d" type="selectionEntryGroup" targetId="6dcf-7de6-0f0f-bfc6"/>
         <entryLink import="true" name="Renown" hidden="false" id="4030-1f67-bcf6-f906" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Brazen Mutations" hidden="false" id="fefe-4623-36c4-49a8" type="selectionEntryGroup" targetId="6072-5cbd-ebb3-a76a"/>
       </entryLinks>
     </entryLink>
   </entryLinks>

--- a/Disciples of Tzeentch.cat
+++ b/Disciples of Tzeentch.cat
@@ -146,6 +146,88 @@ Friendly units that are **masked by illusion** are destroyed at the end of the f
     </selectionEntryGroup>
     <selectionEntryGroup name="Artefacts of Power" id="d953-63d2-257f-850f" hidden="false">
       <selectionEntryGroups>
+        <selectionEntryGroup name="Fated Artefacts" id="561d-15ea-802c-2a54" hidden="true" publicationId="9e18-bb03-7b60-d4ff">
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Tome of Scorched Insight" hidden="false" id="18e0-da7a-b468-3b4d">
+              <profiles>
+                <profile name="Tome of Scorched Insight" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="5211-25a8-b5cb-0952">
+                  <characteristics>
+                    <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Reaction: You declared a non-**^^Summon^^** **^^Spell^^** ability for this unit</characteristic>
+                    <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb"/>
+                    <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Change the casting roll for that spell to a value of 12 that cannot be modified. That spell cannot be unbound and this unit cannot use that **^^Spell^^** ability again for the rest of the battle.</characteristic>
+                    <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+                    <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+                  </characteristics>
+                  <attributes>
+                    <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Yellow</attribute>
+                    <attribute typeId="6d16-c86b-2698-85a4" name="Type">Special</attribute>
+                    <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+                  </attributes>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="d218-e07a-737a-9525" includeChildSelections="true"/>
+              </constraints>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="The Searing Eye" hidden="false" id="e2af-a842-bbc1-df75">
+              <profiles>
+                <profile name="The Searing Eye" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="a146-fd5d-729e-2453">
+                  <characteristics>
+                    <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Reaction: You declared a **^^Spell^^** ability for a **^^Disciples of Tzeentch^^** unit wholly within 12&quot; of this unit</characteristic>
+                    <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb"/>
+                    <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Spend 1 **rage dice**. If your opponent&apos;s **fury level** is lower than yours, they must increase their **fury level** by 1, to a maximum of 7.
+Then, roll a dice. If the roll is the same as any of the dice in the casting roll, that spell is miscast. Otherwise, add the roll to the casting roll.</characteristic>
+                    <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+                    <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+                  </characteristics>
+                  <attributes>
+                    <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Yellow</attribute>
+                    <attribute typeId="6d16-c86b-2698-85a4" name="Type">Special</attribute>
+                    <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+                  </attributes>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="018f-00c4-684c-80bc" includeChildSelections="true"/>
+              </constraints>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="The Five Verses of Volarian" hidden="false" id="6ea8-42f5-632e-103f">
+              <profiles>
+                <profile name="The Five Verses of Volarian" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="d49c-367f-ade1-d9b9">
+                  <characteristics>
+                    <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
+                    <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">This unit has a Move characteristic of 14&quot; and has **^^Fly^^**.</characteristic>
+                  </characteristics>
+                  <attributes>
+                    <attribute typeId="50fe-4f29-6bc3-dcc6" name="Color">Green</attribute>
+                    <attribute typeId="bf11-4e10-3ab1-06f4" name="Type">Movement</attribute>
+                    <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
+                  </attributes>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="7757-1ea0-9949-b5bc" includeChildSelections="true"/>
+              </constraints>
+            </selectionEntry>
+          </selectionEntries>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="78a1-f6c2-71b8-270a" shared="true"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="0151-9c5b-2f1e-32d4" shared="true" childName="✦ General&apos;s Handbook 2026-27"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <rules>
+            <rule name="Enhancement Restrictions" id="3b46-0678-f37c-0ea8" hidden="true">
+              <description>You can pick an artefact from this table instead of from other Artefacts of Power tables available to this faction. Only a Hero can be given an artefact from this table.</description>
+            </rule>
+          </rules>
+        </selectionEntryGroup>
         <selectionEntryGroup name="Fated Artefacts" id="4ebd-7275-b985-2664" hidden="false">
           <selectionEntries>
             <selectionEntry type="upgrade" import="true" name="Kairic Tome" hidden="false" id="cd8a-3f1e-f25f-5a53">
@@ -669,6 +751,100 @@ If you remove 1 or more damage points from the damage pool of a friendly **^^Dis
       </modifiers>
       <constraints>
         <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="f224-a26c-50cb-c3e9"/>
+      </constraints>
+    </selectionEntryGroup>
+    <selectionEntryGroup name="Visions of Fate" id="0fa6-3e80-ca9b-8788" hidden="false">
+      <selectionEntryGroups>
+        <selectionEntryGroup name="Visions of Fate" id="047d-3746-50a4-1740" hidden="true" publicationId="9e18-bb03-7b60-d4ff">
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Vision of Defiant Supremacy" hidden="false" id="7e3f-a1ed-b00b-dc7b">
+              <profiles>
+                <profile name="Vision of Defiant Supremacy" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="21ee-d30b-7e0c-6852">
+                  <characteristics>
+                    <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Battle, Any Hero Phase</characteristic>
+                    <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb"/>
+                    <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">If you won the priority roll this battle round and chose for your opponent to take the first turn or if your opponent seized the initiative this battle round, this unit has **^^Strike-first^^** for the rest of the turn.</characteristic>
+                    <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+                    <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+                  </characteristics>
+                  <attributes>
+                    <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Yellow</attribute>
+                    <attribute typeId="6d16-c86b-2698-85a4" name="Type">Offensive</attribute>
+                    <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+                  </attributes>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="6132-08d5-41f9-503d" includeChildSelections="true"/>
+              </constraints>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Vision of Destined Conquest" hidden="false" id="459b-9a0f-860c-80d5">
+              <profiles>
+                <profile name="Vision of Destined Conquest" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="02cf-b254-4f31-d244">
+                  <characteristics>
+                    <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Battle, Start of Your Turn</characteristic>
+                    <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb"/>
+                    <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">If this unit is contesting an objective that you control that is wholly outside friendly territory:
+• If you are the **underdog**, gain 1 **fate point** for each command point you have.
+• If you are not the **underdog**, roll a dice for each command point you have. For each 3+, gain 1 **fate point**.</characteristic>
+                    <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+                    <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+                  </characteristics>
+                  <attributes>
+                    <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Black</attribute>
+                    <attribute typeId="6d16-c86b-2698-85a4" name="Type">Special</attribute>
+                    <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+                  </attributes>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="ac72-5014-1839-749f" includeChildSelections="true"/>
+              </constraints>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Vision of Arcane Sacrifice" hidden="false" id="98bf-841c-d2e3-a635">
+              <profiles>
+                <profile name="Vision of Arcane Sacrifice" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="62d7-0f55-833e-52ad">
+                  <characteristics>
+                    <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
+                    <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">While units (friendly or enemy) are within 6&quot; of this unit:
+• Add 1 to unbinding rolls for those units.
+• Spells cast by those units are miscast on an unmodified casting roll of 4 or less.
+The first time this unit is destroyed, gain D6 **fate points**.</characteristic>
+                  </characteristics>
+                  <attributes>
+                    <attribute typeId="50fe-4f29-6bc3-dcc6" name="Color">Yellow</attribute>
+                    <attribute typeId="bf11-4e10-3ab1-06f4" name="Type">Special</attribute>
+                    <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
+                  </attributes>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="2dd5-efe4-989a-e60f" includeChildSelections="true"/>
+              </constraints>
+            </selectionEntry>
+          </selectionEntries>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="78a1-f6c2-71b8-270a" shared="true"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="0151-9c5b-2f1e-32d4" shared="true" childName="✦ General&apos;s Handbook 2026-27"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <rules>
+            <rule name="Enhancement Restrictions" id="427a-4af2-d92f-7212" hidden="true">
+              <description>Visions of Fate are unique enhancements that can be given to non-Hero non-Beast Disciples of Tzeentch units. A unit can only have 1 Vision of Fate.</description>
+            </rule>
+          </rules>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <constraints>
+        <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="b4b7-702c-4aff-05cd" includeChildSelections="true"/>
+        <constraint type="max" value="1" field="selections" scope="root-entry" shared="true" id="6d08-263d-2365-326c"/>
       </constraints>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
@@ -1491,6 +1667,7 @@ If you remove 1 or more damage points from the damage pool of a friendly **^^Dis
         <entryLink import="true" name="Paths" hidden="false" id="712f-7456-bd0f-6127" type="selectionEntryGroup" targetId="3fea-aadd-11d7-023d"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="f74c-5a5c-f379-23d7" type="selectionEntryGroup" targetId="9f62-724e-720d-87ff"/>
         <entryLink import="true" name="Renown" hidden="false" id="1e56-f5bc-3ffd-e632" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Visions of Fate" hidden="false" id="2224-de58-40a0-9c41" type="selectionEntryGroup" targetId="0fa6-3e80-ca9b-8788"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="120"/>
@@ -1521,6 +1698,7 @@ If you remove 1 or more damage points from the damage pool of a friendly **^^Dis
         <entryLink import="true" name="Paths" hidden="false" id="92f9-11d0-b3b2-b53f" type="selectionEntryGroup" targetId="3fea-aadd-11d7-023d"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="e48f-991f-857e-36c1" type="selectionEntryGroup" targetId="9f62-724e-720d-87ff"/>
         <entryLink import="true" name="Renown" hidden="false" id="20af-ae6d-c8dc-2841" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Visions of Fate" hidden="false" id="8683-7a2e-2943-8755" type="selectionEntryGroup" targetId="0fa6-3e80-ca9b-8788"/>
       </entryLinks>
     </entryLink>
     <entryLink import="true" name="Chaos Spawn of Tzeentch" hidden="false" id="9d20-b346-5039-25f5" type="selectionEntry" targetId="d804-1f1-49e2-880">
@@ -1604,6 +1782,7 @@ If you remove 1 or more damage points from the damage pool of a friendly **^^Dis
         <entryLink import="true" name="Paths" hidden="false" id="3a5c-1947-b041-e21c" type="selectionEntryGroup" targetId="3fea-aadd-11d7-023d"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="07c7-6022-6bda-5342" type="selectionEntryGroup" targetId="9f62-724e-720d-87ff"/>
         <entryLink import="true" name="Renown" hidden="false" id="5468-809c-8b0b-8b76" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Visions of Fate" hidden="false" id="4997-67c2-d719-d0a3" type="selectionEntryGroup" targetId="0fa6-3e80-ca9b-8788"/>
       </entryLinks>
     </entryLink>
     <entryLink import="true" name="Flamers of Tzeentch" hidden="false" id="f4af-9ab6-54f9-46ae" type="selectionEntry" targetId="734-1521-c440-d919">
@@ -1612,6 +1791,7 @@ If you remove 1 or more damage points from the damage pool of a friendly **^^Dis
         <entryLink import="true" name="Paths" hidden="false" id="6a37-64a0-b13d-f245" type="selectionEntryGroup" targetId="3fea-aadd-11d7-023d"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="ee52-3bb5-cf11-a0bb" type="selectionEntryGroup" targetId="9f62-724e-720d-87ff"/>
         <entryLink import="true" name="Renown" hidden="false" id="3c81-2804-13a1-fde0" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Visions of Fate" hidden="false" id="5b78-111e-5298-2681" type="selectionEntryGroup" targetId="0fa6-3e80-ca9b-8788"/>
       </entryLinks>
       <modifiers>
         <modifier type="multiply" value="2" field="points">
@@ -1659,6 +1839,7 @@ If you remove 1 or more damage points from the damage pool of a friendly **^^Dis
         <entryLink import="true" name="Paths" hidden="false" id="165c-e4c1-210d-8b9d" type="selectionEntryGroup" targetId="3fea-aadd-11d7-023d"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="1ddf-a6a8-7788-1f87" type="selectionEntryGroup" targetId="9f62-724e-720d-87ff"/>
         <entryLink import="true" name="Renown" hidden="false" id="3ad1-1e01-bd1b-6d9b" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Visions of Fate" hidden="false" id="bb00-9d5c-b738-321a" type="selectionEntryGroup" targetId="0fa6-3e80-ca9b-8788"/>
       </entryLinks>
     </entryLink>
     <entryLink import="true" name="Pink Horrors" hidden="false" id="91fb-94e2-7c23-5b8e" type="selectionEntry" targetId="2631-6ae3-b25b-2bbf">
@@ -1667,6 +1848,7 @@ If you remove 1 or more damage points from the damage pool of a friendly **^^Dis
         <entryLink import="true" name="Paths" hidden="false" id="523c-f008-411c-8163" type="selectionEntryGroup" targetId="3fea-aadd-11d7-023d"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="54ce-9e23-2655-dde6" type="selectionEntryGroup" targetId="9f62-724e-720d-87ff"/>
         <entryLink import="true" name="Renown" hidden="false" id="bedb-291f-e31c-422f" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Visions of Fate" hidden="false" id="0fa5-f699-81c9-5686" type="selectionEntryGroup" targetId="0fa6-3e80-ca9b-8788"/>
       </entryLinks>
       <modifiers>
         <modifier type="multiply" value="2" field="points">
@@ -1751,6 +1933,7 @@ If you remove 1 or more damage points from the damage pool of a friendly **^^Dis
         <entryLink import="true" name="Paths" hidden="false" id="34e3-2b07-5539-f4e1" type="selectionEntryGroup" targetId="3fea-aadd-11d7-023d"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="d5f8-5aa5-0377-3610" type="selectionEntryGroup" targetId="9f62-724e-720d-87ff"/>
         <entryLink import="true" name="Renown" hidden="false" id="e903-5219-6453-5730" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Visions of Fate" hidden="false" id="f607-619a-bdc6-9a7d" type="selectionEntryGroup" targetId="0fa6-3e80-ca9b-8788"/>
       </entryLinks>
       <modifiers>
         <modifier type="multiply" value="2" field="points">
@@ -1779,6 +1962,7 @@ If you remove 1 or more damage points from the damage pool of a friendly **^^Dis
         <entryLink import="true" name="Paths" hidden="false" id="8533-f232-4986-06e5" type="selectionEntryGroup" targetId="3fea-aadd-11d7-023d"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="2972-ccec-a743-02fd" type="selectionEntryGroup" targetId="9f62-724e-720d-87ff"/>
         <entryLink import="true" name="Renown" hidden="false" id="4392-d7b6-3368-1dec" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Visions of Fate" hidden="false" id="0b29-9664-b0dc-55cc" type="selectionEntryGroup" targetId="0fa6-3e80-ca9b-8788"/>
       </entryLinks>
       <modifiers>
         <modifier type="multiply" value="2" field="points">
@@ -1807,6 +1991,7 @@ If you remove 1 or more damage points from the damage pool of a friendly **^^Dis
         <entryLink import="true" name="Paths" hidden="false" id="2604-6193-7bc1-c580" type="selectionEntryGroup" targetId="3fea-aadd-11d7-023d"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="460d-2b30-e185-2187" type="selectionEntryGroup" targetId="9f62-724e-720d-87ff"/>
         <entryLink import="true" name="Renown" hidden="false" id="4406-e118-2068-ebb2" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Visions of Fate" hidden="false" id="11de-b5bd-0837-cf8e" type="selectionEntryGroup" targetId="0fa6-3e80-ca9b-8788"/>
       </entryLinks>
       <modifiers>
         <modifier type="multiply" value="2" field="points">
@@ -1835,6 +2020,7 @@ If you remove 1 or more damage points from the damage pool of a friendly **^^Dis
         <entryLink import="true" name="Paths" hidden="false" id="f361-80a7-f050-3d4d" type="selectionEntryGroup" targetId="3fea-aadd-11d7-023d"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="e761-af2f-00cb-878a" type="selectionEntryGroup" targetId="9f62-724e-720d-87ff"/>
         <entryLink import="true" name="Renown" hidden="false" id="405e-40f0-63f5-ed6b" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Visions of Fate" hidden="false" id="759e-d4f2-26ee-a646" type="selectionEntryGroup" targetId="0fa6-3e80-ca9b-8788"/>
       </entryLinks>
       <modifiers>
         <modifier type="multiply" value="2" field="points">
@@ -2070,6 +2256,7 @@ If you remove 1 or more damage points from the damage pool of a friendly **^^Dis
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="48bb-b15a-dde4-d1aa" type="selectionEntryGroup" targetId="9f62-724e-720d-87ff"/>
+        <entryLink import="true" name="Visions of Fate" hidden="false" id="e9d8-b937-0f80-c637" type="selectionEntryGroup" targetId="0fa6-3e80-ca9b-8788"/>
       </entryLinks>
     </entryLink>
     <entryLink import="true" name="Ephilim&apos;s Pandaemonium" hidden="false" id="6cc6-84e2-8486-0351" type="selectionEntry" targetId="16f4-4752-ac83-17ae">
@@ -2095,6 +2282,7 @@ If you remove 1 or more damage points from the damage pool of a friendly **^^Dis
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="78ea-1650-bf64-62b2" type="selectionEntryGroup" targetId="9f62-724e-720d-87ff"/>
+        <entryLink import="true" name="Visions of Fate" hidden="false" id="4225-d872-5a4f-9a01" type="selectionEntryGroup" targetId="0fa6-3e80-ca9b-8788"/>
       </entryLinks>
     </entryLink>
     <entryLink import="true" name="Ogroid Thaumaturge (Scourge of Ghyran)" hidden="false" id="b711-03d7-ad1d-6c93" type="selectionEntry" targetId="1717-5238-e2ba-0f0a">
@@ -2165,6 +2353,7 @@ If you remove 1 or more damage points from the damage pool of a friendly **^^Dis
         <entryLink import="true" name="Paths" hidden="false" id="36b0-ed87-f6fa-0e10" type="selectionEntryGroup" targetId="3fea-aadd-11d7-023d"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="f155-0637-5299-50c5" type="selectionEntryGroup" targetId="9f62-724e-720d-87ff"/>
         <entryLink import="true" name="Renown" hidden="false" id="057f-66c3-75f2-ac37" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Visions of Fate" hidden="false" id="8c12-c995-fcb3-a264" type="selectionEntryGroup" targetId="0fa6-3e80-ca9b-8788"/>
       </entryLinks>
       <modifiers>
         <modifier type="multiply" value="2" field="points">
@@ -2264,6 +2453,7 @@ If you remove 1 or more damage points from the damage pool of a friendly **^^Dis
         <entryLink import="true" name="Paths" hidden="false" id="cf73-0740-b505-2b89" type="selectionEntryGroup" targetId="3fea-aadd-11d7-023d"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="c8e1-1ed2-7ea8-cead" type="selectionEntryGroup" targetId="9f62-724e-720d-87ff"/>
         <entryLink import="true" name="Renown" hidden="false" id="f036-c1ae-a896-7a4a" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Visions of Fate" hidden="false" id="aece-8398-815e-ce4d" type="selectionEntryGroup" targetId="0fa6-3e80-ca9b-8788"/>
       </entryLinks>
       <modifiers>
         <modifier type="multiply" value="2" field="points">

--- a/Hedonites of Slaanesh.cat
+++ b/Hedonites of Slaanesh.cat
@@ -451,6 +451,91 @@
     </selectionEntryGroup>
     <selectionEntryGroup name="Heroic Traits" id="c061-56e0-f2c0-af3e" hidden="false">
       <selectionEntryGroups>
+        <selectionEntryGroup name="The Dark Prince's Beloved" id="ef5e-07c3-ab53-7dae" hidden="true" publicationId="9e18-bb03-7b60-d4ff">
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Agonisingly Elusive" hidden="false" id="f52a-ba41-4edd-d76b">
+              <profiles>
+                <profile name="Agonisingly Elusive" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="9dc8-ac4b-b5b0-8653">
+                  <characteristics>
+                    <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Any Movement Phase</characteristic>
+                    <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick an enemy unit in combat with this unit to be the target.</characteristic>
+                    <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">If it is your turn, apply the effect below. If it is your opponent’s turn, roll a dice. On a 3+, apply the effect below:
+Inflict D3 mortal damage on the target. Then, this unit must move a distance up to its Move characteristic. It can move through the combat ranges of enemy units but cannot end that move in combat.</characteristic>
+                    <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f">**^^Core^^**, **^^Move^^**</characteristic>
+                    <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+                  </characteristics>
+                  <attributes>
+                    <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Gray</attribute>
+                    <attribute typeId="6d16-c86b-2698-85a4" name="Type">Special</attribute>
+                    <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+                  </attributes>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="9b16-1a08-ec4e-a6c2" includeChildSelections="true"/>
+              </constraints>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Incensed" hidden="false" id="0b59-46f1-ef87-4775">
+              <profiles>
+                <profile name="Incensed" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="2311-d091-d797-d3c5">
+                  <characteristics>
+                    <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Your Hero Phase</characteristic>
+                    <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick an objective within 6&quot; of this unit to be the target.</characteristic>
+                    <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Until the start of your next turn, friendly **^^Hedonites of Slaanesh^^** units are not visible to enemy units more than 9&quot; from them while all models in those friendly units are contesting the target objective.</characteristic>
+                    <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+                    <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+                  </characteristics>
+                  <attributes>
+                    <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Yellow</attribute>
+                    <attribute typeId="6d16-c86b-2698-85a4" name="Type">Defensive</attribute>
+                    <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+                  </attributes>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="b3e3-e38d-b774-afbf" includeChildSelections="true"/>
+              </constraints>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Arcane Magnetism" hidden="false" id="e350-063f-a193-7ef6">
+              <profiles>
+                <profile name="Arcane Magnetism" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="5e5e-5b33-3f5f-3b5c">
+                  <characteristics>
+                    <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Any Combat Phase</characteristic>
+                    <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb"/>
+                    <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">If this unit has 3 or more damage points, it can use a **^^Spell^^** ability as if it were your hero phase, as if that ability had the **^^Unlimited^^** keyword and as if this unit had **^^Wizard^^** (1).</characteristic>
+                    <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+                    <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+                  </characteristics>
+                  <attributes>
+                    <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Red</attribute>
+                    <attribute typeId="6d16-c86b-2698-85a4" name="Type">Special</attribute>
+                    <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+                  </attributes>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="886c-33ed-889d-4c18" includeChildSelections="true"/>
+              </constraints>
+            </selectionEntry>
+          </selectionEntries>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="78a1-f6c2-71b8-270a" shared="true"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="0151-9c5b-2f1e-32d4" shared="true" childName="✦ General&apos;s Handbook 2026-27"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <rules>
+            <rule name="Enhancement Restrictions" id="fa9a-6d3c-cc24-afee" hidden="true">
+              <description>**^^Hero^^** only</description>
+            </rule>
+          </rules>
+        </selectionEntryGroup>
         <selectionEntryGroup name="The Dark Prince&apos;s Beloved" id="224b-2ac6-a2d9-0d81" hidden="false">
           <selectionEntries>
             <selectionEntry type="upgrade" import="true" name="Unseemly Vitality" hidden="false" id="d49d-5768-8196-d93c" publicationId="95fc-e96f-a916-bba1">
@@ -700,6 +785,100 @@
       </modifiers>
       <constraints>
         <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="e9b7-ab2e-5aca-264c"/>
+      </constraints>
+    </selectionEntryGroup>
+    <selectionEntryGroup name="All-consuming Obsessions" id="f1b1-3fa5-8b01-9ddc" hidden="false">
+      <selectionEntryGroups>
+        <selectionEntryGroup name="All-consuming Obsessions" id="917a-a59d-199b-daa5" hidden="true" publicationId="9e18-bb03-7b60-d4ff">
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Obsession with Control" hidden="false" id="8554-b8f0-2e45-51e3">
+              <profiles>
+                <profile name="Obsession with Control" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="e159-dbaf-d7bb-c9dd">
+                  <characteristics>
+                    <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Deployment Phase</characteristic>
+                    <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick an objective to be the target.</characteristic>
+                    <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">For the rest of the battle, while this unit is contesting the target objective:
+• This unit has **^^Ward^^** (5+).
+• Add 5 to this unit’s control score.</characteristic>
+                    <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+                    <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+                  </characteristics>
+                  <attributes>
+                    <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Black</attribute>
+                    <attribute typeId="6d16-c86b-2698-85a4" name="Type">Special</attribute>
+                    <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+                  </attributes>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="eb2a-0237-2989-0562" includeChildSelections="true"/>
+              </constraints>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Obsession with Form" hidden="false" id="4680-75a1-f41a-47a8">
+              <profiles>
+                <profile name="Obsession with Form" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="5220-1127-ebc3-66f5">
+                  <characteristics>
+                    <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Reaction: You declared the ‘Run’ ability for this unit</characteristic>
+                    <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb"/>
+                    <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Subtract 1 from hit rolls for attacks that target this unit for the rest of the turn.</characteristic>
+                    <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+                    <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+                  </characteristics>
+                  <attributes>
+                    <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Gray</attribute>
+                    <attribute typeId="6d16-c86b-2698-85a4" name="Type">Defensive</attribute>
+                    <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+                  </attributes>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="b4d9-1cb6-5099-e8d6" includeChildSelections="true"/>
+              </constraints>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Obsession with Pain" hidden="false" id="eb93-5bf0-ccc7-41b5">
+              <profiles>
+                <profile name="Obsession with Pain" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="72f2-622f-b773-64ea">
+                  <characteristics>
+                    <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Any Combat Phase</characteristic>
+                    <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb"/>
+                    <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">If this unit is damaged, spend 1 **rage dice**. If your opponent’s **fury level** is lower than yours, they must increase their **fury level** by 1, to a maximum of 7. Then, add 1 to the Rend characteristic of this unit’s non-**^^Companion^^** melee weapons for the rest of the turn.</characteristic>
+                    <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+                    <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+                  </characteristics>
+                  <attributes>
+                    <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Red</attribute>
+                    <attribute typeId="6d16-c86b-2698-85a4" name="Type">Offensive</attribute>
+                    <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+                  </attributes>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="e48b-0b04-8104-95de" includeChildSelections="true"/>
+              </constraints>
+            </selectionEntry>
+          </selectionEntries>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="78a1-f6c2-71b8-270a" shared="true"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="0151-9c5b-2f1e-32d4" shared="true" childName="✦ General&apos;s Handbook 2026-27"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <rules>
+            <rule name="Enhancement Restrictions" id="35d8-014b-02ed-ce57" hidden="true">
+              <description>All-consuming Obsessions are unique enhancements that can be given to non-**^^Hero^^** **^^Hedonites of Slaanesh^^** **^^Infantry^^** or **^^Cavalry^^** units. A unit can only have 1 All-consuming Obsession.</description>
+            </rule>
+          </rules>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <constraints>
+        <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="48b2-caa3-0834-e0cb" includeChildSelections="true"/>
+        <constraint type="max" value="1" field="selections" scope="root-entry" shared="true" id="79bf-06ca-94d9-99b2"/>
       </constraints>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
@@ -1503,6 +1682,7 @@
         <entryLink import="true" name="Paths" hidden="false" id="318f-ccb3-6978-2634" type="selectionEntryGroup" targetId="3036-9f76-bbb9-e18a"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="2476-44d7-22bf-2fb3" type="selectionEntryGroup" targetId="1331-6d75-79fb-92af"/>
         <entryLink import="true" name="Renown" hidden="false" id="44bc-6cd6-ab8f-91cf" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="All-consuming Obsessions" hidden="false" id="9aa4-46fd-9633-b83f" type="selectionEntryGroup" targetId="f1b1-3fa5-8b01-9ddc"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="140"/>
@@ -1514,6 +1694,7 @@
         <entryLink import="true" name="Paths" hidden="false" id="b421-f932-d80f-00c0" type="selectionEntryGroup" targetId="3036-9f76-bbb9-e18a"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="b4d7-a945-2d4a-82dc" type="selectionEntryGroup" targetId="1331-6d75-79fb-92af"/>
         <entryLink import="true" name="Renown" hidden="false" id="8389-b6f3-0330-db61" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="All-consuming Obsessions" hidden="false" id="eff4-f712-8faa-14c0" type="selectionEntryGroup" targetId="f1b1-3fa5-8b01-9ddc"/>
       </entryLinks>
       <modifiers>
         <modifier type="multiply" value="2" field="points">
@@ -1542,6 +1723,7 @@
         <entryLink import="true" name="Paths" hidden="false" id="2ff3-d736-20b3-e56d" type="selectionEntryGroup" targetId="3036-9f76-bbb9-e18a"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="00f3-caa2-5f3e-bb47" type="selectionEntryGroup" targetId="1331-6d75-79fb-92af"/>
         <entryLink import="true" name="Renown" hidden="false" id="0529-387c-9f9b-bfe8" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="All-consuming Obsessions" hidden="false" id="e38b-85df-76bc-093d" type="selectionEntryGroup" targetId="f1b1-3fa5-8b01-9ddc"/>
       </entryLinks>
       <modifiers>
         <modifier type="multiply" value="2" field="points">
@@ -1570,6 +1752,7 @@
         <entryLink import="true" name="Paths" hidden="false" id="ef4b-e290-ab78-8b56" type="selectionEntryGroup" targetId="3036-9f76-bbb9-e18a"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="34f2-65bf-2ce2-ff4e" type="selectionEntryGroup" targetId="1331-6d75-79fb-92af"/>
         <entryLink import="true" name="Renown" hidden="false" id="ecc6-98c1-0afa-b7d4" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="All-consuming Obsessions" hidden="false" id="9f04-1c90-d4a8-0fc2" type="selectionEntryGroup" targetId="f1b1-3fa5-8b01-9ddc"/>
       </entryLinks>
       <modifiers>
         <modifier type="multiply" value="2" field="points">
@@ -1598,6 +1781,7 @@
         <entryLink import="true" name="Paths" hidden="false" id="ab73-0b10-62cb-9dd1" type="selectionEntryGroup" targetId="3036-9f76-bbb9-e18a"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="f2a9-24db-7fba-05bd" type="selectionEntryGroup" targetId="1331-6d75-79fb-92af"/>
         <entryLink import="true" name="Renown" hidden="false" id="b26f-7c16-11cc-e093" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="All-consuming Obsessions" hidden="false" id="6309-f22b-9a67-bd4c" type="selectionEntryGroup" targetId="f1b1-3fa5-8b01-9ddc"/>
       </entryLinks>
       <modifiers>
         <modifier type="multiply" value="2" field="points">
@@ -1681,6 +1865,7 @@
         <entryLink import="true" name="Paths" hidden="false" id="839d-2267-c46f-b0f0" type="selectionEntryGroup" targetId="3036-9f76-bbb9-e18a"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="3c0e-f876-2c33-22b9" type="selectionEntryGroup" targetId="1331-6d75-79fb-92af"/>
         <entryLink import="true" name="Renown" hidden="false" id="6cee-1baf-715d-24b7" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="All-consuming Obsessions" hidden="false" id="3547-331f-27c6-2123" type="selectionEntryGroup" targetId="f1b1-3fa5-8b01-9ddc"/>
       </entryLinks>
       <modifiers>
         <modifier type="multiply" value="2" field="points">
@@ -1737,6 +1922,7 @@
         <entryLink import="true" name="Paths" hidden="false" id="a8c8-f664-a5b8-5161" type="selectionEntryGroup" targetId="3036-9f76-bbb9-e18a"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="f3e7-847e-f233-83ad" type="selectionEntryGroup" targetId="1331-6d75-79fb-92af"/>
         <entryLink import="true" name="Renown" hidden="false" id="1e4b-502b-203d-1fe5" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="All-consuming Obsessions" hidden="false" id="57a7-eda6-c706-1e52" type="selectionEntryGroup" targetId="f1b1-3fa5-8b01-9ddc"/>
       </entryLinks>
       <modifiers>
         <modifier type="multiply" value="2" field="points">
@@ -1765,6 +1951,7 @@
         <entryLink import="true" name="Paths" hidden="false" id="13bc-89e8-bda1-5744" type="selectionEntryGroup" targetId="3036-9f76-bbb9-e18a"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="d7f1-af27-aabc-995b" type="selectionEntryGroup" targetId="1331-6d75-79fb-92af"/>
         <entryLink import="true" name="Renown" hidden="false" id="ed59-93fa-6bc1-123b" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="All-consuming Obsessions" hidden="false" id="5809-a807-5c6f-5651" type="selectionEntryGroup" targetId="f1b1-3fa5-8b01-9ddc"/>
       </entryLinks>
       <modifiers>
         <modifier type="set" value="true" field="hidden">
@@ -1793,6 +1980,7 @@
         <entryLink import="true" name="Paths" hidden="false" id="e50b-6e97-ebd1-b0b2" type="selectionEntryGroup" targetId="3036-9f76-bbb9-e18a"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="51d6-fcb7-7870-93fc" type="selectionEntryGroup" targetId="1331-6d75-79fb-92af"/>
         <entryLink import="true" name="Renown" hidden="false" id="4296-2dfc-cdf6-a387" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="All-consuming Obsessions" hidden="false" id="6ec9-40d1-e851-e5b7" type="selectionEntryGroup" targetId="f1b1-3fa5-8b01-9ddc"/>
       </entryLinks>
       <modifiers>
         <modifier type="multiply" value="2" field="points">
@@ -1821,6 +2009,7 @@
         <entryLink import="true" name="Paths" hidden="false" id="3003-7573-0b0d-9afa" type="selectionEntryGroup" targetId="3036-9f76-bbb9-e18a"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="442c-519a-7ed4-ca74" type="selectionEntryGroup" targetId="1331-6d75-79fb-92af"/>
         <entryLink import="true" name="Renown" hidden="false" id="8656-1f83-cca6-9e0a" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="All-consuming Obsessions" hidden="false" id="5e14-534d-5f0f-6c5b" type="selectionEntryGroup" targetId="f1b1-3fa5-8b01-9ddc"/>
       </entryLinks>
       <modifiers>
         <modifier type="multiply" value="2" field="points">
@@ -2067,6 +2256,7 @@
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="6afe-e057-94d2-17f2" type="selectionEntryGroup" targetId="1331-6d75-79fb-92af"/>
+        <entryLink import="true" name="All-consuming Obsessions" hidden="false" id="1963-b212-d52d-66bc" type="selectionEntryGroup" targetId="f1b1-3fa5-8b01-9ddc"/>
       </entryLinks>
     </entryLink>
     <entryLink import="true" name="Thricefold Discord" hidden="false" id="40a1-ecaa-7b30-14a4" type="selectionEntry" targetId="2496-8747-e770-79da">
@@ -2129,6 +2319,7 @@
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="c477-c90b-3cd8-7504" type="selectionEntryGroup" targetId="1331-6d75-79fb-92af"/>
+        <entryLink import="true" name="All-consuming Obsessions" hidden="false" id="2f4b-9ba0-d5af-8b04" type="selectionEntryGroup" targetId="f1b1-3fa5-8b01-9ddc"/>
       </entryLinks>
     </entryLink>
     <entryLink import="true" name="Syll&apos;Esske, the Vengeful Allegiance (Scourge of Ghyran)" hidden="false" id="d9c2-48f7-cb40-ca34" type="selectionEntry" targetId="8d85-ce05-2e48-02e9">
@@ -2180,6 +2371,7 @@
         <entryLink import="true" name="Paths" hidden="false" id="792e-e417-f5e4-1c8f" type="selectionEntryGroup" targetId="3036-9f76-bbb9-e18a"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="2a2f-c6bd-1cd7-0e56" type="selectionEntryGroup" targetId="1331-6d75-79fb-92af"/>
         <entryLink import="true" name="Renown" hidden="false" id="f769-d65c-7386-bfc7" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="All-consuming Obsessions" hidden="false" id="0c68-5f48-e051-9a44" type="selectionEntryGroup" targetId="f1b1-3fa5-8b01-9ddc"/>
       </entryLinks>
       <modifiers>
         <modifier type="multiply" value="2" field="points">

--- a/Helsmiths of Hashut.cat
+++ b/Helsmiths of Hashut.cat
@@ -78,6 +78,94 @@ Then, allocate your **daemonic power points** to friendly non-**^^Hobgrot Helsmi
     </selectionEntryGroup>
     <selectionEntryGroup name="Artefacts of Power" id="2be5-91e6-810b-282f" hidden="false">
       <selectionEntryGroups>
+        <selectionEntryGroup name="Dark Gifts of Hashut" id="a117-6d7f-e7f0-cc3a" hidden="true" publicationId="9e18-bb03-7b60-d4ff">
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Gem of Utorak" hidden="false" id="d23a-31ee-c255-bc51">
+              <profiles>
+                <profile name="Gem of Utorak" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="3376-10f4-d0a4-5b2c">
+                  <characteristics>
+                    <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Battle, Your Hero Phase</characteristic>
+                    <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb"/>
+                    <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">If this unit is not a **^^Wizard^^**, it has **^^Wizard (2)^^** until the start of your next turn.
+
+If this unit is a **^^Wizard^^**, until the start of your next turn:
+• Add 1 to this unit’s power level.
+• Add D3 to casting rolls for this unit.</characteristic>
+                    <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+                    <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+                  </characteristics>
+                  <attributes>
+                    <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Yellow</attribute>
+                    <attribute typeId="6d16-c86b-2698-85a4" name="Type">Special</attribute>
+                    <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+                  </attributes>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="11ae-a36c-f19c-e931" includeChildSelections="true"/>
+              </constraints>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Casque of Belittlement" hidden="false" id="e23d-a830-793e-8199">
+              <profiles>
+                <profile name="Casque of Belittlement" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="b34e-3b41-1788-ad7c">
+                  <characteristics>
+                    <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Any Combat Phase</characteristic>
+                    <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick an enemy unit in combat with this unit to be the target.</characteristic>
+                    <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Roll a number of dice equal to your **fury level**. If this unit charged this turn, add 1 to each roll. For each 3+, inflict 1 mortal damage on the target.</characteristic>
+                    <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+                    <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+                  </characteristics>
+                  <attributes>
+                    <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Red</attribute>
+                    <attribute typeId="6d16-c86b-2698-85a4" name="Type">Offensive</attribute>
+                    <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+                  </attributes>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="b7dc-f74f-4b26-6ed5" includeChildSelections="true"/>
+              </constraints>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Horn of the Bullfather" hidden="false" id="ae20-7868-9dd5-371d">
+              <profiles>
+                <profile name="Horn of the Bullfather" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="94d5-2f87-024b-f060">
+                  <characteristics>
+                    <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Deployment Phase</characteristic>
+                    <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick a visible friendly **^^Helsmiths of Hashut^^** unit to be the target. Then, you can pick a visible friendly **^^Hobgrot Vandalz^^** unit to be a second target.</characteristic>
+                    <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Remove each target from the battlefield and set them up again wholly within 7&quot; of the battlefield edge and more than 9&quot; from all enemy units.</characteristic>
+                    <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+                    <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+                  </characteristics>
+                  <attributes>
+                    <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Black</attribute>
+                    <attribute typeId="6d16-c86b-2698-85a4" name="Type">Movement</attribute>
+                    <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+                  </attributes>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="8db9-de9c-b766-a9e1" includeChildSelections="true"/>
+              </constraints>
+            </selectionEntry>
+          </selectionEntries>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="78a1-f6c2-71b8-270a" shared="true"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="0151-9c5b-2f1e-32d4" shared="true" childName="✦ General&apos;s Handbook 2026-27"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <rules>
+            <rule name="Enhancement Restrictions" id="4808-86c5-1eb7-fa6f" hidden="true">
+              <description>**^^Hero^^** only</description>
+            </rule>
+          </rules>
+        </selectionEntryGroup>
         <selectionEntryGroup name="Dark Gifts of Hashut" id="83bd-7696-5c85-233f" hidden="false" publicationId="487d-9798-0633-8040">
           <selectionEntries>
             <selectionEntry type="upgrade" import="true" name="Scroll of Petrification" hidden="false" id="0cd5-aab1-1121-8032">
@@ -472,6 +560,89 @@ Then, allocate your **daemonic power points** to friendly non-**^^Hobgrot Helsmi
     </selectionEntryGroup>
     <selectionEntryGroup name="Accursed Devices" id="d0dc-5188-54c8-6f77" hidden="false">
       <selectionEntryGroups>
+        <selectionEntryGroup name="Accursed Devices: Helsmiths of Hashut" id="86af-42f5-1779-3055" hidden="true" publicationId="9e18-bb03-7b60-d4ff">
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Infernal Motivators" hidden="false" id="2ace-b526-6a90-5b40">
+              <profiles>
+                <profile name="Infernal Motivators" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="ce4a-2d7a-ca4c-455f">
+                  <characteristics>
+                    <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
+                    <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">Add 2&quot; to this unit’s Move characteristic.</characteristic>
+                  </characteristics>
+                  <attributes>
+                    <attribute typeId="50fe-4f29-6bc3-dcc6" name="Color">Gray</attribute>
+                    <attribute typeId="bf11-4e10-3ab1-06f4" name="Type">Movement</attribute>
+                    <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
+                  </attributes>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="f917-6164-b8b8-10c8" includeChildSelections="true"/>
+              </constraints>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Earthwrack Stabilisers" hidden="false" id="2b30-dd7d-0a4d-b086">
+              <profiles>
+                <profile name="Earthwrack Stabilisers" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="8a58-8275-4192-e496">
+                  <characteristics>
+                    <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
+                    <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">Add 1 to the Rend characteristic of this unit’s melee weapons if it has not charged in the same turn.</characteristic>
+                  </characteristics>
+                  <attributes>
+                    <attribute typeId="50fe-4f29-6bc3-dcc6" name="Color">Red</attribute>
+                    <attribute typeId="bf11-4e10-3ab1-06f4" name="Type">Offensive</attribute>
+                    <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
+                  </attributes>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="bd19-7a6d-3618-6086" includeChildSelections="true"/>
+              </constraints>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Bullfather’s Scorn" hidden="false" id="5520-72bf-4d9b-ca07">
+              <profiles>
+                <profile name="Bullfather’s Scorn" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="79d6-4e12-8303-362c">
+                  <characteristics>
+                    <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Your Shooting Phase</characteristic>
+                    <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb"/>
+                    <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">You can spend 1 **rage dice**. If you do:
+• Apply the effect below.
+• If your opponent’s **fury level** is lower than yours, they must increase their **fury level** by 1, to a maximum of 7.
+Otherwise, roll a dice. On a 3+, apply the effect below.
+
+This unit’s ranged weapons have **^^Crit (2 Hits)^^** until the start of your next turn. If each of this unit’s ranged weapons already have **^^Crit (2 Hits)^^**, this unit’s shooting attacks score critical hits on unmodified hit rolls of 5+ until the start of your next turn instead.</characteristic>
+                    <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+                    <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+                  </characteristics>
+                  <attributes>
+                    <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Blue</attribute>
+                    <attribute typeId="6d16-c86b-2698-85a4" name="Type">Shooting</attribute>
+                    <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+                  </attributes>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="6a0d-2529-7a0d-794b" includeChildSelections="true"/>
+              </constraints>
+            </selectionEntry>
+          </selectionEntries>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="78a1-f6c2-71b8-270a" shared="true"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="0151-9c5b-2f1e-32d4" shared="true" childName="✦ General&apos;s Handbook 2026-27"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <rules>
+            <rule name="Enhancement Restrictions" id="0217-28c7-b742-bd07" hidden="true">
+              <description>**^^War Machine^^** only</description>
+            </rule>
+          </rules>
+        </selectionEntryGroup>
         <selectionEntryGroup name="Accursed Devices: Helsmiths of Hashut" id="0455-04af-0dd9-1719" hidden="true" publicationId="f894-7929-f79a-a269">
           <selectionEntries>
             <selectionEntry type="upgrade" import="true" name="Greed Pistons" hidden="false" id="8f46-4718-0522-1964">

--- a/Maggotkin of Nurgle.cat
+++ b/Maggotkin of Nurgle.cat
@@ -469,6 +469,98 @@ the move.</characteristic>
         <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="aa0d-4e72-b554-e1a6" includeChildSelections="true"/>
       </constraints>
     </selectionEntryGroup>
+    <selectionEntryGroup name="Plaguefather&apos;s Poxes" id="6608-e514-cbdd-6174" hidden="false">
+      <selectionEntryGroups>
+        <selectionEntryGroup name="Plaguefather&apos;s Poxes" id="3c54-68f9-2be5-6dac" hidden="true" publicationId="9e18-bb03-7b60-d4ff">
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Snuggling Sickness" hidden="false" id="b3ee-862b-a871-895b">
+              <profiles>
+                <profile name="Snuggling Sickness" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="833a-186d-d79d-92e6">
+                  <characteristics>
+                    <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Any Hero Phase</characteristic>
+                    <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick an enemy unit in combat with this unit to be the target.</characteristic>
+                    <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">For the rest of the turn:
+• Each time the target uses a **^^Retreat^^** ability, if it is in combat with this unit, roll 2D6 as a reaction and add the target’s Control characteristic to the roll. On an 8+, that **^^Retreat^^** ability has no effect.
+• The target cannot be removed from the battlefield by an ability that would allow it to be set up elsewhere on the battlefield or in reserve.</characteristic>
+                    <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+                    <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+                  </characteristics>
+                  <attributes>
+                    <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Yellow</attribute>
+                    <attribute typeId="6d16-c86b-2698-85a4" name="Type">Movement</attribute>
+                    <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+                  </attributes>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="695e-3a31-fc83-982a" includeChildSelections="true"/>
+              </constraints>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Chuckling Murrain" hidden="false" id="e928-0b8b-ff77-dc19">
+              <profiles>
+                <profile name="Chuckling Murrain" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="ec4b-44d8-9986-cc79">
+                  <characteristics>
+                    <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
+                    <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">Your opponent must spend 1 additional **rage dice** for a unit to use the ‘Eruption of Fury’ ability while it is in combat with this unit.
+
+When resolving the damage sequence for enemy units in combat with this unit, each time your opponent would spend **rage dice** as part of the ‘Fight Through the Pain’ ability, they must spend 1 additional **rage dice**.
+
+In both cases, that additional dice does not count towards the number of **rage dice** spent for the purposes of the ability.</characteristic>
+                  </characteristics>
+                  <attributes>
+                    <attribute typeId="50fe-4f29-6bc3-dcc6" name="Color">Black</attribute>
+                    <attribute typeId="bf11-4e10-3ab1-06f4" name="Type">Special</attribute>
+                    <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
+                  </attributes>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="28ea-1775-af3c-b181" includeChildSelections="true"/>
+              </constraints>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="The Weeping Flux" hidden="false" id="3f02-a4f7-da50-7a13">
+              <profiles>
+                <profile name="The Weeping Flux" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="9671-42c0-0c96-760e">
+                  <characteristics>
+                    <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
+                    <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">Each time a model in this unit is slain by a combat attack, roll a number of dice equal to this unit’s Health characteristic. For each 6, inflict 1 mortal damage on the attacking unit.</characteristic>
+                  </characteristics>
+                  <attributes>
+                    <attribute typeId="50fe-4f29-6bc3-dcc6" name="Color">Red</attribute>
+                    <attribute typeId="bf11-4e10-3ab1-06f4" name="Type">Offensive</attribute>
+                    <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
+                  </attributes>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="7cfb-8d87-a196-9df3" includeChildSelections="true"/>
+              </constraints>
+            </selectionEntry>
+          </selectionEntries>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="78a1-f6c2-71b8-270a" shared="true"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="0151-9c5b-2f1e-32d4" shared="true" childName="✦ General&apos;s Handbook 2026-27"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <rules>
+            <rule name="Enhancement Restrictions" id="2f17-79d7-8d45-812f" hidden="true">
+              <description>Plaguefather’s Poxes are unique enhancements that can be given to non-**^^Hero^^** **^^Maggotkin of Nurgle^^** units. A unit can only have 1 Plaguefather’s Pox.</description>
+            </rule>
+          </rules>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <constraints>
+        <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="9da2-87b8-be6d-700b" includeChildSelections="true"/>
+        <constraint type="max" value="1" field="selections" scope="root-entry" shared="true" id="9de0-8879-683a-104c"/>
+      </constraints>
+    </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <sharedSelectionEntries>
     <selectionEntry type="upgrade" import="true" name="Battle Traits: Maggotkin of Nurgle" hidden="false" id="27d6-7ce0-8f51-c075">
@@ -1457,6 +1549,7 @@ the move.</characteristic>
         <entryLink import="true" name="Paths" hidden="false" id="7841-44f0-1fac-7103" type="selectionEntryGroup" targetId="980a-fb59-b159-7706"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="f694-9e8b-1938-4031" type="selectionEntryGroup" targetId="70e9-0585-750d-6663"/>
         <entryLink import="true" name="Renown" hidden="false" id="9336-e387-c905-ccd1" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Plaguefather&apos;s Poxes" hidden="false" id="ffe2-b9d8-e603-4f0c" type="selectionEntryGroup" targetId="6608-e514-cbdd-6174"/>
       </entryLinks>
     </entryLink>
     <entryLink import="true" name="Nurglings" hidden="false" id="787f-8a7a-8596-54b1" type="selectionEntry" targetId="3495-8e1e-11c-5784">
@@ -1482,6 +1575,7 @@ the move.</characteristic>
         <entryLink import="true" name="Paths" hidden="false" id="81b6-631d-05c5-e4ae" type="selectionEntryGroup" targetId="980a-fb59-b159-7706"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="1897-f65b-079a-42b0" type="selectionEntryGroup" targetId="70e9-0585-750d-6663"/>
         <entryLink import="true" name="Renown" hidden="false" id="4ebd-8841-07ba-abb4" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Plaguefather&apos;s Poxes" hidden="false" id="b1d2-cfb7-9def-aa26" type="selectionEntryGroup" targetId="6608-e514-cbdd-6174"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="100"/>
@@ -1510,6 +1604,7 @@ the move.</characteristic>
         <entryLink import="true" name="Paths" hidden="false" id="5250-eac2-6951-b6da" type="selectionEntryGroup" targetId="980a-fb59-b159-7706"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="a7d6-161a-8fbb-5194" type="selectionEntryGroup" targetId="70e9-0585-750d-6663"/>
         <entryLink import="true" name="Renown" hidden="false" id="8348-150a-8923-e4fb" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Plaguefather&apos;s Poxes" hidden="false" id="a1eb-2c5e-b5e5-2f38" type="selectionEntryGroup" targetId="6608-e514-cbdd-6174"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="150"/>
@@ -1548,6 +1643,7 @@ the move.</characteristic>
         <entryLink import="true" name="Paths" hidden="false" id="e6a6-5800-cc0d-8472" type="selectionEntryGroup" targetId="980a-fb59-b159-7706"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="fad9-8493-5d89-b429" type="selectionEntryGroup" targetId="70e9-0585-750d-6663"/>
         <entryLink import="true" name="Renown" hidden="false" id="fe94-fdc2-70bb-a609" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Plaguefather&apos;s Poxes" hidden="false" id="6e05-b120-9e17-7dd1" type="selectionEntryGroup" targetId="6608-e514-cbdd-6174"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="130"/>
@@ -1579,6 +1675,7 @@ the move.</characteristic>
         <entryLink import="true" name="Paths" hidden="false" id="ec6b-ff68-6803-7d93" type="selectionEntryGroup" targetId="980a-fb59-b159-7706"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="58d0-1db5-77ed-5da3" type="selectionEntryGroup" targetId="70e9-0585-750d-6663"/>
         <entryLink import="true" name="Renown" hidden="false" id="c4e3-4f61-9f9e-16c5" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Plaguefather&apos;s Poxes" hidden="false" id="2207-ab53-c34c-924c" type="selectionEntryGroup" targetId="6608-e514-cbdd-6174"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="190"/>
@@ -1616,6 +1713,7 @@ the move.</characteristic>
         <entryLink import="true" name="Paths" hidden="false" id="ce6d-67da-d1a2-a974" type="selectionEntryGroup" targetId="980a-fb59-b159-7706"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="e9d3-37fa-c646-d9b5" type="selectionEntryGroup" targetId="70e9-0585-750d-6663"/>
         <entryLink import="true" name="Renown" hidden="false" id="824a-c9fc-5ef7-d0f0" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Plaguefather&apos;s Poxes" hidden="false" id="0e16-8f49-9f5d-d9ff" type="selectionEntryGroup" targetId="6608-e514-cbdd-6174"/>
       </entryLinks>
     </entryLink>
     <entryLink import="true" name="Putrid Blightkings" hidden="false" id="5302-b2e9-5197-6c81" type="selectionEntry" targetId="9951-ae95-5386-f8cf">
@@ -1641,6 +1739,7 @@ the move.</characteristic>
         <entryLink import="true" name="Paths" hidden="false" id="8d65-83d4-263a-467d" type="selectionEntryGroup" targetId="980a-fb59-b159-7706"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="6c75-2764-17d4-d3df" type="selectionEntryGroup" targetId="70e9-0585-750d-6663"/>
         <entryLink import="true" name="Renown" hidden="false" id="409f-d916-cc64-7399" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Plaguefather&apos;s Poxes" hidden="false" id="b7d8-c4e0-b38c-e5f8" type="selectionEntryGroup" targetId="6608-e514-cbdd-6174"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="130"/>
@@ -1669,6 +1768,7 @@ the move.</characteristic>
         <entryLink import="true" name="Paths" hidden="false" id="35c7-5e52-ad14-4885" type="selectionEntryGroup" targetId="980a-fb59-b159-7706"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="ae3c-ce02-731e-931c" type="selectionEntryGroup" targetId="70e9-0585-750d-6663"/>
         <entryLink import="true" name="Renown" hidden="false" id="04ec-80e0-09f8-2b8a" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Plaguefather&apos;s Poxes" hidden="false" id="17f0-7779-71ff-0172" type="selectionEntryGroup" targetId="6608-e514-cbdd-6174"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="140"/>
@@ -1694,6 +1794,7 @@ the move.</characteristic>
         <entryLink import="true" name="Paths" hidden="false" id="bc81-57c9-f978-bd86" type="selectionEntryGroup" targetId="980a-fb59-b159-7706"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="bfe3-85b1-bf55-5242" type="selectionEntryGroup" targetId="70e9-0585-750d-6663"/>
         <entryLink import="true" name="Renown" hidden="false" id="f86f-1662-656e-0e81" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Plaguefather&apos;s Poxes" hidden="false" id="0541-aa45-a961-a911" type="selectionEntryGroup" targetId="6608-e514-cbdd-6174"/>
       </entryLinks>
     </entryLink>
     <entryLink import="true" name="Epidemius, Tallyman of Nurgle" hidden="false" id="531a-84bb-ea1c-428a" type="selectionEntry" targetId="5b0d-37e4-73a4-f952">
@@ -1815,6 +1916,7 @@ the move.</characteristic>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="8fd0-332e-391d-3181" type="selectionEntryGroup" targetId="70e9-0585-750d-6663"/>
+        <entryLink import="true" name="Plaguefather&apos;s Poxes" hidden="false" id="6019-b983-be06-c188" type="selectionEntryGroup" targetId="6608-e514-cbdd-6174"/>
       </entryLinks>
     </entryLink>
     <entryLink import="true" name="Feculent Gnarlmaw" hidden="false" id="1918-e7dc-8772-38ec" type="selectionEntry" targetId="f4aa-9ef3-286-f6db" defaultAmount="1"/>
@@ -1836,6 +1938,7 @@ the move.</characteristic>
       </modifiers>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="2525-534b-2de3-5485" type="selectionEntryGroup" targetId="70e9-0585-750d-6663"/>
+        <entryLink import="true" name="Plaguefather&apos;s Poxes" hidden="false" id="c165-5e8a-9682-58e6" type="selectionEntryGroup" targetId="6608-e514-cbdd-6174"/>
       </entryLinks>
     </entryLink>
     <entryLink import="true" name="Rotigus (Scourge of Ghyran)" hidden="false" id="6e94-3722-303e-6728" type="selectionEntry" targetId="d5ae-2efe-d4e1-01a1">
@@ -2171,6 +2274,7 @@ the move.</characteristic>
         <entryLink import="true" name="Paths" hidden="false" id="d4d4-e498-3d94-ed5f" type="selectionEntryGroup" targetId="980a-fb59-b159-7706"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="96c1-7af3-3a4f-df07" type="selectionEntryGroup" targetId="70e9-0585-750d-6663"/>
         <entryLink import="true" name="Renown" hidden="false" id="3276-119d-0450-cce9" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Plaguefather&apos;s Poxes" hidden="false" id="f0a3-7173-4c14-65da" type="selectionEntryGroup" targetId="6608-e514-cbdd-6174"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="110"/>
@@ -2199,6 +2303,7 @@ the move.</characteristic>
         <entryLink import="true" name="Paths" hidden="false" id="66f0-fe19-8167-0b02" type="selectionEntryGroup" targetId="980a-fb59-b159-7706"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="1000-4823-ef83-7317" type="selectionEntryGroup" targetId="70e9-0585-750d-6663"/>
         <entryLink import="true" name="Renown" hidden="false" id="4e3a-94d5-60c9-7692" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Plaguefather&apos;s Poxes" hidden="false" id="0f5f-46f9-3566-c962" type="selectionEntryGroup" targetId="6608-e514-cbdd-6174"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="180"/>
@@ -2227,6 +2332,7 @@ the move.</characteristic>
         <entryLink import="true" name="Paths" hidden="false" id="5943-ad99-fe2d-460c" type="selectionEntryGroup" targetId="980a-fb59-b159-7706"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="2b59-4beb-7c6f-10a9" type="selectionEntryGroup" targetId="70e9-0585-750d-6663"/>
         <entryLink import="true" name="Renown" hidden="false" id="efed-8a15-9dd0-bee0" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Plaguefather&apos;s Poxes" hidden="false" id="56d6-67e9-5d42-4d70" type="selectionEntryGroup" targetId="6608-e514-cbdd-6174"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="210"/>
@@ -2255,6 +2361,7 @@ the move.</characteristic>
         <entryLink import="true" name="Paths" hidden="false" id="a7bc-c951-31f8-fbc8" type="selectionEntryGroup" targetId="980a-fb59-b159-7706"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="9553-9541-14fc-e4df" type="selectionEntryGroup" targetId="70e9-0585-750d-6663"/>
         <entryLink import="true" name="Renown" hidden="false" id="f746-0a6c-400a-49a6" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Plaguefather&apos;s Poxes" hidden="false" id="0621-ab4e-10c1-efb9" type="selectionEntryGroup" targetId="6608-e514-cbdd-6174"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="210"/>
@@ -2283,6 +2390,7 @@ the move.</characteristic>
         <entryLink import="true" name="Paths" hidden="false" id="b8bd-456e-47de-aeb0" type="selectionEntryGroup" targetId="980a-fb59-b159-7706"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="2ede-cc36-e535-f32e" type="selectionEntryGroup" targetId="70e9-0585-750d-6663"/>
         <entryLink import="true" name="Renown" hidden="false" id="1162-63bc-e136-ed08" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Plaguefather&apos;s Poxes" hidden="false" id="1f98-3fa6-a3f2-c27f" type="selectionEntryGroup" targetId="6608-e514-cbdd-6174"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="140"/>

--- a/Skaven.cat
+++ b/Skaven.cat
@@ -371,6 +371,82 @@ of the unit using the ‘Redeploy’ command to be the targets. Each target mus
     </selectionEntryGroup>
     <selectionEntryGroup name="Heroic Traits" id="26fc-3985-5b0a-b181" hidden="false">
       <selectionEntryGroups>
+        <selectionEntryGroup name="Devious Machinations" id="fae1-f9f0-a876-8cee" hidden="true" publicationId="9e18-bb03-7b60-d4ff">
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Masterclan Connections" hidden="false" id="918e-f0e7-d0ff-15df">
+              <profiles>
+                <profile name="Masterclan Connections" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="3b13-01cd-32ff-76ee">
+                  <characteristics>
+                    <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Reaction: You declared a **^^Spell^^** or **^^Unbind^^** ability for a visible **^^Skaven^^** unit wholly within 13&quot; of this unit</characteristic>
+                    <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb"/>
+                    <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Add D3 to that casting roll or unbinding roll.</characteristic>
+                    <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+                    <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+                  </characteristics>
+                  <attributes>
+                    <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Yellow</attribute>
+                    <attribute typeId="6d16-c86b-2698-85a4" name="Type">Special</attribute>
+                    <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+                  </attributes>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="d965-4bd3-712b-cc19" includeChildSelections="true"/>
+              </constraints>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Master of the Swarm" hidden="false" id="dc9a-3a24-be3e-dd7c">
+              <profiles>
+                <profile name="Master of the Swarm" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="2076-18aa-9ff6-f906">
+                  <characteristics>
+                    <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
+                    <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">Each time an ability returns 1 or more slain models to a friendly **^^Skaven^^** unit wholly within 13&quot; of this unit, after that ability has been resolved, you can return 1 additional slain model to it.</characteristic>
+                  </characteristics>
+                  <attributes>
+                    <attribute typeId="50fe-4f29-6bc3-dcc6" name="Color">Black</attribute>
+                    <attribute typeId="bf11-4e10-3ab1-06f4" name="Type">Rallying</attribute>
+                    <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
+                  </attributes>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="5e40-2ad7-d83e-85c0" includeChildSelections="true"/>
+              </constraints>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Essence of the Gnaw" hidden="false" id="1163-7b0f-9e99-9879">
+              <profiles>
+                <profile name="Essence of the Gnaw" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="24a0-cc95-691b-c3d2">
+                  <characteristics>
+                    <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Any Combat Phase</characteristic>
+                    <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick another visible **^^Skaven^^** unit wholly within 13&quot; of this unit and in combat to be the target.</characteristic>
+                    <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">For the rest of the turn, this unit has **^^Strike-first^^** and the target has **^^Strike-last^^**.</characteristic>
+                    <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+                    <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+                  </characteristics>
+                  <attributes>
+                    <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Red</attribute>
+                    <attribute typeId="6d16-c86b-2698-85a4" name="Type">Offensive</attribute>
+                    <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+                  </attributes>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="64e3-de90-712a-6833" includeChildSelections="true"/>
+              </constraints>
+            </selectionEntry>
+          </selectionEntries>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="78a1-f6c2-71b8-270a" shared="true"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="0151-9c5b-2f1e-32d4" shared="true" childName="✦ General&apos;s Handbook 2026-27"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </selectionEntryGroup>
         <selectionEntryGroup name="Devious Machinators" id="1371-6ee2-7325-2f1c" hidden="false" publicationId="40f6-9b64-7daa-d1c8">
           <selectionEntries>
             <selectionEntry type="upgrade" import="true" name="Short-tempered" hidden="false" id="ae10-7478-7f72-642a">
@@ -615,6 +691,99 @@ of the unit using the ‘Redeploy’ command to be the targets. Each target mus
       </modifiers>
       <constraints>
         <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="92e5-23cd-b8cb-e5fe"/>
+      </constraints>
+    </selectionEntryGroup>
+    <selectionEntryGroup name="Moulder Mutations" id="16d4-5922-ea32-43b4" hidden="false">
+      <selectionEntryGroups>
+        <selectionEntryGroup name="Moulder Mutations" id="a82b-1fd7-f79d-411f" hidden="true" publicationId="9e18-bb03-7b60-d4ff">
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Transplanted Brains" hidden="false" id="924a-ff8e-9122-3fa8">
+              <profiles>
+                <profile name="Transplanted Brains" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="812f-2cbc-160d-7ff6">
+                  <characteristics>
+                    <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Any Hero Phase</characteristic>
+                    <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb"/>
+                    <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Pick 1 of the following brains. Its effects apply for the rest of the turn:
+**Warpstone Addict’s Brain:**
+• Add 1 to hit rolls for this unit’s combat attacks.
+• This unit has a maximum control score of 1.
+**Warlock Whelp’s Brain:** Add 10 to this unit’s control score.</characteristic>
+                    <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+                    <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+                  </characteristics>
+                  <attributes>
+                    <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Yellow</attribute>
+                    <attribute typeId="6d16-c86b-2698-85a4" name="Type">Special</attribute>
+                    <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+                  </attributes>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="1587-4f35-07e9-73df" includeChildSelections="true"/>
+              </constraints>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Anabolic Accelerators" hidden="false" id="21f8-42bd-2ab3-8f73">
+              <profiles>
+                <profile name="Anabolic Accelerators" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="c37a-7f9b-ed03-cae3">
+                  <characteristics>
+                    <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Your Charge Phase</characteristic>
+                    <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb"/>
+                    <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">If this unit was set up this turn, when making charge rolls for this unit, add 1 to the number of dice rolled, to a maximum of 3, then remove 1 dice of your choice and use the remaining dice as the charge roll.</characteristic>
+                    <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+                    <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+                  </characteristics>
+                  <attributes>
+                    <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Orange</attribute>
+                    <attribute typeId="6d16-c86b-2698-85a4" name="Type">Movement</attribute>
+                    <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+                  </attributes>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="0fce-2801-06e7-3bf7" includeChildSelections="true"/>
+              </constraints>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Serrated Bone Protrusions" hidden="false" id="0696-95e6-c3d1-2670">
+              <profiles>
+                <profile name="Serrated Bone Protrusions" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="c4ee-8dfa-13ce-b753">
+                  <characteristics>
+                    <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
+                    <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">For each unmodified hit roll of 1 for a combat attack made by an enemy unit that targets this unit, inflict 1 mortal damage on the attacking unit after the **^^Fight^^** ability has been resolved.</characteristic>
+                  </characteristics>
+                  <attributes>
+                    <attribute typeId="50fe-4f29-6bc3-dcc6" name="Color">Red</attribute>
+                    <attribute typeId="bf11-4e10-3ab1-06f4" name="Type">Offensive</attribute>
+                    <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
+                  </attributes>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="eeac-4f6a-6173-1156" includeChildSelections="true"/>
+              </constraints>
+            </selectionEntry>
+          </selectionEntries>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="78a1-f6c2-71b8-270a" shared="true"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="0151-9c5b-2f1e-32d4" shared="true" childName="✦ General&apos;s Handbook 2026-27"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <rules>
+            <rule name="Enhancement Restrictions" id="f6cc-5bf0-5669-4c91" hidden="true">
+              <description>Moulder Mutations are unique enhancements that can be given to non-**^^Hero^^** non-**^^War Machine^^** **^^Skaven^^** units. A unit can only have 1 Moulder Mutation.</description>
+            </rule>
+          </rules>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <constraints>
+        <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="5f85-74e1-61d1-2522" includeChildSelections="true"/>
+        <constraint type="max" value="1" field="selections" scope="root-entry" shared="true" id="9186-1c31-96b3-e689"/>
       </constraints>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
@@ -1659,6 +1828,7 @@ of the unit using the ‘Redeploy’ command to be the targets. Each target mus
         <entryLink import="true" name="Paths" hidden="false" id="f81f-a1af-f48b-2893" type="selectionEntryGroup" targetId="9e59-94d3-7bfe-3534"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="01b3-807d-306a-4fe4" type="selectionEntryGroup" targetId="462c-2914-b583-1688"/>
         <entryLink import="true" name="Renown" hidden="false" id="1a92-60c0-8783-cd9b" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Moulder Mutations" hidden="false" id="9f23-5170-1c88-a743" type="selectionEntryGroup" targetId="16d4-5922-ea32-43b4"/>
       </entryLinks>
       <modifiers>
         <modifier type="multiply" value="2" field="points">
@@ -1725,6 +1895,7 @@ of the unit using the ‘Redeploy’ command to be the targets. Each target mus
         <entryLink import="true" name="Paths" hidden="false" id="9c41-3784-04b6-3060" type="selectionEntryGroup" targetId="9e59-94d3-7bfe-3534"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="a0c3-6a16-64d6-bfd5" type="selectionEntryGroup" targetId="462c-2914-b583-1688"/>
         <entryLink import="true" name="Renown" hidden="false" id="f9ab-8876-1558-feba" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Moulder Mutations" hidden="false" id="ed9d-3a8e-fb32-4099" type="selectionEntryGroup" targetId="16d4-5922-ea32-43b4"/>
       </entryLinks>
       <modifiers>
         <modifier type="multiply" value="2" field="points">
@@ -1956,6 +2127,7 @@ of the unit using the ‘Redeploy’ command to be the targets. Each target mus
         <entryLink import="true" name="Paths" hidden="false" id="df22-8a6a-1921-cd10" type="selectionEntryGroup" targetId="9e59-94d3-7bfe-3534"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="538b-daa0-fbbc-2959" type="selectionEntryGroup" targetId="462c-2914-b583-1688"/>
         <entryLink import="true" name="Renown" hidden="false" id="0ba2-70d5-192e-dfea" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Moulder Mutations" hidden="false" id="1319-c5b9-96ea-3efa" type="selectionEntryGroup" targetId="16d4-5922-ea32-43b4"/>
       </entryLinks>
       <modifiers>
         <modifier type="multiply" value="2" field="points">
@@ -2003,6 +2175,7 @@ of the unit using the ‘Redeploy’ command to be the targets. Each target mus
         <entryLink import="true" name="Paths" hidden="false" id="f2cd-de38-5f15-a0a9" type="selectionEntryGroup" targetId="9e59-94d3-7bfe-3534"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="777e-9503-f629-e995" type="selectionEntryGroup" targetId="462c-2914-b583-1688"/>
         <entryLink import="true" name="Renown" hidden="false" id="bc8e-569a-4682-5271" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Moulder Mutations" hidden="false" id="13ec-7698-344c-15ef" type="selectionEntryGroup" targetId="16d4-5922-ea32-43b4"/>
       </entryLinks>
     </entryLink>
     <entryLink import="true" name="Plague Censer Bearers" hidden="false" id="5d77-22a3-e306-b1cd" type="selectionEntry" targetId="1d37-8688-0cdd-434b">
@@ -2011,6 +2184,7 @@ of the unit using the ‘Redeploy’ command to be the targets. Each target mus
         <entryLink import="true" name="Paths" hidden="false" id="f0e4-ec6c-25ec-6a03" type="selectionEntryGroup" targetId="9e59-94d3-7bfe-3534"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="703f-d3fc-5063-8a63" type="selectionEntryGroup" targetId="462c-2914-b583-1688"/>
         <entryLink import="true" name="Renown" hidden="false" id="2331-77c4-25fb-3e04" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Moulder Mutations" hidden="false" id="5ae4-dc8a-7fbc-86d6" type="selectionEntryGroup" targetId="16d4-5922-ea32-43b4"/>
       </entryLinks>
       <modifiers>
         <modifier type="multiply" value="2" field="points">
@@ -2066,6 +2240,7 @@ of the unit using the ‘Redeploy’ command to be the targets. Each target mus
         <entryLink import="true" name="Paths" hidden="false" id="2e89-6758-1b5b-5a8d" type="selectionEntryGroup" targetId="9e59-94d3-7bfe-3534"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="f4f0-6874-cce8-b236" type="selectionEntryGroup" targetId="462c-2914-b583-1688"/>
         <entryLink import="true" name="Renown" hidden="false" id="560f-96de-da79-0513" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Moulder Mutations" hidden="false" id="8cdd-38bf-99cd-0a3a" type="selectionEntryGroup" targetId="16d4-5922-ea32-43b4"/>
       </entryLinks>
       <modifiers>
         <modifier type="multiply" value="2" field="points">
@@ -2152,6 +2327,7 @@ of the unit using the ‘Redeploy’ command to be the targets. Each target mus
         <entryLink import="true" name="Paths" hidden="false" id="b334-00dc-6634-5373" type="selectionEntryGroup" targetId="9e59-94d3-7bfe-3534"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="b014-f607-2e81-a017" type="selectionEntryGroup" targetId="462c-2914-b583-1688"/>
         <entryLink import="true" name="Renown" hidden="false" id="04ae-4ed2-6779-1dcc" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Moulder Mutations" hidden="false" id="435c-21f3-6464-265f" type="selectionEntryGroup" targetId="16d4-5922-ea32-43b4"/>
       </entryLinks>
     </entryLink>
     <entryLink import="true" name="Ratling Warpblaster" hidden="false" id="400f-c9f7-c20d-8316" type="selectionEntry" targetId="6792-1e93-a367-95c8">
@@ -2232,6 +2408,7 @@ of the unit using the ‘Redeploy’ command to be the targets. Each target mus
         <entryLink import="true" name="Paths" hidden="false" id="0e46-0464-fef7-e4fb" type="selectionEntryGroup" targetId="9e59-94d3-7bfe-3534"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="a5c7-3413-631e-6170" type="selectionEntryGroup" targetId="462c-2914-b583-1688"/>
         <entryLink import="true" name="Renown" hidden="false" id="61f8-36cd-06d4-16c3" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Moulder Mutations" hidden="false" id="885e-0cb7-a181-22fe" type="selectionEntryGroup" targetId="16d4-5922-ea32-43b4"/>
       </entryLinks>
       <modifiers>
         <modifier type="multiply" value="2" field="points">
@@ -2260,6 +2437,7 @@ of the unit using the ‘Redeploy’ command to be the targets. Each target mus
         <entryLink import="true" name="Paths" hidden="false" id="b933-c3b5-6773-c9a9" type="selectionEntryGroup" targetId="9e59-94d3-7bfe-3534"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="06dc-64e8-9456-bcf7" type="selectionEntryGroup" targetId="462c-2914-b583-1688"/>
         <entryLink import="true" name="Renown" hidden="false" id="aecb-a514-156c-11ee" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Moulder Mutations" hidden="false" id="593e-cbb9-1bb4-fae3" type="selectionEntryGroup" targetId="16d4-5922-ea32-43b4"/>
       </entryLinks>
       <modifiers>
         <modifier type="multiply" value="2" field="points">
@@ -2418,6 +2596,7 @@ of the unit using the ‘Redeploy’ command to be the targets. Each target mus
         <entryLink import="true" name="Paths" hidden="false" id="877d-73f0-7d37-a50a" type="selectionEntryGroup" targetId="9e59-94d3-7bfe-3534"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="4ef3-8802-3f29-886a" type="selectionEntryGroup" targetId="462c-2914-b583-1688"/>
         <entryLink import="true" name="Renown" hidden="false" id="4c7b-24bb-c112-f5fe" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Moulder Mutations" hidden="false" id="33ac-d108-b045-6b58" type="selectionEntryGroup" targetId="16d4-5922-ea32-43b4"/>
       </entryLinks>
     </entryLink>
     <entryLink import="true" name="Warplock Jezzails" hidden="false" id="9f75-2b2f-ba5e-d517" type="selectionEntry" targetId="160-3400-6da6-eb08">
@@ -2426,6 +2605,7 @@ of the unit using the ‘Redeploy’ command to be the targets. Each target mus
         <entryLink import="true" name="Paths" hidden="false" id="28ac-1424-4264-b33b" type="selectionEntryGroup" targetId="9e59-94d3-7bfe-3534"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="db99-a023-13c5-4d65" type="selectionEntryGroup" targetId="462c-2914-b583-1688"/>
         <entryLink import="true" name="Renown" hidden="false" id="12a6-76fa-f710-df51" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Moulder Mutations" hidden="false" id="d50b-5093-0f54-7141" type="selectionEntryGroup" targetId="16d4-5922-ea32-43b4"/>
       </entryLinks>
       <modifiers>
         <modifier type="multiply" value="2" field="points">
@@ -2510,6 +2690,7 @@ of the unit using the ‘Redeploy’ command to be the targets. Each target mus
         <entryLink import="true" name="Paths" hidden="false" id="0680-d0a6-d189-674d" type="selectionEntryGroup" targetId="9e59-94d3-7bfe-3534"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="39e8-12fb-7111-4ea3" type="selectionEntryGroup" targetId="462c-2914-b583-1688"/>
         <entryLink import="true" name="Renown" hidden="false" id="691a-21fe-110a-9030" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Moulder Mutations" hidden="false" id="2830-b5cd-0b45-92f4" type="selectionEntryGroup" targetId="16d4-5922-ea32-43b4"/>
       </entryLinks>
       <modifiers>
         <modifier type="multiply" value="2" field="points">
@@ -2555,6 +2736,7 @@ of the unit using the ‘Redeploy’ command to be the targets. Each target mus
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="12fb-8895-2f22-d707" type="selectionEntryGroup" targetId="462c-2914-b583-1688"/>
+        <entryLink import="true" name="Moulder Mutations" hidden="false" id="aa91-7c07-6191-e7fc" type="selectionEntryGroup" targetId="16d4-5922-ea32-43b4"/>
       </entryLinks>
     </entryLink>
     <entryLink import="true" name="Spiteclaw&apos;s Swarm" hidden="false" id="9f7c-b30b-7595-6f8a" type="selectionEntry" targetId="6459-a4be-e73f-7222">
@@ -2580,6 +2762,7 @@ of the unit using the ‘Redeploy’ command to be the targets. Each target mus
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="c34f-4981-eaec-743f" type="selectionEntryGroup" targetId="462c-2914-b583-1688"/>
+        <entryLink import="true" name="Moulder Mutations" hidden="false" id="6ab5-cba2-cd07-3866" type="selectionEntryGroup" targetId="16d4-5922-ea32-43b4"/>
       </entryLinks>
     </entryLink>
     <entryLink import="true" name="Skittershank&apos;s Clawpack" hidden="false" id="68c9-857a-7a23-b195" type="selectionEntry" targetId="3c80-fb87-4ba2-326c">
@@ -2605,6 +2788,7 @@ of the unit using the ‘Redeploy’ command to be the targets. Each target mus
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="9ddc-1f5e-ccfe-98f2" type="selectionEntryGroup" targetId="462c-2914-b583-1688"/>
+        <entryLink import="true" name="Moulder Mutations" hidden="false" id="ebc5-d529-81fd-390e" type="selectionEntryGroup" targetId="16d4-5922-ea32-43b4"/>
       </entryLinks>
     </entryLink>
     <entryLink import="true" name="Brood Terror" hidden="false" id="9659-8454-494e-94dd" type="selectionEntry" targetId="4a53-c768-57de-d622">
@@ -2632,6 +2816,7 @@ of the unit using the ‘Redeploy’ command to be the targets. Each target mus
         <entryLink import="true" name="Paths" hidden="false" id="76ac-935b-9187-4bef" type="selectionEntryGroup" targetId="9e59-94d3-7bfe-3534"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="9937-aa0b-ebbb-fffa" type="selectionEntryGroup" targetId="462c-2914-b583-1688"/>
         <entryLink import="true" name="Renown" hidden="false" id="7ca2-69ea-ed7a-eea2" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Moulder Mutations" hidden="false" id="6aab-3762-e2a4-43b1" type="selectionEntryGroup" targetId="16d4-5922-ea32-43b4"/>
       </entryLinks>
     </entryLink>
     <entryLink import="true" name="Krittok Foulblade" hidden="false" id="a9a9-9048-a1b8-3fe7" type="selectionEntry" targetId="64d0-3abe-62b7-7e40">
@@ -2743,6 +2928,7 @@ of the unit using the ‘Redeploy’ command to be the targets. Each target mus
         <entryLink import="true" name="Paths" hidden="false" id="8ad3-72fc-0e88-c91a" type="selectionEntryGroup" targetId="9e59-94d3-7bfe-3534"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="3b71-49fe-3337-004a" type="selectionEntryGroup" targetId="462c-2914-b583-1688"/>
         <entryLink import="true" name="Renown" hidden="false" id="0ac9-217d-0c63-7413" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Moulder Mutations" hidden="false" id="fc38-7c0e-d34c-5100" type="selectionEntryGroup" targetId="16d4-5922-ea32-43b4"/>
       </entryLinks>
     </entryLink>
     <entryLink import="true" name="Warlock Galvaneer" hidden="false" id="5a48-e3a1-625c-dae1" type="selectionEntry" targetId="05dd-ab28-998d-8cca">
@@ -2886,6 +3072,7 @@ of the unit using the ‘Redeploy’ command to be the targets. Each target mus
         <entryLink import="true" name="Paths" hidden="false" id="e1cb-21d2-6e21-5b03" type="selectionEntryGroup" targetId="9e59-94d3-7bfe-3534"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="a7b7-5dc3-e53c-c168" type="selectionEntryGroup" targetId="462c-2914-b583-1688"/>
         <entryLink import="true" name="Renown" hidden="false" id="32bf-c9a9-33bf-de07" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Moulder Mutations" hidden="false" id="11ba-f957-8231-c6af" type="selectionEntryGroup" targetId="16d4-5922-ea32-43b4"/>
       </entryLinks>
       <modifiers>
         <modifier type="multiply" value="2" field="points">
@@ -2964,6 +3151,7 @@ of the unit using the ‘Redeploy’ command to be the targets. Each target mus
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="bf61-cc6f-9634-7fd3" type="selectionEntryGroup" targetId="462c-2914-b583-1688"/>
+        <entryLink import="true" name="Moulder Mutations" hidden="false" id="3a45-754c-85bc-980e" type="selectionEntryGroup" targetId="16d4-5922-ea32-43b4"/>
       </entryLinks>
     </entryLink>
     <entryLink import="true" name="Anvil of Apotheosis: Skaven Hero" hidden="true" id="1337-7381-222c-4712" type="selectionEntry" targetId="c011-fb8c-500a-e727">
@@ -3008,6 +3196,7 @@ of the unit using the ‘Redeploy’ command to be the targets. Each target mus
         <entryLink import="true" name="Renown" hidden="false" id="cd62-af06-4133-c54f" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="8c97-2f1f-0ad1-c7aa" type="selectionEntryGroup" targetId="462c-2914-b583-1688"/>
         <entryLink import="true" name="Paths" hidden="false" id="1ecf-4632-233e-2ccb" type="selectionEntryGroup" targetId="9e59-94d3-7bfe-3534"/>
+        <entryLink import="true" name="Moulder Mutations" hidden="false" id="4813-c81e-e95a-0703" type="selectionEntryGroup" targetId="16d4-5922-ea32-43b4"/>
       </entryLinks>
       <modifiers>
         <modifier type="multiply" value="2" field="points">
@@ -3080,6 +3269,7 @@ of the unit using the ‘Redeploy’ command to be the targets. Each target mus
         <entryLink import="true" name="Paths" hidden="false" id="ba9f-c133-1b2e-aff2" type="selectionEntryGroup" targetId="9e59-94d3-7bfe-3534"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="2649-5999-05f5-9a2f" type="selectionEntryGroup" targetId="462c-2914-b583-1688"/>
         <entryLink import="true" name="Renown" hidden="false" id="b4cc-9108-2bdf-b893" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Moulder Mutations" hidden="false" id="3bd2-d59e-ac1f-60ae" type="selectionEntryGroup" targetId="16d4-5922-ea32-43b4"/>
       </entryLinks>
       <modifiers>
         <modifier type="multiply" value="2" field="points">

--- a/Slaves to Darkness.cat
+++ b/Slaves to Darkness.cat
@@ -18,6 +18,89 @@
     </selectionEntryGroup>
     <selectionEntryGroup name="Artefacts of Power" id="a81-fa40-378b-46e8" hidden="false">
       <selectionEntryGroups>
+        <selectionEntryGroup name="Infernal Treasures" id="0609-3ed9-fbb8-8e7b" hidden="true" publicationId="9e18-bb03-7b60-d4ff">
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Aelfskin Scroll" hidden="false" id="4043-02c7-07b0-f659">
+              <profiles>
+                <profile name="Aelfskin Scroll" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="d6a7-0b3b-da75-b942">
+                  <characteristics>
+                    <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Battle, Reaction: Opponent declared a **^^Spell^^** ability for a **^^Wizard^^** within 18&quot; of this unit</characteristic>
+                    <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb"/>
+                    <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Pick a visible friendly **^^Slaves to Darkness^^** **^^Wizard^^** within 18&quot; of this unit. After that **^^Spell^^** ability has been resolved, that friendly **^^Wizard^^** can use a **^^Spell^^** ability as if it were your hero phase, and the casting roll for that spell is equal to the casting roll for that enemy spell. Do not count that spell towards the number of **^^Spell^^** abilities that friendly **^^Wizard^^** can use this phase.</characteristic>
+                    <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+                    <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+                  </characteristics>
+                  <attributes>
+                    <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Yellow</attribute>
+                    <attribute typeId="6d16-c86b-2698-85a4" name="Type">Special</attribute>
+                    <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+                  </attributes>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="3159-2823-1fa3-e4c4" includeChildSelections="true"/>
+              </constraints>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Rune of Murder" hidden="false" id="a75f-ad70-53ae-5f15">
+              <profiles>
+                <profile name="Rune of Murder" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="4820-9486-55af-a4f9">
+                  <characteristics>
+                    <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Battle, Any Combat Phase</characteristic>
+                    <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick 1 of this unit’s melee weapons to be the target.</characteristic>
+                    <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Pick 1 of the following effects:
+• Inflict 3 mortal damage on this unit. Then, double the target weapon’s Attacks characteristic for the rest of the turn.
+• Add D6 to the target weapon’s Attacks characteristic for the rest of the turn.</characteristic>
+                    <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+                    <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+                  </characteristics>
+                  <attributes>
+                    <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Red</attribute>
+                    <attribute typeId="6d16-c86b-2698-85a4" name="Type">Offensive</attribute>
+                    <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+                  </attributes>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="ea19-2f27-5b3a-ee06" includeChildSelections="true"/>
+              </constraints>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Darkflame Pendant" hidden="false" id="3b46-4a16-41b6-77ab">
+              <profiles>
+                <profile name="Darkflame Pendant" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="e04f-d6fa-d3c2-0eab">
+                  <characteristics>
+                    <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
+                    <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">Weapons used for attacks that target this unit have a maximum Damage characteristic of 1.</characteristic>
+                  </characteristics>
+                  <attributes>
+                    <attribute typeId="50fe-4f29-6bc3-dcc6" name="Color">Green</attribute>
+                    <attribute typeId="bf11-4e10-3ab1-06f4" name="Type">Defensive</attribute>
+                    <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
+                  </attributes>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="60e0-0c53-791a-473f" includeChildSelections="true"/>
+              </constraints>
+            </selectionEntry>
+          </selectionEntries>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="78a1-f6c2-71b8-270a" shared="true"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="0151-9c5b-2f1e-32d4" shared="true" childName="✦ General&apos;s Handbook 2026-27"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <rules>
+            <rule name="Enhancement Restrictions" id="54b4-3ad6-9fbb-d26b" hidden="true">
+              <description>**^^Hero^^** only</description>
+            </rule>
+          </rules>
+        </selectionEntryGroup>
         <selectionEntryGroup name="Infernal Treasures" id="4c2-96a0-7dd9-ca99" hidden="false" publicationId="6357-5d77-a2b2-f86b">
           <selectionEntries>
             <selectionEntry type="upgrade" import="true" name="The Conquerer&apos;s Crown" hidden="false" id="89ca-29f-2a98-ee0d">
@@ -634,6 +717,100 @@ In addition, while this unit includes any standard bearers, this unit has **^^Wa
       </modifiers>
       <constraints>
         <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="396b-8e45-97b6-2cfc"/>
+      </constraints>
+    </selectionEntryGroup>
+    <selectionEntryGroup name="Brands of the Dark Gods" id="2e4a-66f0-fbef-f77d" hidden="false">
+      <selectionEntryGroups>
+        <selectionEntryGroup name="Brands of the Dark Gods" id="9dd7-589f-29da-489d" hidden="true" publicationId="9e18-bb03-7b60-d4ff">
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Brand of Unbreakable Bonds" hidden="false" id="4212-8768-6eb5-1b09">
+              <profiles>
+                <profile name="Brand of Unbreakable Bonds" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="fcfa-7c30-2159-a3fe">
+                  <characteristics>
+                    <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Battle, Your Movement Phase</characteristic>
+                    <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb"/>
+                    <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Remove this unit from the battlefield and set it up again wholly within 3&quot; of an objective you control and not in combat. This unit cannot use **^^Charge^^** abilities for the rest of the turn.</characteristic>
+                    <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+                    <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+                  </characteristics>
+                  <attributes>
+                    <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Black</attribute>
+                    <attribute typeId="6d16-c86b-2698-85a4" name="Type">Movement</attribute>
+                    <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+                  </attributes>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="2f61-5689-eb84-23c3" includeChildSelections="true"/>
+              </constraints>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Brand of the Unaligned" hidden="false" id="ed22-5f5e-88b5-e7fd">
+              <profiles>
+                <profile name="Brand of the Unaligned" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="93ba-0980-1544-507b">
+                  <characteristics>
+                    <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Your Hero Phase</characteristic>
+                    <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb"/>
+                    <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Remove all of this unit’s **^^Pledge to Chaos^^** keywords. Then, pick 1 of the following **^^Pledge to Chaos^^** keywords. You cannot pick a keyword you picked for this unit earlier in the battle.
+• **^^Pledged to Khorne^^**
+• **^^Pledged to Tzeentch^^**
+• **^^Pledged to Nurgle^^**
+• **^^Pledged to Slaanesh^^**
+This unit has that keyword for the rest of the battle.</characteristic>
+                    <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+                    <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+                  </characteristics>
+                  <attributes>
+                    <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Yellow</attribute>
+                    <attribute typeId="6d16-c86b-2698-85a4" name="Type">Special</attribute>
+                    <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+                  </attributes>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="5252-85b9-546a-d1a5" includeChildSelections="true"/>
+              </constraints>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Brand of Apoplexy" hidden="false" id="f62c-f28b-9d34-8e65">
+              <profiles>
+                <profile name="Brand of Apoplexy" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="1c5c-fe72-0caf-aa57">
+                  <characteristics>
+                    <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
+                    <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">While your **fury level** is 7, add 1 to the Damage characteristic of this unit’s weapons.</characteristic>
+                  </characteristics>
+                  <attributes>
+                    <attribute typeId="50fe-4f29-6bc3-dcc6" name="Color">Red</attribute>
+                    <attribute typeId="bf11-4e10-3ab1-06f4" name="Type">Offensive</attribute>
+                    <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
+                  </attributes>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="3962-f89c-48e7-1bdd" includeChildSelections="true"/>
+              </constraints>
+            </selectionEntry>
+          </selectionEntries>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="78a1-f6c2-71b8-270a" shared="true"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="0151-9c5b-2f1e-32d4" shared="true" childName="✦ General&apos;s Handbook 2026-27"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <rules>
+            <rule name="Enhancement Restrictions" id="3108-48e0-6c08-7c8b" hidden="true">
+              <description>A Brand of the Dark Gods is a unique enhancement that can only be given to non-**^^Hero^^** **^^Slaves to Darkness^^** **^^Infantry^^** units.  A unit can only have 1 Brand of the Dark Gods.</description>
+            </rule>
+          </rules>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <constraints>
+        <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="e30a-0180-22aa-1033" includeChildSelections="true"/>
+        <constraint type="max" value="1" field="selections" scope="root-entry" shared="true" id="c297-4369-3b2b-3c26"/>
       </constraints>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
@@ -2084,6 +2261,7 @@ During the battle, the target gains **Dark Apotheosis** points as follows:
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="7ef2-0f6b-2cee-2b40" type="selectionEntryGroup" targetId="20bb-e408-9d25-ffc6"/>
         <entryLink import="true" name="Paths" hidden="false" id="b42e-fe13-d26d-2b52" type="selectionEntryGroup" targetId="b0a6-aba3-da51-8a7f"/>
         <entryLink import="true" name="Renown" hidden="false" id="51df-08d5-53cb-71fa" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Brands of the Dark Gods" hidden="false" id="482c-c378-521a-4f24" type="selectionEntryGroup" targetId="2e4a-66f0-fbef-f77d"/>
       </entryLinks>
       <modifiers>
         <modifier type="multiply" value="2" field="points">
@@ -2112,6 +2290,7 @@ During the battle, the target gains **Dark Apotheosis** points as follows:
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="9e46-6b0b-7c4b-8559" type="selectionEntryGroup" targetId="20bb-e408-9d25-ffc6"/>
         <entryLink import="true" name="Paths" hidden="false" id="adc1-5332-6095-afcb" type="selectionEntryGroup" targetId="b0a6-aba3-da51-8a7f"/>
         <entryLink import="true" name="Renown" hidden="false" id="809d-3c10-8b1a-2e0f" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Brands of the Dark Gods" hidden="false" id="0393-9812-5fce-cb0b" type="selectionEntryGroup" targetId="2e4a-66f0-fbef-f77d"/>
       </entryLinks>
       <modifiers>
         <modifier type="multiply" value="2" field="points">
@@ -2188,6 +2367,7 @@ During the battle, the target gains **Dark Apotheosis** points as follows:
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="6444-a3f4-7fe4-2be8" type="selectionEntryGroup" targetId="20bb-e408-9d25-ffc6"/>
         <entryLink import="true" name="Paths" hidden="false" id="19ba-af7b-568c-d98a" type="selectionEntryGroup" targetId="b0a6-aba3-da51-8a7f"/>
         <entryLink import="true" name="Renown" hidden="false" id="3cc5-8ad3-5343-b9c1" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Brands of the Dark Gods" hidden="false" id="253e-c56e-74ea-a14f" type="selectionEntryGroup" targetId="2e4a-66f0-fbef-f77d"/>
       </entryLinks>
     </entryLink>
     <entryLink import="true" name="Chaos Spawn" hidden="false" id="5445-5020-de97-208b" type="selectionEntry" targetId="ead3-8dd9-3ace-8198">
@@ -2224,6 +2404,7 @@ During the battle, the target gains **Dark Apotheosis** points as follows:
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="c6d2-defe-09e2-7510" type="selectionEntryGroup" targetId="20bb-e408-9d25-ffc6"/>
         <entryLink import="true" name="Paths" hidden="false" id="0f47-6518-af52-83f1" type="selectionEntryGroup" targetId="b0a6-aba3-da51-8a7f"/>
         <entryLink import="true" name="Renown" hidden="false" id="8453-4b10-584d-63b7" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Brands of the Dark Gods" hidden="false" id="1ef0-c3d1-f6da-a11a" type="selectionEntryGroup" targetId="2e4a-66f0-fbef-f77d"/>
       </entryLinks>
       <modifiers>
         <modifier type="multiply" value="2" field="points">
@@ -2253,6 +2434,7 @@ During the battle, the target gains **Dark Apotheosis** points as follows:
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="022a-5f1d-f3ea-56d4" type="selectionEntryGroup" targetId="20bb-e408-9d25-ffc6"/>
         <entryLink import="true" name="Paths" hidden="false" id="2a0b-4415-e2af-c8a0" type="selectionEntryGroup" targetId="b0a6-aba3-da51-8a7f"/>
         <entryLink import="true" name="Renown" hidden="false" id="91a7-d9ab-e775-621b" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Brands of the Dark Gods" hidden="false" id="e179-09b6-2145-eea6" type="selectionEntryGroup" targetId="2e4a-66f0-fbef-f77d"/>
       </entryLinks>
       <modifiers>
         <modifier type="multiply" value="2" field="points">
@@ -2311,6 +2493,7 @@ During the battle, the target gains **Dark Apotheosis** points as follows:
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="133e-9b54-2c68-3bc3" type="selectionEntryGroup" targetId="20bb-e408-9d25-ffc6"/>
         <entryLink import="true" name="Paths" hidden="false" id="db36-a7ed-ea48-70a8" type="selectionEntryGroup" targetId="b0a6-aba3-da51-8a7f"/>
         <entryLink import="true" name="Renown" hidden="false" id="a0f5-dad2-adb2-abf2" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Brands of the Dark Gods" hidden="false" id="342d-0615-c833-febc" type="selectionEntryGroup" targetId="2e4a-66f0-fbef-f77d"/>
       </entryLinks>
       <modifiers>
         <modifier type="multiply" value="2" field="points">
@@ -2338,6 +2521,7 @@ During the battle, the target gains **Dark Apotheosis** points as follows:
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="1075-f6da-91f3-3e7b" type="selectionEntryGroup" targetId="20bb-e408-9d25-ffc6"/>
         <entryLink import="true" name="Paths" hidden="false" id="04aa-c9a3-e766-6b72" type="selectionEntryGroup" targetId="b0a6-aba3-da51-8a7f"/>
         <entryLink import="true" name="Renown" hidden="false" id="79eb-e3d9-da91-e3cc" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Brands of the Dark Gods" hidden="false" id="0410-67c8-daf7-5096" type="selectionEntryGroup" targetId="2e4a-66f0-fbef-f77d"/>
       </entryLinks>
       <modifiers>
         <modifier type="multiply" value="2" field="points">
@@ -2567,6 +2751,7 @@ During the battle, the target gains **Dark Apotheosis** points as follows:
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="b0bf-fb94-c161-4afd" type="selectionEntryGroup" targetId="20bb-e408-9d25-ffc6"/>
         <entryLink import="true" name="Paths" hidden="false" id="f05c-8e5d-cdf1-22e4" type="selectionEntryGroup" targetId="b0a6-aba3-da51-8a7f"/>
         <entryLink import="true" name="Renown" hidden="false" id="ab44-ef5d-1500-7569" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Brands of the Dark Gods" hidden="false" id="580f-0c64-b22b-4f62" type="selectionEntryGroup" targetId="2e4a-66f0-fbef-f77d"/>
       </entryLinks>
       <modifiers>
         <modifier type="multiply" value="2" field="points">
@@ -3011,6 +3196,7 @@ During the battle, the target gains **Dark Apotheosis** points as follows:
       </constraints>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="7ac9-e087-4e4c-6e05" type="selectionEntryGroup" targetId="20bb-e408-9d25-ffc6"/>
+        <entryLink import="true" name="Brands of the Dark Gods" hidden="false" id="ce9c-6a97-e170-ce68" type="selectionEntryGroup" targetId="2e4a-66f0-fbef-f77d"/>
       </entryLinks>
     </entryLink>
     <entryLink import="true" name="Varanguard" hidden="false" id="80ba-f8dc-ff8d-3b4" type="selectionEntry" targetId="3f86-7961-558c-50aa">
@@ -3067,6 +3253,7 @@ During the battle, the target gains **Dark Apotheosis** points as follows:
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="ae74-7238-cbe9-13b0" type="selectionEntryGroup" targetId="20bb-e408-9d25-ffc6"/>
         <entryLink import="true" name="Paths" hidden="false" id="4e3a-310d-0546-96ba" type="selectionEntryGroup" targetId="b0a6-aba3-da51-8a7f"/>
         <entryLink import="true" name="Renown" hidden="false" id="ac2c-d661-640e-49fd" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Brands of the Dark Gods" hidden="false" id="c86a-f0d0-d77c-65c7" type="selectionEntryGroup" targetId="2e4a-66f0-fbef-f77d"/>
       </entryLinks>
     </entryLink>
     <entryLink import="true" name="Cypher Lords" hidden="false" id="9ab1-3223-f141-1f26" type="selectionEntry" targetId="5a21-301b-7e70-62fd">
@@ -3094,6 +3281,7 @@ During the battle, the target gains **Dark Apotheosis** points as follows:
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="a07f-aa56-acca-6a7f" type="selectionEntryGroup" targetId="20bb-e408-9d25-ffc6"/>
         <entryLink import="true" name="Paths" hidden="false" id="30d7-890a-f15a-209c" type="selectionEntryGroup" targetId="b0a6-aba3-da51-8a7f"/>
         <entryLink import="true" name="Renown" hidden="false" id="b36f-03b7-1107-dbb8" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Brands of the Dark Gods" hidden="false" id="40fb-3f46-898d-37e6" type="selectionEntryGroup" targetId="2e4a-66f0-fbef-f77d"/>
       </entryLinks>
     </entryLink>
     <entryLink import="true" name="Horns of Hashut" hidden="false" id="c2df-74d6-4478-5ade" type="selectionEntry" targetId="4146-b722-ff22-610d">
@@ -3121,6 +3309,7 @@ During the battle, the target gains **Dark Apotheosis** points as follows:
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="0d2b-65d8-817e-5dde" type="selectionEntryGroup" targetId="20bb-e408-9d25-ffc6"/>
         <entryLink import="true" name="Paths" hidden="false" id="effb-61d7-5379-56a8" type="selectionEntryGroup" targetId="b0a6-aba3-da51-8a7f"/>
         <entryLink import="true" name="Renown" hidden="false" id="c0fa-5596-7425-c063" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Brands of the Dark Gods" hidden="false" id="4e55-bdbc-777c-e096" type="selectionEntryGroup" targetId="2e4a-66f0-fbef-f77d"/>
       </entryLinks>
     </entryLink>
     <entryLink import="true" name="Iron Golem" hidden="false" id="4a79-a489-2f04-b87c" type="selectionEntry" targetId="9a4c-e68d-108d-98f5">
@@ -3149,6 +3338,7 @@ During the battle, the target gains **Dark Apotheosis** points as follows:
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="7948-8dfa-3598-6846" type="selectionEntryGroup" targetId="20bb-e408-9d25-ffc6"/>
         <entryLink import="true" name="Paths" hidden="false" id="d78e-d080-9d40-8ef0" type="selectionEntryGroup" targetId="b0a6-aba3-da51-8a7f"/>
         <entryLink import="true" name="Renown" hidden="false" id="77b2-00c9-6f22-f4c4" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Brands of the Dark Gods" hidden="false" id="5a71-ac20-8e9e-3f3e" type="selectionEntryGroup" targetId="2e4a-66f0-fbef-f77d"/>
       </entryLinks>
     </entryLink>
     <entryLink import="true" name="Scions of the Flame" hidden="false" id="ea38-78c5-617d-4336" type="selectionEntry" targetId="cc95-e171-14b9-002f">
@@ -3176,6 +3366,7 @@ During the battle, the target gains **Dark Apotheosis** points as follows:
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="d9aa-054f-2426-075c" type="selectionEntryGroup" targetId="20bb-e408-9d25-ffc6"/>
         <entryLink import="true" name="Paths" hidden="false" id="1ea1-c4c8-cad3-80e4" type="selectionEntryGroup" targetId="b0a6-aba3-da51-8a7f"/>
         <entryLink import="true" name="Renown" hidden="false" id="93ae-5172-96c9-bf4c" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Brands of the Dark Gods" hidden="false" id="c396-a8a8-d4ed-6143" type="selectionEntryGroup" targetId="2e4a-66f0-fbef-f77d"/>
       </entryLinks>
     </entryLink>
     <entryLink import="true" name="Spire Tyrants" hidden="false" id="3798-a94f-c3c2-a847" type="selectionEntry" targetId="62a3-63bf-2306-e2a2">
@@ -3203,6 +3394,7 @@ During the battle, the target gains **Dark Apotheosis** points as follows:
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="91d0-f9c2-dd17-e8e0" type="selectionEntryGroup" targetId="20bb-e408-9d25-ffc6"/>
         <entryLink import="true" name="Paths" hidden="false" id="7ea8-de1f-5a0a-23b3" type="selectionEntryGroup" targetId="b0a6-aba3-da51-8a7f"/>
         <entryLink import="true" name="Renown" hidden="false" id="d0cb-5abd-f80a-3c8b" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Brands of the Dark Gods" hidden="false" id="e81b-7978-b2b7-3032" type="selectionEntryGroup" targetId="2e4a-66f0-fbef-f77d"/>
       </entryLinks>
     </entryLink>
     <entryLink import="true" name="Splintered Fang" hidden="false" id="d82a-95d9-b777-37e1" type="selectionEntry" targetId="78f8-9ac5-641f-8b5c">
@@ -3230,6 +3422,7 @@ During the battle, the target gains **Dark Apotheosis** points as follows:
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="93e6-2560-ffad-ed00" type="selectionEntryGroup" targetId="20bb-e408-9d25-ffc6"/>
         <entryLink import="true" name="Paths" hidden="false" id="4eb7-517c-b7d1-7de1" type="selectionEntryGroup" targetId="b0a6-aba3-da51-8a7f"/>
         <entryLink import="true" name="Renown" hidden="false" id="f12e-e705-cc55-1512" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Brands of the Dark Gods" hidden="false" id="e34e-cc29-e9da-a751" type="selectionEntryGroup" targetId="2e4a-66f0-fbef-f77d"/>
       </entryLinks>
     </entryLink>
     <entryLink import="true" name="Tarantulos Brood" hidden="false" id="2dce-8abc-c24b-a5ca" type="selectionEntry" targetId="066a-b04a-44ea-fca2">
@@ -3257,6 +3450,7 @@ During the battle, the target gains **Dark Apotheosis** points as follows:
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="67ef-1adf-0996-adff" type="selectionEntryGroup" targetId="20bb-e408-9d25-ffc6"/>
         <entryLink import="true" name="Paths" hidden="false" id="d15a-3a73-e950-7a9b" type="selectionEntryGroup" targetId="b0a6-aba3-da51-8a7f"/>
         <entryLink import="true" name="Renown" hidden="false" id="8544-5ecb-a1b4-f81e" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Brands of the Dark Gods" hidden="false" id="3ea6-3fea-ade6-e2b9" type="selectionEntryGroup" targetId="2e4a-66f0-fbef-f77d"/>
       </entryLinks>
     </entryLink>
     <entryLink import="true" name="The Unmade" hidden="false" id="da7a-0512-dc1a-ac0d" type="selectionEntry" targetId="6aef-12ed-3dc9-2c83">
@@ -3284,6 +3478,7 @@ During the battle, the target gains **Dark Apotheosis** points as follows:
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="abad-0cff-8498-8895" type="selectionEntryGroup" targetId="20bb-e408-9d25-ffc6"/>
         <entryLink import="true" name="Paths" hidden="false" id="6f85-977e-3787-7d55" type="selectionEntryGroup" targetId="b0a6-aba3-da51-8a7f"/>
         <entryLink import="true" name="Renown" hidden="false" id="9dcb-5af9-2598-80ae" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Brands of the Dark Gods" hidden="false" id="e438-576a-06cb-8137" type="selectionEntryGroup" targetId="2e4a-66f0-fbef-f77d"/>
       </entryLinks>
     </entryLink>
     <entryLink import="true" name="Untamed Beasts" hidden="false" id="d0f3-f79e-25f5-e369" type="selectionEntry" targetId="056b-6839-dc2f-46db">
@@ -3311,6 +3506,7 @@ During the battle, the target gains **Dark Apotheosis** points as follows:
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="15b4-f017-e536-a496" type="selectionEntryGroup" targetId="20bb-e408-9d25-ffc6"/>
         <entryLink import="true" name="Paths" hidden="false" id="540b-2594-5e19-471d" type="selectionEntryGroup" targetId="b0a6-aba3-da51-8a7f"/>
         <entryLink import="true" name="Renown" hidden="false" id="ea66-8138-6242-9d0d" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Brands of the Dark Gods" hidden="false" id="c2d2-c372-e83c-4d9a" type="selectionEntryGroup" targetId="2e4a-66f0-fbef-f77d"/>
       </entryLinks>
     </entryLink>
     <entryLink import="true" name="Godsworn Hunt" hidden="false" id="a7d5-74de-6e60-9130" type="selectionEntry" targetId="1bb9-8fa7-8bf8-e4a2">
@@ -3336,6 +3532,7 @@ During the battle, the target gains **Dark Apotheosis** points as follows:
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="ab46-9474-24ea-c7a3" type="selectionEntryGroup" targetId="20bb-e408-9d25-ffc6"/>
+        <entryLink import="true" name="Brands of the Dark Gods" hidden="false" id="4a80-4605-0eab-efad" type="selectionEntryGroup" targetId="2e4a-66f0-fbef-f77d"/>
       </entryLinks>
     </entryLink>
     <entryLink import="true" name="The Gnarlspirit Pack" hidden="false" id="b0cd-5867-a3f5-2066" type="selectionEntry" targetId="8046-a145-5d79-aa66">
@@ -3361,6 +3558,7 @@ During the battle, the target gains **Dark Apotheosis** points as follows:
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="ff96-80af-977c-4e1b" type="selectionEntryGroup" targetId="20bb-e408-9d25-ffc6"/>
+        <entryLink import="true" name="Brands of the Dark Gods" hidden="false" id="3de5-29a7-7ab4-dfd3" type="selectionEntryGroup" targetId="2e4a-66f0-fbef-f77d"/>
       </entryLinks>
     </entryLink>
     <entryLink import="true" name="Khagra&apos;s Ravagers" hidden="false" id="f83b-2e39-f2a4-c214" type="selectionEntry" targetId="c9bb-a2c8-8c92-a00c">
@@ -3386,6 +3584,7 @@ During the battle, the target gains **Dark Apotheosis** points as follows:
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="2de6-a98f-1707-09bf" type="selectionEntryGroup" targetId="20bb-e408-9d25-ffc6"/>
+        <entryLink import="true" name="Brands of the Dark Gods" hidden="false" id="4629-4759-1859-87fc" type="selectionEntryGroup" targetId="2e4a-66f0-fbef-f77d"/>
       </entryLinks>
     </entryLink>
     <entryLink import="true" name="Anvil of Apotheosis: Slaves to Darkness Hero" hidden="true" id="20ca-03db-916c-19e6" type="selectionEntry" targetId="0ed5-d41f-e776-045e">

--- a/Slaves to Darkness.cat
+++ b/Slaves to Darkness.cat
@@ -734,7 +734,7 @@ In addition, while this unit includes any standard bearers, this unit has **^^Wa
                     <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
                   </characteristics>
                   <attributes>
-                    <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Black</attribute>
+                    <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Gray</attribute>
                     <attribute typeId="6d16-c86b-2698-85a4" name="Type">Movement</attribute>
                     <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
                   </attributes>


### PR DESCRIPTION
Add the two Scourge of Aqshy enhancement tables for Slaves to Darkness, following the Order convention. Base army only (main file); Library and Army-of-Renown files untouched.

- Infernal Treasures (Artefacts of Power, Hero only): a new SoA-gated table (publicationId Scourge of Aqshy, GHB 2026-27 / PtG gating) nested inside the existing Artefacts of Power group alongside the base table, so it inherits the same hero visibility. Artefacts: Aelfskin Scroll, Rune of Murder, Darkflame Pendant.
- Brands of the Dark Gods: a new unique enhancement category (outer group carries max-1-per-roster + max-1-per-unit) with a gated SoA table (Brand of Unbreakable Bonds, Brand of the Unaligned, Brand of Apoplexy), linked into all 22 non-Hero Slaves to Darkness Infantry units in the main army file.

Ability text/timing from the PDF text layer; colour/type from the page image. Verified: parses, 0 new duplicate ids, additions-only, CRLF preserved, both SoA groups hidden + SoA publication + 78a1/0151 gating.