### PR TITLE
Ogor Mawtribes: fix hero regiment options (+ Maw Nomad) and add missing Mawpit Ward (6+)

### DIFF
--- a/Ogor Mawtribes - Library.cat
+++ b/Ogor Mawtribes - Library.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="true" id="9a90-83e7-7a45-6aed" name="Ogor Mawtribes - Library" gameSystemId="e51d-b1a3-75fc-dc3g" gameSystemRevision="2" revision="20" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="true" id="9a90-83e7-7a45-6aed" name="Ogor Mawtribes - Library" gameSystemId="e51d-b1a3-75fc-dc3g" gameSystemRevision="2" revision="21" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <sharedSelectionEntries>
     <selectionEntry type="unit" import="true" name="Bloodpelt Hunter" hidden="false" id="a800-1a5b-4097-8f11" publicationId="1ac6-e227-a186-12">
       <entryLinks>
@@ -2318,6 +2318,7 @@ Then, roll a dice. On a 3+, until the start of your next turn, the target cannot
         <categoryLink name="FACTION TERRAIN" hidden="false" id="242c-0eb8-96d8-0115" targetId="cdd6-ffa1-9b32-4cb8" primary="true"/>
         <categoryLink name="DESTRUCTION" hidden="false" id="0817-0379-0409-25b1" targetId="9057-5a29-dda5-3c28" primary="false"/>
         <categoryLink name="OGOR MAWTRIBES" hidden="false" id="24ee-d3e8-67c4-3036" targetId="743-1bd8-e3d-ced2" primary="false"/>
+        <categoryLink name="WARD (6+)" hidden="false" id="0aa7-1bd5-3ce9-4f62" targetId="70a4-383f-421f-52cd" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry type="upgrade" import="true" name="Ever-hungry Pit" hidden="false" id="8376-e2ae-b242-b4fd">

--- a/Ogor Mawtribes.cat
+++ b/Ogor Mawtribes.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="6353-cb84-ac7f-9a15" name="Ogor Mawtribes" gameSystemId="e51d-b1a3-75fc-dc3g" gameSystemRevision="2" revision="32" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="false" id="6353-cb84-ac7f-9a15" name="Ogor Mawtribes" gameSystemId="e51d-b1a3-75fc-dc3g" gameSystemRevision="2" revision="33" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <sharedSelectionEntryGroups>
     <selectionEntryGroup name="Spell Lores" id="daa3-d823-9bac-b8d" hidden="false" flatten="true">
       <selectionEntries>
@@ -910,11 +910,24 @@ Then, the unit using this ability can make a pile-in move. If the target of this
         <modifierGroup type="and">
           <modifiers>
             <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.743-1bd8-e3d-ced2"/>
-            <modifier type="add" value="8f4b-1fa6-3128-8405" field="category" scope="force" affects="self.entries.recursive.3941-ff89-5c42-9230"/>
           </modifiers>
           <conditions>
             <condition type="instanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
           </conditions>
+        </modifierGroup>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="bf4e-4b1b-7055-2ec8" field="category"/>
+          </modifiers>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
         </modifierGroup>
       </modifierGroups>
     </entryLink>
@@ -972,11 +985,33 @@ Then, the unit using this ability can make a pile-in move. If the target of this
       <modifierGroups>
         <modifierGroup type="and">
           <modifiers>
-            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.5c0d-5e93-d71f-f0da"/>
+            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.410d-6b15-3cf4-88d0"/>
           </modifiers>
           <conditions>
             <condition type="instanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
           </conditions>
+        </modifierGroup>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.75d6-6995-dfcc-3898"/>
+          </modifiers>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
+          </conditions>
+        </modifierGroup>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="bf4e-4b1b-7055-2ec8" field="category"/>
+          </modifiers>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
         </modifierGroup>
       </modifierGroups>
     </entryLink>
@@ -1020,11 +1055,8 @@ Then, the unit using this ability can make a pile-in move. If the target of this
       <modifierGroups>
         <modifierGroup type="and">
           <modifiers>
-            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.5c0d-5e93-d71f-f0da"/>
-            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.139a-e1a2-a79a-6fce"/>
-            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.1f2a-58a9-839b-59b0"/>
-            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.7b4c-9343-e884-9b28"/>
-            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.3a87-b1c8-8528-7efd"/>
+            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.75d6-6995-dfcc-3898"/>
+            <modifier type="add" value="8f4b-1fa6-3128-8405" field="category" scope="force" affects="self.entries.recursive.bf4e-4b1b-7055-2ec8"/>
           </modifiers>
           <conditions>
             <condition type="instanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
@@ -1224,21 +1256,8 @@ Then, the unit using this ability can make a pile-in move. If the target of this
       <modifierGroups>
         <modifierGroup type="and">
           <modifiers>
-            <modifier type="add" value="bf4e-4b1b-7055-2ec8" field="category"/>
-          </modifiers>
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true"/>
-                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifierGroup>
-        <modifierGroup type="and">
-          <modifiers>
-            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.1a3d-33f9-c4cc-fe0"/>
+            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.743-1bd8-e3d-ced2"/>
+            <modifier type="add" value="8f4b-1fa6-3128-8405" field="category" scope="force" affects="self.entries.recursive.bf4e-4b1b-7055-2ec8"/>
           </modifiers>
           <conditions>
             <condition type="instanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
@@ -1288,21 +1307,8 @@ Then, the unit using this ability can make a pile-in move. If the target of this
       <modifierGroups>
         <modifierGroup type="and">
           <modifiers>
-            <modifier type="add" value="bf4e-4b1b-7055-2ec8" field="category"/>
-          </modifiers>
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true"/>
-                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifierGroup>
-        <modifierGroup type="and">
-          <modifiers>
-            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.1a3d-33f9-c4cc-fe0"/>
+            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.743-1bd8-e3d-ced2"/>
+            <modifier type="add" value="8f4b-1fa6-3128-8405" field="category" scope="force" affects="self.entries.recursive.bf4e-4b1b-7055-2ec8"/>
           </modifiers>
           <conditions>
             <condition type="instanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
@@ -1352,21 +1358,7 @@ Then, the unit using this ability can make a pile-in move. If the target of this
       <modifierGroups>
         <modifierGroup type="and">
           <modifiers>
-            <modifier type="add" value="bf4e-4b1b-7055-2ec8" field="category"/>
-          </modifiers>
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true"/>
-                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifierGroup>
-        <modifierGroup type="and">
-          <modifiers>
-            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.1a3d-33f9-c4cc-fe0"/>
+            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.743-1bd8-e3d-ced2"/>
           </modifiers>
           <conditions>
             <condition type="instanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
@@ -1408,6 +1400,7 @@ Then, the unit using this ability can make a pile-in move. If the target of this
         <modifierGroup type="and">
           <modifiers>
             <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.743-1bd8-e3d-ced2"/>
+            <modifier type="add" value="8f4b-1fa6-3128-8405" field="category" scope="force" affects="self.entries.recursive.bf4e-4b1b-7055-2ec8"/>
           </modifiers>
           <conditions>
             <condition type="instanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
@@ -1858,7 +1851,15 @@ Then, the unit using this ability can make a pile-in move. If the target of this
         </modifierGroup>
         <modifierGroup type="and">
           <modifiers>
-            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.1a3d-33f9-c4cc-fe0"/>
+            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.410d-6b15-3cf4-88d0"/>
+          </modifiers>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
+          </conditions>
+        </modifierGroup>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.75d6-6995-dfcc-3898"/>
           </modifiers>
           <conditions>
             <condition type="instanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
@@ -1873,6 +1874,40 @@ Then, the unit using this ability can make a pile-in move. If the target of this
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="c9ee-c9c8-32cf-d5c0" type="selectionEntryGroup" targetId="9b0d-58b7-8982-2128"/>
       </entryLinks>
+      <modifiers>
+        <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="lessThan" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true" includeChildForces="true"/>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="set" value="true" field="hidden">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <modifierGroups>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.743-1bd8-e3d-ced2"/>
+            <modifier type="add" value="8f4b-1fa6-3128-8405" field="category" scope="force" affects="self.entries.recursive.bf4e-4b1b-7055-2ec8"/>
+          </modifiers>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
+          </conditions>
+        </modifierGroup>
+      </modifierGroups>
     </entryLink>
     <entryLink import="true" name="Grell Firefist" hidden="false" id="29ec-3583-c704-1e15" type="selectionEntry" targetId="3fb5-d2d7-81b4-6a19">
       <costs>
@@ -1881,6 +1916,53 @@ Then, the unit using this ability can make a pile-in move. If the target of this
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="4dcc-5b5f-e726-1d0a" type="selectionEntryGroup" targetId="9b0d-58b7-8982-2128"/>
       </entryLinks>
+      <modifiers>
+        <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="lessThan" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true" includeChildForces="true"/>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="set" value="true" field="hidden">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <modifierGroups>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.743-1bd8-e3d-ced2"/>
+          </modifiers>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
+          </conditions>
+        </modifierGroup>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="bf4e-4b1b-7055-2ec8" field="category"/>
+          </modifiers>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifierGroup>
+      </modifierGroups>
     </entryLink>
     <entryLink import="true" name="Redd the Maw, High Slaughtermaster" hidden="false" id="ccf2-f7fd-a8ae-c8ae" type="selectionEntry" targetId="63b1-7b0e-39da-a18f">
       <costs>
@@ -1889,6 +1971,40 @@ Then, the unit using this ability can make a pile-in move. If the target of this
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="2589-f0cd-82e6-1536" type="selectionEntryGroup" targetId="9b0d-58b7-8982-2128"/>
       </entryLinks>
+      <modifiers>
+        <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="lessThan" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true" includeChildForces="true"/>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="set" value="true" field="hidden">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <modifierGroups>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.743-1bd8-e3d-ced2"/>
+            <modifier type="add" value="8f4b-1fa6-3128-8405" field="category" scope="force" affects="self.entries.recursive.bf4e-4b1b-7055-2ec8"/>
+          </modifiers>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
+          </conditions>
+        </modifierGroup>
+      </modifierGroups>
     </entryLink>
     <entryLink import="true" name="Tyrant on Glutthorn" hidden="false" id="0d98-17de-fdc4-9899" type="selectionEntry" targetId="9e4e-efb1-3f18-b23d">
       <entryLinks>
@@ -1905,6 +2021,40 @@ Then, the unit using this ability can make a pile-in move. If the target of this
       <costs>
         <cost name="pts" typeId="points" value="400"/>
       </costs>
+      <modifiers>
+        <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="lessThan" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true" includeChildForces="true"/>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="set" value="true" field="hidden">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <modifierGroups>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.743-1bd8-e3d-ced2"/>
+            <modifier type="add" value="8f4b-1fa6-3128-8405" field="category" scope="force" affects="self.entries.recursive.bf4e-4b1b-7055-2ec8"/>
+          </modifiers>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
+          </conditions>
+        </modifierGroup>
+      </modifierGroups>
     </entryLink>
     <entryLink import="true" name="Maulbeast Cavalry" hidden="false" id="29f5-da35-9731-81b2" type="selectionEntry" targetId="4781-28ae-2385-ff02">
       <entryLinks>
@@ -2408,7 +2558,7 @@ Then, the unit using this ability can make a pile-in move. If the target of this
     </selectionEntry>
   </selectionEntries>
   <categoryEntries>
-    <categoryEntry name="Voice of the Everwinter" id="bf4e-4b1b-7055-2ec8" hidden="false">
+    <categoryEntry name="Maw Nomad" id="bf4e-4b1b-7055-2ec8" hidden="false">
       <modifiers>
         <modifier type="set" value="1" field="559f-7afb-324c-765b">
           <conditionGroups>


### PR DESCRIPTION
Two data fixes for the new Ogor Mawtribes battletome on the `ogors` branch, verified against the August 2026 Battle Profiles and the battletome warscrolls.

### 1. Hero regiment options + Maw Nomad (`Ogor Mawtribes.cat`)
The heroes still carried their pre-battletome regiment options. Reworked to match the Aug 2026 profiles:

- **Bloodpelt Hunter / Mantrapper** → Any Beastclaw, Any Infantry
- **Butcher** → 0-1 Maw Nomad, Any Infantry
- **Frostlords, Huskards (Stonehorn & Thundertusk), Kragnos, Morga, Redd the Maw, Tyrant on Glutthorn** → 0-1 Maw Nomad, Any Ogor Mawtribes
- **Huskard on Thundertusk (Scourge of Aqshy)** → Any Ogor Mawtribes
- **Tyrant, Grell Firefist** → Any Ogor Mawtribes, and eligible to join a regiment as a Maw Nomad

Renamed the "Voice of the Everwinter" regiment category to **Maw Nomad**, tagged the Maw-Nomad-eligible heroes (Bloodpelt, Grell, Mantrapper, Tyrant), added the 0-1 Maw Nomad slot to the leaders that get it, and added regiment-leader structure to the new heroes (Grell, Morga, Redd, Tyrant on Glutthorn).

### 2. Mawpit Ward (6+) (`Ogor Mawtribes - Library.cat`)
The Mawpit's warscroll lists **Ward (6+)** among its keywords, but the terrain feature had no `WARD (6+)` category link, so it granted no ward. Added the link to the shared Ward (6+) category.

Rebased on the current `ogors` branch, so this contains only the above — the recent Legends-unit restore and ability-cost fixes are already there.

---
This is my **first pull request** here. I checked the changes by parsing them against the profiles, but if anything is done wrong or doesn't match your conventions, please don't hesitate to let me know and I'll fix it. Thanks for all the work on this battletome!
