### PR TITLE
Ogor Mawtribes: Battletome Supplement warscrolls + Legends heroes' regiment options

### DIFF
--- a/Age of Sigmar 4.0.gst
+++ b/Age of Sigmar 4.0.gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem xmlns="http://www.battlescribe.net/schema/gameSystemSchema" id="e51d-b1a3-75fc-dc3g" name="Age of Sigmar 4.0" revision="98" battleScribeVersion="2.03" type="gameSystem">
+<gameSystem xmlns="http://www.battlescribe.net/schema/gameSystemSchema" id="e51d-b1a3-75fc-dc3g" name="Age of Sigmar 4.0" revision="99" battleScribeVersion="2.03" type="gameSystem">
   <costTypes>
     <costType id="points" name="pts" defaultCostLimit="0" hidden="false"/>
     <costType name="Destiny Points" id="bc33-05f5-8d3f-af43" defaultCostLimit="-1" hidden="true">

--- a/Age of Sigmar 4.0.gst
+++ b/Age of Sigmar 4.0.gst
@@ -15710,8 +15710,7 @@ Each part of this **^^Manifestation^^** is armed with **Tendrils of Light and S
     <publication name="General&apos;s Handbook 2024-25" id="ec12-a5ee-5304-af7" hidden="false"/>
     <publication name="Regiments of Renown" id="27d9-b0c5-1ecc-ba2f" hidden="false"/>
     <publication name="Battletome: Lumineth Realmlords" id="9ed1-cf74-eb97-dee2" hidden="false"/>
-    <publication name="Faction Pack: Ogor Mawtribes" id="1ac6-e227-a186-12" hidden="false"/>
-    <publication name="Battletome: Ogor Mawtribes" id="feba-6749-6df3-ea9e" hidden="false"/>
+    <publication name="Battletome: Ogor Mawtribes" id="1ac6-e227-a186-12" hidden="false"/>
     <publication name="Battletome: Hedonites of Slaanesh" id="95fc-e96f-a916-bba1" hidden="false"/>
     <publication name="Battletome: Maggotkin of Nurgle" id="9c71-86cb-e1d0-ec8d" hidden="false"/>
     <publication name="Battletome: Nighthaunt" id="67f7-aa7f-294f-880d" hidden="false"/>

--- a/Age of Sigmar 4.0.gst
+++ b/Age of Sigmar 4.0.gst
@@ -1632,6 +1632,8 @@
         <forceEntryLink name="Brand&apos;s Oathbound" id="a77a-2c33-2058-cc55" hidden="false" targetId="f8bf-3c82-73dc-a7e8" type="forceEntry"/>
         <forceEntryLink name="Bundo Whalebiter" id="725e-8464-14ed-fbee" hidden="false" targetId="fb09-ac57-e70e-716d" type="forceEntry"/>
         <forceEntryLink name="Da Hurtlin&apos; Hogz" id="0e89-f526-57b7-1d9f" hidden="false" targetId="3cd2-b31b-43c8-e42c" type="forceEntry"/>
+        <forceEntryLink name="Okar&apos;s Torrbad" id="c486-232e-39e9-6f8d" hidden="false" targetId="7199-3205-3f4e-5567" type="forceEntry"/>
+        <forceEntryLink name="Urrgar&apos;s Maulerguts" id="8ae3-0748-798b-3e6b" hidden="false" targetId="71ed-0753-4dbb-c952" type="forceEntry"/>
         <forceEntryLink name="Da Kountin&apos; Krew" id="eafd-da06-ddf2-45c2" hidden="false" targetId="1d9c-5fbb-bb1e-bdb8" type="forceEntry"/>
         <forceEntryLink name="Drekki&apos;s Privateers" id="e55f-f5e4-0234-a556" hidden="false" targetId="accf-873b-ebe8-1d1c" type="forceEntry"/>
         <forceEntryLink name="Elthwin&apos;s Thorns" id="ec71-e9ad-433e-12f5" hidden="false" targetId="e484-c06-d856-2921" type="forceEntry"/>
@@ -2947,6 +2949,8 @@
         <forceEntryLink name="Brand&apos;s Oathbound" id="e810-dd10-ad40-d7dc" hidden="false" targetId="f8bf-3c82-73dc-a7e8" type="forceEntry"/>
         <forceEntryLink name="Bundo Whalebiter" id="a446-1667-9435-a624" hidden="false" targetId="fb09-ac57-e70e-716d" type="forceEntry"/>
         <forceEntryLink name="Da Hurtlin&apos; Hogz" id="0fef-4de2-cbaf-1fa4" hidden="false" targetId="3cd2-b31b-43c8-e42c" type="forceEntry"/>
+        <forceEntryLink name="Okar&apos;s Torrbad" id="016e-c595-be24-d468" hidden="false" targetId="7199-3205-3f4e-5567" type="forceEntry"/>
+        <forceEntryLink name="Urrgar&apos;s Maulerguts" id="ae53-9733-e2c5-4623" hidden="false" targetId="71ed-0753-4dbb-c952" type="forceEntry"/>
         <forceEntryLink name="Da Kountin&apos; Krew" id="1d29-8502-728e-9022" hidden="false" targetId="1d9c-5fbb-bb1e-bdb8" type="forceEntry"/>
         <forceEntryLink name="Drekki&apos;s Privateers" id="45d5-6e29-ce35-2e1d" hidden="false" targetId="accf-873b-ebe8-1d1c" type="forceEntry"/>
         <forceEntryLink name="Elthwin&apos;s Thorns" id="f425-dd87-f665-f408" hidden="false" targetId="e484-c06-d856-2921" type="forceEntry"/>
@@ -7006,6 +7010,16 @@
             <modifier type="set" value="false" field="hidden"/>
           </modifiers>
         </forceEntryLink>
+        <forceEntryLink name="Okar&apos;s Torrbad" id="a3b7-55ec-1879-31be" hidden="false" targetId="7199-3205-3f4e-5567" type="forceEntry">
+          <modifiers>
+            <modifier type="set" value="false" field="hidden"/>
+          </modifiers>
+        </forceEntryLink>
+        <forceEntryLink name="Urrgar&apos;s Maulerguts" id="3145-d476-ea69-fe00" hidden="false" targetId="71ed-0753-4dbb-c952" type="forceEntry">
+          <modifiers>
+            <modifier type="set" value="false" field="hidden"/>
+          </modifiers>
+        </forceEntryLink>
         <forceEntryLink name="Da Kountin&apos; Krew" id="24e9-6e6a-7561-22a8" hidden="false" targetId="1d9c-5fbb-bb1e-bdb8" type="forceEntry">
           <modifiers>
             <modifier type="set" value="false" field="hidden"/>
@@ -7415,6 +7429,90 @@
       <costs>
         <cost name="pts" typeId="points" value="400"/>
         <cost name="Destiny Points" typeId="bc33-05f5-8d3f-af43" value="0"/>
+      </costs>
+    </forceEntry>
+    <forceEntry name="Okar&apos;s Torrbad" id="7199-3205-3f4e-5567" hidden="true">
+      <modifiers>
+        <modifier type="set" value="false" field="hidden">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="parent" childId="9baf-c109-f621-e60" shared="true"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="parent" childId="832c-fd6-a535-ffae" shared="true"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="parent" childId="8aef-b85d-b63a-ef05" shared="true"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="parent" childId="de5f-588b-ea57-d6b5" shared="true"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="1ed8-2e23-1563-c119" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink name="HERO" hidden="false" id="fb4a-1088-3c65-b847" targetId="6e72-1656-d554-528a"/>
+        <categoryLink name="MONSTER" hidden="false" id="1c14-f56f-2bd7-5c00" targetId="6d54-625c-d063-13e2"/>
+        <categoryLink name="Reference" hidden="false" id="43ab-37c1-8310-a288" targetId="3360-1158-e879-9606"/>
+      </categoryLinks>
+      <constraints>
+        <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="fb98-7bc5-1db4-37c3"/>
+      </constraints>
+      <costs>
+        <cost name="pts" typeId="points" value="490"/>
+        <cost name="Destiny Points" typeId="bc33-05f5-8d3f-af43" value="0"/>
+        <cost name="Force Category - PTG" typeId="e63c-79ff-93ba-c5eb" value="0"/>
+        <cost name="Force Category - GHB" typeId="de92-2099-fbf7-a156" value="0"/>
+      </costs>
+    </forceEntry>
+    <forceEntry name="Urrgar&apos;s Maulerguts" id="71ed-0753-4dbb-c952" hidden="true">
+      <modifiers>
+        <modifier type="set" value="false" field="hidden">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition type="instanceOf" value="1" field="selections" scope="parent" childId="42ad-8ca7-4b48-7df1" shared="true"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="parent" childId="b53b-1217-df2e-66d2" shared="true"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="parent" childId="b3f9-6c96-b99a-1e71" shared="true"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="parent" childId="9baf-c109-f621-e60" shared="true"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="parent" childId="b7b7-cf58-4189-56ec" shared="true"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="parent" childId="832c-fd6-a535-ffae" shared="true"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="parent" childId="1100-a22f-15c6-bdea" shared="true"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="parent" childId="8aef-b85d-b63a-ef05" shared="true"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="parent" childId="8e0e-5e8c-5824-89c9" shared="true"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="parent" childId="231a-2a83-26f0-a718" shared="true"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="parent" childId="2c23-a678-196b-ad69" shared="true"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="parent" childId="405e-c5f4-8579-b05c" shared="true"/>
+                    <condition type="instanceOf" value="1" field="selections" scope="parent" childId="1bd9-ad7d-68ee-3b53" shared="true"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="primary-catalogue" childId="1ed8-2e23-1563-c119" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <categoryLinks>
+        <categoryLink name="HERO" hidden="false" id="9835-ba0a-099d-f712" targetId="6e72-1656-d554-528a"/>
+        <categoryLink name="MONSTER" hidden="false" id="c522-4634-9c6a-7141" targetId="6d54-625c-d063-13e2"/>
+        <categoryLink name="CAVALRY" hidden="false" id="2ae5-9f4e-33d3-5165" targetId="926c-df8c-6841-d49e"/>
+        <categoryLink name="Reference" hidden="false" id="0b0f-7516-6809-39de" targetId="3360-1158-e879-9606"/>
+      </categoryLinks>
+      <constraints>
+        <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="1efa-64f2-7611-c2a2"/>
+      </constraints>
+      <costs>
+        <cost name="pts" typeId="points" value="600"/>
+        <cost name="Destiny Points" typeId="bc33-05f5-8d3f-af43" value="0"/>
+        <cost name="Force Category - PTG" typeId="e63c-79ff-93ba-c5eb" value="0"/>
+        <cost name="Force Category - GHB" typeId="de92-2099-fbf7-a156" value="0"/>
       </costs>
     </forceEntry>
     <forceEntry name="One-eyed Grunnock" id="733b-7b81-c2b-b772" hidden="true">
@@ -13818,6 +13916,8 @@
         <forceEntryLink name="Brand&apos;s Oathbound" id="7894-f810-3ceb-3ec1" hidden="false" targetId="f8bf-3c82-73dc-a7e8" type="forceEntry"/>
         <forceEntryLink name="Bundo Whalebiter" id="cfad-8d09-3590-b433" hidden="false" targetId="fb09-ac57-e70e-716d" type="forceEntry"/>
         <forceEntryLink name="Da Hurtlin&apos; Hogz" id="ca7e-b2cb-83a2-59f4" hidden="false" targetId="3cd2-b31b-43c8-e42c" type="forceEntry"/>
+        <forceEntryLink name="Okar&apos;s Torrbad" id="6ac5-295e-993b-ff14" hidden="false" targetId="7199-3205-3f4e-5567" type="forceEntry"/>
+        <forceEntryLink name="Urrgar&apos;s Maulerguts" id="6e6a-6824-8273-5661" hidden="false" targetId="71ed-0753-4dbb-c952" type="forceEntry"/>
         <forceEntryLink name="Da Kountin&apos; Krew" id="33a0-b698-5e4b-bc74" hidden="false" targetId="1d9c-5fbb-bb1e-bdb8" type="forceEntry"/>
         <forceEntryLink name="Drekki&apos;s Privateers" id="15cf-2bef-c1a0-d16f" hidden="false" targetId="accf-873b-ebe8-1d1c" type="forceEntry"/>
         <forceEntryLink name="Elthwin&apos;s Thorns" id="0039-d6da-433e-f4fd" hidden="false" targetId="e484-c06-d856-2921" type="forceEntry"/>

--- a/Age of Sigmar 4.0.gst
+++ b/Age of Sigmar 4.0.gst
@@ -291,9 +291,11 @@
     <categoryEntry name="WARFLOCK" id="33cc-ab90-fc8f-69ec" hidden="false"/>
     <categoryEntry name="KHARADRON OVERLORDS" id="9c8d-276-b7d2-f1fd" hidden="false"/>
     <categoryEntry name="SKYFARER" id="e13e-4c7c-54fd-908" hidden="false"/>
+    <categoryEntry name="BEASTCLAW" id="410d-6b15-3cf4-88d0" hidden="false"/>
     <categoryEntry name="BEASTCLAW RAIDERS" id="1a3d-33f9-c4cc-fe0" hidden="false"/>
     <categoryEntry name="CHAMPION (1/5)" id="11c3-dbff-a3f7-ab" hidden="false"/>
     <categoryEntry name="GUTBUSTERS" id="5c0d-5e93-d71f-f0da" hidden="false"/>
+    <categoryEntry name="MAWSEEKERS" id="b50b-6a98-f92a-c99c" hidden="false"/>
     <categoryEntry name="MUSICIAN (1/6)" id="a9bc-adc0-42a0-e843" hidden="false"/>
     <categoryEntry name="OGOR" id="ddcb-3c91-472f-c35a" hidden="false"/>
     <categoryEntry name="OGOR MAWTRIBES" id="743-1bd8-e3d-ced2" hidden="false"/>
@@ -15709,6 +15711,7 @@ Each part of this **^^Manifestation^^** is armed with **Tendrils of Light and S
     <publication name="Regiments of Renown" id="27d9-b0c5-1ecc-ba2f" hidden="false"/>
     <publication name="Battletome: Lumineth Realmlords" id="9ed1-cf74-eb97-dee2" hidden="false"/>
     <publication name="Faction Pack: Ogor Mawtribes" id="1ac6-e227-a186-12" hidden="false"/>
+    <publication name="Battletome: Ogor Mawtribes" id="feba-6749-6df3-ea9e" hidden="false"/>
     <publication name="Battletome: Hedonites of Slaanesh" id="95fc-e96f-a916-bba1" hidden="false"/>
     <publication name="Battletome: Maggotkin of Nurgle" id="9c71-86cb-e1d0-ec8d" hidden="false"/>
     <publication name="Battletome: Nighthaunt" id="67f7-aa7f-294f-880d" hidden="false"/>

--- a/Lores.cat
+++ b/Lores.cat
@@ -4952,7 +4952,7 @@ If the chanting roll was 8+, add 1 to the Attacks characteristic of the target&
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
-    <selectionEntryGroup name="Lore of Gut Magic" id="1708-0960-47ad-a552" hidden="false" publicationId="feba-6749-6df3-ea9e">
+    <selectionEntryGroup name="Lore of Gut Magic" id="1708-0960-47ad-a552" hidden="false" publicationId="1ac6-e227-a186-12">
       <selectionEntries>
         <selectionEntry type="upgrade" import="true" name="Blood Feast" hidden="false" id="6e44-eda7-7752-3c3e">
           <profiles>
@@ -5045,7 +5045,7 @@ If the chanting roll was 8+, add 1 to the Attacks characteristic of the target&
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
-    <selectionEntryGroup name="Lore of the Everwinter" id="e5b8-86da-de17-d117" hidden="false" publicationId="feba-6749-6df3-ea9e">
+    <selectionEntryGroup name="Lore of the Everwinter" id="e5b8-86da-de17-d117" hidden="false" publicationId="1ac6-e227-a186-12">
       <selectionEntries>
         <selectionEntry type="upgrade" import="true" name="Freezing Tailwinds" hidden="false" id="a038-780f-2395-811b">
           <profiles>

--- a/Lores.cat
+++ b/Lores.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="true" id="0a11-cd61-2a4e-8e04" name="❖ Lores" gameSystemId="e51d-b1a3-75fc-dc3g" gameSystemRevision="15" revision="77" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="true" id="0a11-cd61-2a4e-8e04" name="❖ Lores" gameSystemId="e51d-b1a3-75fc-dc3g" gameSystemRevision="15" revision="78" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <sharedSelectionEntryGroups>
     <selectionEntryGroup name="Brodd&apos;s Bellows" id="f678-9cf2-1433-0bd8" hidden="true" publicationId="9e18-bb03-7b60-d4ff">
       <selectionEntries>
@@ -14844,6 +14844,190 @@ In addition, if the chanting roll was 8+, add 1 to the Attacks characteristic of
           </conditionGroups>
         </modifier>
       </modifiers>
+    </selectionEntryGroup>
+    <selectionEntryGroup name="Alfrostun Prayer Lore" id="2c0c-99e2-717c-d10f" hidden="false" publicationId="1ac6-e227-a186-12">
+      <selectionEntries>
+        <selectionEntry type="upgrade" import="true" name="Keening Gale" hidden="false" id="5777-f7f4-875c-a63f">
+          <profiles>
+            <profile name="Keening Gale" typeId="5946-234-d7b4-6195" typeName="Ability (Prayer)" hidden="false" id="cee1-85cf-8221-bf39">
+              <characteristics>
+                <characteristic name="Timing" typeId="76bf-8126-64d4-c709">Your Hero Phase</characteristic>
+                <characteristic name="Chanting Value" typeId="f192-6780-8138-9cef">3</characteristic>
+                <characteristic name="Declare" typeId="284c-90b2-245b-adf3">Pick a friendly **^^Alfrostun Priest^^** to chant this prayer, pick a visible friendly **^^Alfrostun^^** unit wholly within 12&quot; of them to be the target, then make a chanting roll of D6.</characteristic>
+                <characteristic name="Effect" typeId="6219-6fcc-5ae2-a6b7">Until the start of your next turn, add 2 to run rolls for the target. In addition, if the chanting roll was 6+, until the start of your next turn, add 2 to charge rolls for the target.</characteristic>
+                <characteristic name="Keywords" typeId="e3d8-f58b-e4e0-8e9d">**^^Prayer^^**, **^^Unlimited^^**</characteristic>
+              </characteristics>
+              <attributes>
+                <attribute name="Color" typeId="7564-4bf0-b34a-b143">Yellow</attribute>
+                <attribute name="Type" typeId="c63c-196d-34a7-cec3">Movement</attribute>
+                <attribute name="Parent Node" typeId="5d25-63d6-3935-9312"/>
+              </attributes>
+            </profile>
+          </profiles>
+          <constraints>
+            <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="70ce-40e5-af85-8083" automatic="true"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="de9a-271a-a996-cd52" automatic="true"/>
+          </constraints>
+          <modifiers>
+            <modifier type="set" value="1" field="70ce-40e5-af85-8083">
+              <conditions>
+                <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="707c-1c04-9af6-2307" shared="true"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry type="upgrade" import="true" name="Terrors of the Old Ice" hidden="false" id="3554-8b55-77cb-23d5">
+          <profiles>
+            <profile name="Terrors of the Old Ice" typeId="5946-234-d7b4-6195" typeName="Ability (Prayer)" hidden="false" id="8dc8-2048-ad2e-4aed">
+              <characteristics>
+                <characteristic name="Timing" typeId="76bf-8126-64d4-c709">Your Hero Phase</characteristic>
+                <characteristic name="Chanting Value" typeId="f192-6780-8138-9cef">4</characteristic>
+                <characteristic name="Declare" typeId="284c-90b2-245b-adf3">Pick a friendly **^^Alfrostun Priest^^** to chant this prayer, pick an objective or terrain feature wholly within 18&quot; of them to be the target, then make a chanting roll of D6.</characteristic>
+                <characteristic name="Effect" typeId="6219-6fcc-5ae2-a6b7">Until the start of your next turn, subtract 10 from the control scores of enemy units while they are contesting the target. If the chanting roll was 8+, until the start of your next turn, enemy units have a maximum control score of 1 while they are contesting the target.</characteristic>
+                <characteristic name="Keywords" typeId="e3d8-f58b-e4e0-8e9d">**^^Prayer^^**</characteristic>
+              </characteristics>
+              <attributes>
+                <attribute name="Color" typeId="7564-4bf0-b34a-b143">Yellow</attribute>
+                <attribute name="Type" typeId="c63c-196d-34a7-cec3">Control</attribute>
+                <attribute name="Parent Node" typeId="5d25-63d6-3935-9312"/>
+              </attributes>
+            </profile>
+          </profiles>
+          <constraints>
+            <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="cef3-ee31-c88d-9911" automatic="true"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="5c5d-0e72-52cb-9a94" automatic="true"/>
+          </constraints>
+          <modifiers>
+            <modifier type="set" value="1" field="cef3-ee31-c88d-9911">
+              <conditions>
+                <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="707c-1c04-9af6-2307" shared="true"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry type="upgrade" import="true" name="Avalanche Voice" hidden="false" id="6286-ea54-990c-0d66">
+          <profiles>
+            <profile name="Avalanche Voice" typeId="5946-234-d7b4-6195" typeName="Ability (Prayer)" hidden="false" id="1d26-59a8-78a4-2dde">
+              <characteristics>
+                <characteristic name="Timing" typeId="76bf-8126-64d4-c709">Your Hero Phase</characteristic>
+                <characteristic name="Chanting Value" typeId="f192-6780-8138-9cef">4</characteristic>
+                <characteristic name="Declare" typeId="284c-90b2-245b-adf3">Pick a friendly **^^Alfrostun Priest^^** to chant this prayer, pick a visible enemy unit within 18&quot; of them to be the target, then make a chanting roll of D6.</characteristic>
+                <characteristic name="Effect" typeId="6219-6fcc-5ae2-a6b7">Until the start of your next turn, each time your opponent declares a command for the target, as a reaction, make a tremor roll of D6 for the target. On a 5+, unless they spend 1 additional command point to use that command, the command has no effect, it still counts as having been used and the command points spent to use it are still lost. In addition, if the chanting roll was 8+, until the start of your next turn, add 2 to tremor rolls for the target.</characteristic>
+                <characteristic name="Keywords" typeId="e3d8-f58b-e4e0-8e9d">**^^Prayer^^**</characteristic>
+              </characteristics>
+              <attributes>
+                <attribute name="Color" typeId="7564-4bf0-b34a-b143">Yellow</attribute>
+                <attribute name="Type" typeId="c63c-196d-34a7-cec3">Special</attribute>
+                <attribute name="Parent Node" typeId="5d25-63d6-3935-9312"/>
+              </attributes>
+            </profile>
+          </profiles>
+          <constraints>
+            <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="1676-b094-476c-d2da" automatic="true"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="a22d-a5f8-9d8c-fb6a" automatic="true"/>
+          </constraints>
+          <modifiers>
+            <modifier type="set" value="1" field="1676-b094-476c-d2da">
+              <conditions>
+                <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="707c-1c04-9af6-2307" shared="true"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup name="Gollop Spell Lore" id="6fbc-8802-19c4-8cba" hidden="false" publicationId="1ac6-e227-a186-12">
+      <selectionEntries>
+        <selectionEntry type="upgrade" import="true" name="Bonecruncher" hidden="false" id="1dea-7c56-5feb-afbe">
+          <profiles>
+            <profile name="Bonecruncher" typeId="7312-8367-c171-f2ef" typeName="Ability (Spell)" hidden="false" id="d60d-4c6c-6d0c-2607">
+              <characteristics>
+                <characteristic name="Timing" typeId="76bf-8126-64d4-c709">Your Hero Phase</characteristic>
+                <characteristic name="Casting Value" typeId="9fc7-b0f6-d018-a608">5</characteristic>
+                <characteristic name="Declare" typeId="284c-90b2-245b-adf3">Pick a friendly **^^Gollop Wizard^^** to cast this spell, pick a visible enemy unit within 18&quot; of them that has not been picked to be the target of this ability this turn to be the target, then make a casting roll of 2D6.</characteristic>
+                <characteristic name="Effect" typeId="6219-6fcc-5ae2-a6b7">Inflict D3 mortal damage on the target. Gain a number of **raw ingredients** equal to the number of those damage points that are allocated to the target.</characteristic>
+                <characteristic name="Keywords" typeId="e3d8-f58b-e4e0-8e9d">**^^Spell^^**, **^^Unlimited^^**</characteristic>
+              </characteristics>
+              <attributes>
+                <attribute name="Color" typeId="7564-4bf0-b34a-b143">Yellow</attribute>
+                <attribute name="Type" typeId="c63c-196d-34a7-cec3">Offensive</attribute>
+                <attribute name="Parent Node" typeId="5d25-63d6-3935-9312"/>
+              </attributes>
+            </profile>
+          </profiles>
+          <constraints>
+            <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="1fb7-deb5-102d-58a8" automatic="true"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="b313-831f-316e-5fb3" automatic="true"/>
+          </constraints>
+          <modifiers>
+            <modifier type="set" value="1" field="1fb7-deb5-102d-58a8">
+              <conditions>
+                <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="707c-1c04-9af6-2307" shared="true"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry type="upgrade" import="true" name="Bloodgruel" hidden="false" id="1466-cdeb-1d03-485b">
+          <profiles>
+            <profile name="Bloodgruel" typeId="7312-8367-c171-f2ef" typeName="Ability (Spell)" hidden="false" id="665b-6f65-9cdc-0550">
+              <characteristics>
+                <characteristic name="Timing" typeId="76bf-8126-64d4-c709">Your Hero Phase</characteristic>
+                <characteristic name="Casting Value" typeId="9fc7-b0f6-d018-a608">7</characteristic>
+                <characteristic name="Declare" typeId="284c-90b2-245b-adf3">Pick a friendly **^^Gollop Wizard^^** to cast this spell, pick a visible friendly **^^Gollop^^** unit wholly within 12&quot; of them to be the target, then make a casting roll of 2D6.</characteristic>
+                <characteristic name="Effect" typeId="6219-6fcc-5ae2-a6b7">Pick 1 of the following effects:
+• Return 1 slain model to the target.
+• **Heal (D6)** the target.</characteristic>
+                <characteristic name="Keywords" typeId="e3d8-f58b-e4e0-8e9d">**^^Spell^^**</characteristic>
+              </characteristics>
+              <attributes>
+                <attribute name="Color" typeId="7564-4bf0-b34a-b143">Yellow</attribute>
+                <attribute name="Type" typeId="c63c-196d-34a7-cec3">Rallying</attribute>
+                <attribute name="Parent Node" typeId="5d25-63d6-3935-9312"/>
+              </attributes>
+            </profile>
+          </profiles>
+          <constraints>
+            <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="b625-a1a8-ad2e-9401" automatic="true"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="28b6-aa88-e89b-bbc4" automatic="true"/>
+          </constraints>
+          <modifiers>
+            <modifier type="set" value="1" field="b625-a1a8-ad2e-9401">
+              <conditions>
+                <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="707c-1c04-9af6-2307" shared="true"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+        <selectionEntry type="upgrade" import="true" name="The Cosmos Writhes" hidden="false" id="5593-9427-d2e4-b3d9">
+          <profiles>
+            <profile name="The Cosmos Writhes" typeId="7312-8367-c171-f2ef" typeName="Ability (Spell)" hidden="false" id="b095-65e6-69bb-44f0">
+              <characteristics>
+                <characteristic name="Timing" typeId="76bf-8126-64d4-c709">Your Hero Phase</characteristic>
+                <characteristic name="Casting Value" typeId="9fc7-b0f6-d018-a608">6</characteristic>
+                <characteristic name="Declare" typeId="284c-90b2-245b-adf3">Pick a friendly **^^Gollop Wizard^^** to cast this spell, pick a visible friendly **^^Gollop^^** unit wholly within 12&quot; of them to be the target, then make a casting roll of 2D6.</characteristic>
+                <characteristic name="Effect" typeId="6219-6fcc-5ae2-a6b7">Remove the target from the battlefield and set it up again on the battlefield more than 9&quot; from all enemy units.</characteristic>
+                <characteristic name="Keywords" typeId="e3d8-f58b-e4e0-8e9d">**^^Spell^^**</characteristic>
+              </characteristics>
+              <attributes>
+                <attribute name="Color" typeId="7564-4bf0-b34a-b143">Yellow</attribute>
+                <attribute name="Type" typeId="c63c-196d-34a7-cec3">Movement</attribute>
+                <attribute name="Parent Node" typeId="5d25-63d6-3935-9312"/>
+              </attributes>
+            </profile>
+          </profiles>
+          <constraints>
+            <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="17ff-8e9c-1d71-0704" automatic="true"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="0569-c629-986d-bcf7" automatic="true"/>
+          </constraints>
+          <modifiers>
+            <modifier type="set" value="1" field="17ff-8e9c-1d71-0704">
+              <conditions>
+                <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="707c-1c04-9af6-2307" shared="true"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+      </selectionEntries>
     </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <catalogueLinks>

--- a/Lores.cat
+++ b/Lores.cat
@@ -4952,182 +4952,187 @@ If the chanting roll was 8+, add 1 to the Attacks characteristic of the target&
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
-    <selectionEntryGroup name="Lore of Maw-magic" id="6958-4e79-e1d0-14e8" hidden="false" publicationId="1ac6-e227-a186-12">
+    <selectionEntryGroup name="Lore of Gut Magic" id="1708-0960-47ad-a552" hidden="false" publicationId="feba-6749-6df3-ea9e">
       <selectionEntries>
-        <selectionEntry type="upgrade" import="true" name="Blood Feast" hidden="false" id="f6c7-91f2-6bf8-760c">
+        <selectionEntry type="upgrade" import="true" name="Blood Feast" hidden="false" id="6e44-eda7-7752-3c3e">
           <profiles>
-            <profile name="Blood Feast" typeId="7312-8367-c171-f2ef" typeName="Ability (Spell)" hidden="false" id="8f75-3c74-a240-b4aa">
+            <profile name="Blood Feast" typeId="7312-8367-c171-f2ef" typeName="Ability (Spell)" hidden="false" id="aea6-b194-048f-9118">
               <characteristics>
-                <characteristic name="Timing" typeId="de6f-d57b-248a-83be">Your Hero Phase</characteristic>
-                <characteristic name="Casting Value" typeId="9fc7-b0f6-d018-a608">7</characteristic>
-                <characteristic name="Declare" typeId="24f8-3803-4ab1-3b6c">Pick a friendly **^^Ogor Mawtribes Wizard^^** to cast this spell, pick a visible friendly **^^Ogor Infantry^^** unit wholly within 12&quot; of them to be the target, then make a casting roll of 2D6.</characteristic>
-                <characteristic name="Effect" typeId="1cb9-a-1345-907f">Add 1 to the Attacks characteristic of the target&apos;s melee weapons until the start of your next turn.</characteristic>
-                <characteristic name="Keywords" typeId="353f-565e-c351-1cf2">**^^Spell^^**</characteristic>
-              </characteristics>
-              <attributes>
-                <attribute typeId="16b6-0911-f549-a4bd" name="Color">Yellow</attribute>
-                <attribute typeId="da27-8d61-f955-5031" name="Parent Node">Offensive</attribute>
-              </attributes>
-            </profile>
-          </profiles>
-          <modifiers>
-            <modifier type="set" value="1" field="26a8-bce5-eb8c-1a3a">
-              <conditions>
-                <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="707c-1c04-9af6-2307" shared="true"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="26a8-bce5-eb8c-1a3a" automatic="true"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="9fcf-eda6-d1ef-e895" automatic="true"/>
-          </constraints>
-        </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="Greasy Deluge" hidden="false" id="5b23-1aee-3c47-0deb">
-          <profiles>
-            <profile name="Greasy Deluge" typeId="7312-8367-c171-f2ef" typeName="Ability (Spell)" hidden="false" id="acb5-96be-2523-8e8b">
-              <characteristics>
-                <characteristic name="Timing" typeId="de6f-d57b-248a-83be">Your Hero Phase</characteristic>
+                <characteristic name="Timing" typeId="76bf-8126-64d4-c709">Your Hero Phase</characteristic>
                 <characteristic name="Casting Value" typeId="9fc7-b0f6-d018-a608">6</characteristic>
-                <characteristic name="Declare" typeId="24f8-3803-4ab1-3b6c">Pick a friendly **^^Ogor Mawtribes Wizard^^** to cast this spell, pick a visible enemy unit within 18&quot; of them to be the target, then make a casting roll of 2D6.</characteristic>
-                <characteristic name="Effect" typeId="1cb9-a-1345-907f">Subtract 1 from hit rolls for the target&apos;s attacks until the start of your next turn.</characteristic>
-                <characteristic name="Keywords" typeId="353f-565e-c351-1cf2">**^^Spell^^**</characteristic>
+                <characteristic name="Declare" typeId="284c-90b2-245b-adf3">Pick a friendly **^^Ogor Mawtribes Wizard^^** to cast this spell, pick a visible friendly **^^Ogor Mawtribes^^** unit wholly within 12&quot; of them to be the target, then make a casting roll of 2D6.</characteristic>
+                <characteristic name="Effect" typeId="6219-6fcc-5ae2-a6b7">Until the start of your next turn, add 1 to hit rolls for the target's combat attacks.</characteristic>
+                <characteristic name="Keywords" typeId="e3d8-f58b-e4e0-8e9d">**^^Spell^^**, **^^Unlimited^^**</characteristic>
               </characteristics>
               <attributes>
-                <attribute typeId="16b6-0911-f549-a4bd" name="Color">Yellow</attribute>
-                <attribute typeId="da27-8d61-f955-5031" name="Parent Node">Defensive</attribute>
+                <attribute name="Color" typeId="7564-4bf0-b34a-b143">Yellow</attribute>
+                <attribute name="Type" typeId="c63c-196d-34a7-cec3">Offensive</attribute>
+                <attribute name="Parent Node" typeId="5d25-63d6-3935-9312"/>
               </attributes>
             </profile>
           </profiles>
+          <constraints>
+            <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="d34a-aa08-3145-317f" automatic="true"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ac5f-f47f-83ab-4758" automatic="true"/>
+          </constraints>
           <modifiers>
-            <modifier type="set" value="1" field="ca18-919a-1f27-151e">
+            <modifier type="set" value="1" field="d34a-aa08-3145-317f">
               <conditions>
                 <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="707c-1c04-9af6-2307" shared="true"/>
               </conditions>
             </modifier>
           </modifiers>
-          <constraints>
-            <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="ca18-919a-1f27-151e" automatic="true"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="5bd0-fa0f-3d0f-7cfb" automatic="true"/>
-          </constraints>
         </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="Troggoth Guts" hidden="false" id="4692-b37e-8dc1-9890">
+        <selectionEntry type="upgrade" import="true" name="Shincruncher" hidden="false" id="4cb4-d093-a9be-a74e">
           <profiles>
-            <profile name="Troggoth Guts" typeId="7312-8367-c171-f2ef" typeName="Ability (Spell)" hidden="false" id="0b59-1e13-826a-57c0">
+            <profile name="Shincruncher" typeId="7312-8367-c171-f2ef" typeName="Ability (Spell)" hidden="false" id="30f0-cbdc-6471-88e4">
               <characteristics>
-                <characteristic name="Timing" typeId="de6f-d57b-248a-83be">Your Hero Phase</characteristic>
-                <characteristic name="Casting Value" typeId="9fc7-b0f6-d018-a608">5</characteristic>
-                <characteristic name="Declare" typeId="24f8-3803-4ab1-3b6c">Pick a friendly **^^Ogor Mawtribes Wizard^^** to cast this spell, pick a visible friendly **^^Ogor Mawtribes^^** unit within 12&quot; of them that has not been picked to be the target of this ability this turn to be the target, then make a casting roll of 2D6.</characteristic>
-                <characteristic name="Effect" typeId="1cb9-a-1345-907f">**Heal (D3)** the target and add 3 to the target&apos;s control score for the rest of the turn.</characteristic>
-                <characteristic name="Keywords" typeId="353f-565e-c351-1cf2">**^^Spell^^**, **^^Unlimited^^**</characteristic>
+                <characteristic name="Timing" typeId="76bf-8126-64d4-c709">Your Hero Phase</characteristic>
+                <characteristic name="Casting Value" typeId="9fc7-b0f6-d018-a608">7</characteristic>
+                <characteristic name="Declare" typeId="284c-90b2-245b-adf3">Pick a friendly **^^Ogor Mawtribes Wizard^^** to cast this spell, pick a visible enemy unit within 12&quot; of them to be the target, then make a casting roll of 2D6.</characteristic>
+                <characteristic name="Effect" typeId="6219-6fcc-5ae2-a6b7">Until the start of your next turn, each time the target ends a move or is set up on the battlefield, inflict D3 mortal damage on the target after the ability has been resolved.
+
+***Designer's Note**: The 'Bull Charge' ability in the battle traits forces an enemy unit to move.*</characteristic>
+                <characteristic name="Keywords" typeId="e3d8-f58b-e4e0-8e9d">**^^Spell^^**</characteristic>
               </characteristics>
               <attributes>
-                <attribute typeId="16b6-0911-f549-a4bd" name="Color">Yellow</attribute>
-                <attribute typeId="da27-8d61-f955-5031" name="Parent Node">Special</attribute>
+                <attribute name="Color" typeId="7564-4bf0-b34a-b143">Yellow</attribute>
+                <attribute name="Type" typeId="c63c-196d-34a7-cec3">Offensive</attribute>
+                <attribute name="Parent Node" typeId="5d25-63d6-3935-9312"/>
               </attributes>
             </profile>
           </profiles>
+          <constraints>
+            <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="ec7d-67f3-4f89-7eea" automatic="true"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6a10-c796-0b02-dfe3" automatic="true"/>
+          </constraints>
           <modifiers>
-            <modifier type="set" value="1" field="77bb-cc5e-ab4e-a892">
+            <modifier type="set" value="1" field="ec7d-67f3-4f89-7eea">
               <conditions>
                 <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="707c-1c04-9af6-2307" shared="true"/>
               </conditions>
             </modifier>
           </modifiers>
+        </selectionEntry>
+        <selectionEntry type="upgrade" import="true" name="Tallowflage" hidden="false" id="f2be-6d2e-d661-712f">
+          <profiles>
+            <profile name="Tallowflage" typeId="7312-8367-c171-f2ef" typeName="Ability (Spell)" hidden="false" id="5edd-65a7-c6c5-918d">
+              <characteristics>
+                <characteristic name="Timing" typeId="76bf-8126-64d4-c709">Your Hero Phase</characteristic>
+                <characteristic name="Casting Value" typeId="9fc7-b0f6-d018-a608">7</characteristic>
+                <characteristic name="Declare" typeId="284c-90b2-245b-adf3">Pick a friendly **^^Ogor Mawtribes Wizard^^** to cast this spell, pick a visible friendly **^^Ogor Mawtribes^^** unit wholly within 12&quot; of them to be the target, then make a casting roll of 2D6.</characteristic>
+                <characteristic name="Effect" typeId="6219-6fcc-5ae2-a6b7">Until the start of your next turn, the target is not visible to enemy units more than 12&quot; away from it.</characteristic>
+                <characteristic name="Keywords" typeId="e3d8-f58b-e4e0-8e9d">**^^Spell^^**</characteristic>
+              </characteristics>
+              <attributes>
+                <attribute name="Color" typeId="7564-4bf0-b34a-b143">Yellow</attribute>
+                <attribute name="Type" typeId="c63c-196d-34a7-cec3">Defensive</attribute>
+                <attribute name="Parent Node" typeId="5d25-63d6-3935-9312"/>
+              </attributes>
+            </profile>
+          </profiles>
           <constraints>
-            <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="77bb-cc5e-ab4e-a892" automatic="true"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="17fd-a47c-180a-33da" automatic="true"/>
+            <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="7b6d-3f30-cb57-8147" automatic="true"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="c871-c4f5-a042-027c" automatic="true"/>
           </constraints>
+          <modifiers>
+            <modifier type="set" value="1" field="7b6d-3f30-cb57-8147">
+              <conditions>
+                <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="707c-1c04-9af6-2307" shared="true"/>
+              </conditions>
+            </modifier>
+          </modifiers>
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
-    <selectionEntryGroup name="Everwinter Prayers" id="48ca-ef37-a530-211f" hidden="false" publicationId="1ac6-e227-a186-12">
+    <selectionEntryGroup name="Lore of the Everwinter" id="e5b8-86da-de17-d117" hidden="false" publicationId="feba-6749-6df3-ea9e">
       <selectionEntries>
-        <selectionEntry type="upgrade" import="true" name="Call of the Blizzard" hidden="false" id="112a-91d9-a0bf-e0f2">
+        <selectionEntry type="upgrade" import="true" name="Freezing Tailwinds" hidden="false" id="a038-780f-2395-811b">
           <profiles>
-            <profile name="Call of the Blizzard" typeId="5946-234-d7b4-6195" typeName="Ability (Prayer)" hidden="false" id="aa48-f372-adbc-1e8b">
+            <profile name="Freezing Tailwinds" typeId="5946-234-d7b4-6195" typeName="Ability (Prayer)" hidden="false" id="3806-cf14-6e21-031e">
               <characteristics>
                 <characteristic name="Timing" typeId="76bf-8126-64d4-c709">Your Hero Phase</characteristic>
-                <characteristic name="Chanting Value" typeId="f192-6780-8138-9cef">4</characteristic>
-                <characteristic name="Declare" typeId="284c-90b2-245b-adf3">Pick a friendly **^^Ogor Mawtribes Priest^^** to chant this prayer, pick a terrain feature within 18&quot; of them to be the target, then make a chanting roll of D6.</characteristic>
-                <characteristic name="Effect" typeId="6219-6fcc-5ae2-a6b7">Place a **blizzard token** next to the target. Terrain features that have a **blizzard token** gain the &apos;Obscuring&apos; terrain ability. In addition, if the chanting roll was 8+, until the start of your next turn, friendly **^^Beastclaw Raiders^^** units have **^^Ward (5+)^^** while they are within 3&quot; of any terrain features that have **blizzard tokens**.</characteristic>
+                <characteristic name="Chanting Value" typeId="f192-6780-8138-9cef">3</characteristic>
+                <characteristic name="Declare" typeId="284c-90b2-245b-adf3">Pick a friendly **^^Ogor Mawtribes^^** **^^Priest^^** to chant this prayer, pick a visible friendly **^^Ogor Mawtribes^^** unit wholly within 12&quot; of them to be the target, then make a chanting roll of D6.</characteristic>
+                <characteristic name="Effect" typeId="6219-6fcc-5ae2-a6b7">Until the start of your next turn, add 1 to run rolls and charge rolls for the target. Add 2 instead if the chanting roll was 6+.</characteristic>
                 <characteristic name="Keywords" typeId="e3d8-f58b-e4e0-8e9d">**^^Prayer^^**, **^^Unlimited^^**</characteristic>
               </characteristics>
               <attributes>
-                <attribute typeId="7564-4bf0-b34a-b143" name="Color">Yellow</attribute>
-                <attribute typeId="c63c-196d-34a7-cec3" name="Type">Defensive</attribute>
+                <attribute name="Color" typeId="7564-4bf0-b34a-b143">Yellow</attribute>
+                <attribute name="Type" typeId="c63c-196d-34a7-cec3">Movement</attribute>
                 <attribute name="Parent Node" typeId="5d25-63d6-3935-9312"/>
               </attributes>
             </profile>
           </profiles>
+          <constraints>
+            <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="311e-d76c-3841-cb4c" automatic="true"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="36f3-87fe-881c-01b0" automatic="true"/>
+          </constraints>
           <modifiers>
-            <modifier type="set" value="1" field="8cd6-155b-5768-8004">
+            <modifier type="set" value="1" field="311e-d76c-3841-cb4c">
               <conditions>
                 <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="707c-1c04-9af6-2307" shared="true"/>
               </conditions>
             </modifier>
           </modifiers>
-          <constraints>
-            <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="8cd6-155b-5768-8004" automatic="true"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="d2c8-4649-241f-22f1" automatic="true"/>
-          </constraints>
         </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="Keening Gale" hidden="false" id="b4d0-119c-ba7c-01bd">
+        <selectionEntry type="upgrade" import="true" name="Pulverising Hailstorm" hidden="false" id="ef60-445a-a280-ebd1">
           <profiles>
-            <profile name="Keening Gale" typeId="5946-234-d7b4-6195" typeName="Ability (Prayer)" hidden="false" id="5f4b-52dc-577b-bd86">
+            <profile name="Pulverising Hailstorm" typeId="5946-234-d7b4-6195" typeName="Ability (Prayer)" hidden="false" id="6a91-c703-5deb-4785">
               <characteristics>
                 <characteristic name="Timing" typeId="76bf-8126-64d4-c709">Your Hero Phase</characteristic>
                 <characteristic name="Chanting Value" typeId="f192-6780-8138-9cef">4</characteristic>
-                <characteristic name="Declare" typeId="284c-90b2-245b-adf3">Pick a friendly **^^Ogor Mawtribes Priest^^** to chant this prayer, pick a visible friendly **^^Ogor Mawtribes Monster^^** or **Mournfang Pack** unit wholly within 12&quot; of them to be the target, then make a chanting roll of D6.</characteristic>
-                <characteristic name="Effect" typeId="6219-6fcc-5ae2-a6b7">For the rest of the turn, the target can use a **^^Run^^** ability and still use **^^Charge^^** abilities later in the turn. In addition, if the chanting roll was 8+, you can re-roll run rolls and charge rolls for the target for the rest of the turn.</characteristic>
+                <characteristic name="Declare" typeId="284c-90b2-245b-adf3">Pick a friendly **^^Ogor Mawtribes^^** **^^Priest^^** to chant this prayer, pick a visible enemy unit within 12&quot; of them to be the target, then make a chanting roll of D6.</characteristic>
+                <characteristic name="Effect" typeId="6219-6fcc-5ae2-a6b7">If the chanting roll was 8+, you can pick another eligible unit to be a second target. Then, inflict 3 mortal damage on the target(s).</characteristic>
                 <characteristic name="Keywords" typeId="e3d8-f58b-e4e0-8e9d">**^^Prayer^^**</characteristic>
               </characteristics>
               <attributes>
-                <attribute typeId="7564-4bf0-b34a-b143" name="Color">Yellow</attribute>
-                <attribute typeId="c63c-196d-34a7-cec3" name="Type">Movement</attribute>
+                <attribute name="Color" typeId="7564-4bf0-b34a-b143">Yellow</attribute>
+                <attribute name="Type" typeId="c63c-196d-34a7-cec3">Offensive</attribute>
                 <attribute name="Parent Node" typeId="5d25-63d6-3935-9312"/>
               </attributes>
             </profile>
           </profiles>
+          <constraints>
+            <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="35e6-8b34-9e3e-c399" automatic="true"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="c644-e5fe-b1d8-d956" automatic="true"/>
+          </constraints>
           <modifiers>
-            <modifier type="set" value="1" field="3eaf-135e-7c6f-8f8f">
+            <modifier type="set" value="1" field="35e6-8b34-9e3e-c399">
               <conditions>
                 <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="707c-1c04-9af6-2307" shared="true"/>
               </conditions>
             </modifier>
           </modifiers>
-          <constraints>
-            <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="3eaf-135e-7c6f-8f8f" automatic="true"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="3f22-60ec-efe5-475d" automatic="true"/>
-          </constraints>
         </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="Pulverising Hailstorm" hidden="false" id="c3ed-a420-c909-aa37">
+        <selectionEntry type="upgrade" import="true" name="Fortifying Hoarfrost" hidden="false" id="9395-875c-2afe-54e9">
           <profiles>
-            <profile name="Pulverising Hailstorm" typeId="5946-234-d7b4-6195" typeName="Ability (Prayer)" hidden="false" id="b9e2-9c10-8976-147">
+            <profile name="Fortifying Hoarfrost" typeId="5946-234-d7b4-6195" typeName="Ability (Prayer)" hidden="false" id="d373-2edb-e803-7270">
               <characteristics>
                 <characteristic name="Timing" typeId="76bf-8126-64d4-c709">Your Hero Phase</characteristic>
                 <characteristic name="Chanting Value" typeId="f192-6780-8138-9cef">4</characteristic>
-                <characteristic name="Declare" typeId="284c-90b2-245b-adf3">Pick a friendly **^^Ogor Mawtribes Priest^^** to chant this prayer, pick a point on the battlefield within 12&quot; of them, then pick each visible enemy unit within 3&quot; of that point to be the targets. Then, make a chanting roll of D6.</characteristic>
-                <characteristic name="Effect" typeId="6219-6fcc-5ae2-a6b7">Roll a D3 for each target. On a 2+, inflict an amount of mortal damage on the target equal to the roll. If the chanting roll was 8+, double the amount of mortal damage inflicted.</characteristic>
+                <characteristic name="Declare" typeId="284c-90b2-245b-adf3">Pick a friendly **^^Ogor Mawtribes^^** **^^Priest^^** to chant this prayer, pick a visible friendly **^^Ogor Mawtribes^^** unit wholly within 12&quot; of them to be the target, then make a chanting roll of D6.</characteristic>
+                <characteristic name="Effect" typeId="6219-6fcc-5ae2-a6b7">Until the start of your next turn, subtract 1 from wound rolls for attacks that target that friendly unit. In addition, if the chanting roll was 8+, until the start of your next turn, subtract 1 from the Rend characteristic of weapons used for attacks that target that friendly unit.</characteristic>
                 <characteristic name="Keywords" typeId="e3d8-f58b-e4e0-8e9d">**^^Prayer^^**</characteristic>
               </characteristics>
               <attributes>
-                <attribute typeId="7564-4bf0-b34a-b143" name="Color">Yellow</attribute>
-                <attribute typeId="c63c-196d-34a7-cec3" name="Type">Offensive</attribute>
+                <attribute name="Color" typeId="7564-4bf0-b34a-b143">Yellow</attribute>
+                <attribute name="Type" typeId="c63c-196d-34a7-cec3">Defensive</attribute>
                 <attribute name="Parent Node" typeId="5d25-63d6-3935-9312"/>
               </attributes>
             </profile>
           </profiles>
+          <constraints>
+            <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="0ddd-c58d-c21d-1aab" automatic="true"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="b641-26b6-96e0-eb53" automatic="true"/>
+          </constraints>
           <modifiers>
-            <modifier type="set" value="1" field="0b9a-11d5-b2b6-583b">
+            <modifier type="set" value="1" field="0ddd-c58d-c21d-1aab">
               <conditions>
                 <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="707c-1c04-9af6-2307" shared="true"/>
               </conditions>
             </modifier>
           </modifiers>
-          <constraints>
-            <constraint type="min" value="0" field="selections" scope="parent" shared="true" id="0b9a-11d5-b2b6-583b" automatic="true"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6980-409e-59c0-5da1" automatic="true"/>
-          </constraints>
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
@@ -15930,7 +15935,7 @@ In addition, if the chanting roll was 8+, add 1 to the Attacks characteristic of
                 </modifier>
               </modifiers>
             </entryLink>
-            <entryLink import="true" name="Everwinter Prayers" hidden="true" id="83b9-f9e4-addf-4911" type="selectionEntryGroup" targetId="48ca-ef37-a530-211f" collapsible="true">
+            <entryLink import="true" name="Lore of the Everwinter" hidden="true" id="83b9-f9e4-addf-4911" type="selectionEntryGroup" targetId="e5b8-86da-de17-d117" collapsible="true">
               <modifiers>
                 <modifier type="set" value="false" field="hidden">
                   <conditionGroups>
@@ -15981,7 +15986,7 @@ In addition, if the chanting roll was 8+, add 1 to the Attacks characteristic of
                 </modifier>
               </modifiers>
             </entryLink>
-            <entryLink import="true" name="Lore of Maw-magic" hidden="true" id="c500-988c-77ba-58b5" type="selectionEntryGroup" targetId="6958-4e79-e1d0-14e8" collapsible="true">
+            <entryLink import="true" name="Lore of Gut Magic" hidden="true" id="c500-988c-77ba-58b5" type="selectionEntryGroup" targetId="1708-0960-47ad-a552" collapsible="true">
               <modifiers>
                 <modifier type="set" value="false" field="hidden">
                   <conditionGroups>
@@ -19914,7 +19919,7 @@ In addition, if the chanting roll was 8+, add 1 to the Attacks characteristic of
                 </modifier>
               </modifiers>
             </entryLink>
-            <entryLink import="true" name="Everwinter Prayers" hidden="true" id="eb70-0378-0f8a-c9fd" type="selectionEntryGroup" targetId="48ca-ef37-a530-211f" collapsible="true">
+            <entryLink import="true" name="Lore of the Everwinter" hidden="true" id="eb70-0378-0f8a-c9fd" type="selectionEntryGroup" targetId="e5b8-86da-de17-d117" collapsible="true">
               <modifiers>
                 <modifier type="set" value="false" field="hidden">
                   <conditionGroups>
@@ -21055,7 +21060,7 @@ In addition, if the chanting roll was 8+, add 1 to the Attacks characteristic of
                 </modifier>
               </modifiers>
             </entryLink>
-            <entryLink import="true" name="Lore of Maw-magic" hidden="true" id="7f3c-5554-a647-b8f9" type="selectionEntryGroup" targetId="6958-4e79-e1d0-14e8" collapsible="true">
+            <entryLink import="true" name="Lore of Gut Magic" hidden="true" id="7f3c-5554-a647-b8f9" type="selectionEntryGroup" targetId="1708-0960-47ad-a552" collapsible="true">
               <modifiers>
                 <modifier type="set" value="false" field="hidden">
                   <conditionGroups>
@@ -23505,7 +23510,7 @@ In addition, if the chanting roll was 8+, add 1 to the Attacks characteristic of
                 </modifier>
               </modifiers>
             </entryLink>
-            <entryLink import="true" name="Everwinter Prayers" hidden="true" id="a318-4bda-0305-444f" type="selectionEntryGroup" targetId="48ca-ef37-a530-211f" collapsible="true">
+            <entryLink import="true" name="Lore of the Everwinter" hidden="true" id="a318-4bda-0305-444f" type="selectionEntryGroup" targetId="e5b8-86da-de17-d117" collapsible="true">
               <modifiers>
                 <modifier type="set" value="false" field="hidden">
                   <conditionGroups>
@@ -24754,7 +24759,7 @@ In addition, if the chanting roll was 8+, add 1 to the Attacks characteristic of
                 </modifier>
               </modifiers>
             </entryLink>
-            <entryLink import="true" name="Lore of Maw-magic" hidden="true" id="9909-792b-e7d0-862b" type="selectionEntryGroup" targetId="6958-4e79-e1d0-14e8" collapsible="true">
+            <entryLink import="true" name="Lore of Gut Magic" hidden="true" id="9909-792b-e7d0-862b" type="selectionEntryGroup" targetId="1708-0960-47ad-a552" collapsible="true">
               <modifiers>
                 <modifier type="set" value="false" field="hidden">
                   <conditionGroups>
@@ -26686,7 +26691,7 @@ In addition, if the chanting roll was 8+, add 1 to the Attacks characteristic of
                 </modifier>
               </modifiers>
             </entryLink>
-            <entryLink import="true" name="Everwinter Prayers" hidden="true" id="a36d-1942-a2c0-6b10" type="selectionEntryGroup" targetId="48ca-ef37-a530-211f" collapsible="true">
+            <entryLink import="true" name="Lore of the Everwinter" hidden="true" id="a36d-1942-a2c0-6b10" type="selectionEntryGroup" targetId="e5b8-86da-de17-d117" collapsible="true">
               <modifiers>
                 <modifier type="set" value="false" field="hidden">
                   <conditionGroups>
@@ -27103,7 +27108,7 @@ In addition, if the chanting roll was 8+, add 1 to the Attacks characteristic of
                 </modifier>
               </modifiers>
             </entryLink>
-            <entryLink import="true" name="Lore of Maw-magic" hidden="true" id="c020-5eb5-863d-3433" type="selectionEntryGroup" targetId="6958-4e79-e1d0-14e8" collapsible="true">
+            <entryLink import="true" name="Lore of Gut Magic" hidden="true" id="c020-5eb5-863d-3433" type="selectionEntryGroup" targetId="1708-0960-47ad-a552" collapsible="true">
               <modifiers>
                 <modifier type="set" value="false" field="hidden">
                   <conditionGroups>

--- a/Ogor Mawtribes - Beastclaw Alfrostun.cat
+++ b/Ogor Mawtribes - Beastclaw Alfrostun.cat
@@ -1,0 +1,747 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue library="false" id="3dca-a9a3-7f3e-6a69" name="Ogor Mawtribes - Beastclaw Alfrostun" gameSystemId="e51d-b1a3-75fc-dc3g" gameSystemRevision="2" revision="1" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <entryLinks>
+    <entryLink import="true" name="Bloodpelt Hunter" hidden="false" id="6ea3-1a99-dc86-b0b8" type="selectionEntry" targetId="a800-1a5b-4097-8f11">
+      <categoryLinks>
+        <categoryLink name="ALFROSTUN" hidden="false" id="06c9-7018-7fc1-f431" targetId="cf1a-5514-16a2-c2c1" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink import="true" name="Heroic Traits" hidden="false" id="fa3a-d791-cf8e-0512" type="selectionEntryGroup" targetId="df6e-02f5-f526-726c"/>
+        <entryLink import="true" name="Artefacts of Power" hidden="false" id="e4b0-6753-cfd2-b1b5" type="selectionEntryGroup" targetId="65c3-4d7d-a294-8a10"/>
+        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="2adc-31a9-603e-5a4d" type="selectionEntryGroup" targetId="fe20-91ab-f55d-d204"/>
+        <entryLink import="true" name="Paths" hidden="false" id="1c0a-577b-854f-99c0" type="selectionEntryGroup" targetId="5f4d-269f-3aa6-e31d"/>
+        <entryLink import="true" name="Warlord" hidden="false" id="46f3-0aff-4c27-78e0" type="selectionEntry" targetId="bb28-fa4a-bf5f-f793"/>
+        <entryLink import="true" name="Renown" hidden="false" id="6be5-975f-efaf-1bb6" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="5637-f966-4af2-4b75" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="130"/>
+      </costs>
+      <modifiers>
+        <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="lessThan" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true" includeChildForces="true"/>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="set" value="true" field="hidden">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="8f4b-1fa6-3128-8405" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint type="max" value="-1" field="selections" scope="force" shared="true" id="a905-84e2-4278-5205" includeChildSelections="true"/>
+      </constraints>
+      <modifierGroups>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.5c0d-5e93-d71f-f0da"/>
+          </modifiers>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
+          </conditions>
+        </modifierGroup>
+      </modifierGroups>
+    </entryLink>
+    <entryLink import="true" name="Frostlord on Stonehorn" hidden="false" id="97e6-aded-f608-63fb" type="selectionEntry" targetId="e445-5f3b-4228-8bd3">
+      <categoryLinks>
+        <categoryLink name="ALFROSTUN" hidden="false" id="9bee-be2b-77a1-2cb0" targetId="cf1a-5514-16a2-c2c1" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink import="true" name="Heroic Traits" hidden="false" id="9fb3-f9bf-4389-25a6" type="selectionEntryGroup" targetId="df6e-02f5-f526-726c"/>
+        <entryLink import="true" name="Artefacts of Power" hidden="false" id="48be-1d2a-99c7-55d8" type="selectionEntryGroup" targetId="65c3-4d7d-a294-8a10"/>
+        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="da1e-9d85-d441-c7b0" type="selectionEntryGroup" targetId="fe20-91ab-f55d-d204"/>
+        <entryLink import="true" name="Paths" hidden="false" id="82a0-2b1f-00ff-2fab" type="selectionEntryGroup" targetId="5f4d-269f-3aa6-e31d"/>
+        <entryLink import="true" name="Warlord" hidden="false" id="5827-b720-0b6a-9da8" type="selectionEntry" targetId="bb28-fa4a-bf5f-f793"/>
+        <entryLink import="true" name="Renown" hidden="false" id="c817-67d6-cd05-d117" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="6adc-075c-e436-d5d7" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="340"/>
+      </costs>
+      <modifiers>
+        <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="lessThan" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true" includeChildForces="true"/>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="set" value="true" field="hidden">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <modifierGroups>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.743-1bd8-e3d-ced2"/>
+          </modifiers>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
+          </conditions>
+        </modifierGroup>
+      </modifierGroups>
+    </entryLink>
+    <entryLink import="true" name="Frostlord on Thundertusk" hidden="false" id="ccc5-9a01-ba54-05df" type="selectionEntry" targetId="e1b4-2fef-26cc-81c4">
+      <categoryLinks>
+        <categoryLink name="ALFROSTUN" hidden="false" id="2a14-ac64-4e0c-cc10" targetId="cf1a-5514-16a2-c2c1" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink import="true" name="Heroic Traits" hidden="false" id="7a9e-0e0e-3e01-6c7a" type="selectionEntryGroup" targetId="df6e-02f5-f526-726c"/>
+        <entryLink import="true" name="Artefacts of Power" hidden="false" id="9800-d205-18fa-b3ad" type="selectionEntryGroup" targetId="65c3-4d7d-a294-8a10"/>
+        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="ebf3-6cb2-ed07-3733" type="selectionEntryGroup" targetId="fe20-91ab-f55d-d204"/>
+        <entryLink import="true" name="Paths" hidden="false" id="bdd7-5025-34ea-9f09" type="selectionEntryGroup" targetId="5f4d-269f-3aa6-e31d"/>
+        <entryLink import="true" name="Warlord" hidden="false" id="462d-42a7-60a6-c203" type="selectionEntry" targetId="bb28-fa4a-bf5f-f793"/>
+        <entryLink import="true" name="Renown" hidden="false" id="6c56-bfa1-3416-f414" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="f40e-d90b-b3cc-7c79" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="280"/>
+      </costs>
+      <modifiers>
+        <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="lessThan" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true" includeChildForces="true"/>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="set" value="true" field="hidden">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <modifierGroups>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.743-1bd8-e3d-ced2"/>
+          </modifiers>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
+          </conditions>
+        </modifierGroup>
+      </modifierGroups>
+    </entryLink>
+    <entryLink import="true" name="Huskard on Stonehorn" hidden="false" id="6023-5bd9-45db-50fd" type="selectionEntry" targetId="8bfb-791d-158b-35a2">
+      <categoryLinks>
+        <categoryLink name="ALFROSTUN" hidden="false" id="f3d4-9266-f61d-f566" targetId="cf1a-5514-16a2-c2c1" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink import="true" name="Heroic Traits" hidden="false" id="18ca-f8f2-9b69-059c" type="selectionEntryGroup" targetId="df6e-02f5-f526-726c"/>
+        <entryLink import="true" name="Artefacts of Power" hidden="false" id="1098-b332-c0d4-1e4a" type="selectionEntryGroup" targetId="65c3-4d7d-a294-8a10"/>
+        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="209e-afa4-72aa-96f1" type="selectionEntryGroup" targetId="fe20-91ab-f55d-d204"/>
+        <entryLink import="true" name="Paths" hidden="false" id="0f6b-05b5-6b2b-7d08" type="selectionEntryGroup" targetId="5f4d-269f-3aa6-e31d"/>
+        <entryLink import="true" name="Warlord" hidden="false" id="5602-ba97-fdb1-db9f" type="selectionEntry" targetId="bb28-fa4a-bf5f-f793"/>
+        <entryLink import="true" name="Renown" hidden="false" id="959e-b4bc-1cde-6352" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="4d64-7533-fd1a-46d4" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="300"/>
+      </costs>
+      <modifiers>
+        <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="lessThan" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true" includeChildForces="true"/>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="set" value="true" field="hidden">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="8f4b-1fa6-3128-8405" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <modifierGroups>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="bf4e-4b1b-7055-2ec8" field="category"/>
+          </modifiers>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifierGroup>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.1a3d-33f9-c4cc-fe0"/>
+          </modifiers>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
+          </conditions>
+        </modifierGroup>
+      </modifierGroups>
+    </entryLink>
+    <entryLink import="true" name="Huskard on Thundertusk" hidden="false" id="faf6-60a8-cb27-aed0" type="selectionEntry" targetId="ebcd-aa92-94f1-c1be">
+      <categoryLinks>
+        <categoryLink name="ALFROSTUN" hidden="false" id="0d3e-ea12-8662-1d26" targetId="cf1a-5514-16a2-c2c1" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink import="true" name="Heroic Traits" hidden="false" id="27f5-fe41-453f-ac6d" type="selectionEntryGroup" targetId="df6e-02f5-f526-726c"/>
+        <entryLink import="true" name="Artefacts of Power" hidden="false" id="265b-37a2-1222-a993" type="selectionEntryGroup" targetId="65c3-4d7d-a294-8a10"/>
+        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="93b6-183f-11b8-a43b" type="selectionEntryGroup" targetId="fe20-91ab-f55d-d204"/>
+        <entryLink import="true" name="Paths" hidden="false" id="f554-94cc-d26f-a897" type="selectionEntryGroup" targetId="5f4d-269f-3aa6-e31d"/>
+        <entryLink import="true" name="Warlord" hidden="false" id="5380-082b-4b9c-bda0" type="selectionEntry" targetId="bb28-fa4a-bf5f-f793"/>
+        <entryLink import="true" name="Renown" hidden="false" id="9bf5-0483-aaac-8852" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="5884-5cf2-a9e3-45af" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="280"/>
+      </costs>
+      <modifiers>
+        <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="lessThan" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true" includeChildForces="true"/>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="set" value="true" field="hidden">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="8f4b-1fa6-3128-8405" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <modifierGroups>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="bf4e-4b1b-7055-2ec8" field="category"/>
+          </modifiers>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifierGroup>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.1a3d-33f9-c4cc-fe0"/>
+          </modifiers>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
+          </conditions>
+        </modifierGroup>
+      </modifierGroups>
+    </entryLink>
+    <entryLink import="true" name="Stonehorn Beastriders" hidden="false" id="8266-f8db-e7be-facf" type="selectionEntry" targetId="8b95-893a-4c1a-9224">
+      <categoryLinks>
+        <categoryLink name="ALFROSTUN" hidden="false" id="717d-cd43-e9a5-c55e" targetId="cf1a-5514-16a2-c2c1" primary="false"/>
+      </categoryLinks>
+      <modifiers>
+        <modifier type="multiply" value="2" field="points">
+          <conditions>
+            <condition type="atLeast" value="1" field="selections" scope="self" childId="1b37-82b8-c062-eb82" shared="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="set" value="true" field="hidden">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="db3a-7199-c92e-f3cf" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <costs>
+        <cost name="pts" typeId="points" value="280"/>
+      </costs>
+      <entryLinks>
+        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="d9f7-21cd-939e-2203" type="selectionEntryGroup" targetId="fe20-91ab-f55d-d204"/>
+        <entryLink import="true" name="Paths" hidden="false" id="7f85-e078-c016-25ad" type="selectionEntryGroup" targetId="5f4d-269f-3aa6-e31d"/>
+        <entryLink import="true" name="Renown" hidden="false" id="dfd4-2d24-3665-6b65" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+      </entryLinks>
+    </entryLink>
+    <entryLink import="true" name="Thundertusk Beastriders" hidden="false" id="3ca3-5d1d-4972-deaf" type="selectionEntry" targetId="e5a2-5b7c-b7af-8da6">
+      <categoryLinks>
+        <categoryLink name="ALFROSTUN" hidden="false" id="c3b7-489e-5c0f-8255" targetId="cf1a-5514-16a2-c2c1" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="ff5d-a406-93bc-4c09" type="selectionEntryGroup" targetId="fe20-91ab-f55d-d204"/>
+        <entryLink import="true" name="Paths" hidden="false" id="ba3d-b3ab-4b21-ac73" type="selectionEntryGroup" targetId="5f4d-269f-3aa6-e31d"/>
+        <entryLink import="true" name="Renown" hidden="false" id="9bd1-2f5b-c75d-92b6" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+      </entryLinks>
+      <modifiers>
+        <modifier type="multiply" value="2" field="points">
+          <conditions>
+            <condition type="atLeast" value="1" field="selections" scope="self" childId="1b37-82b8-c062-eb82" shared="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="set" value="true" field="hidden">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="db3a-7199-c92e-f3cf" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <costs>
+        <cost name="pts" typeId="points" value="240"/>
+      </costs>
+    </entryLink>
+    <entryLink import="true" name="Mantrapper" hidden="false" id="548b-3d2d-2438-9796" type="selectionEntry" targetId="9167-b1ce-996d-5d19">
+      <categoryLinks>
+        <categoryLink name="ALFROSTUN" hidden="false" id="3ebe-b0a1-481c-cfb1" targetId="cf1a-5514-16a2-c2c1" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink import="true" name="Heroic Traits" hidden="false" id="4f1e-57be-f5fd-1248" type="selectionEntryGroup" targetId="df6e-02f5-f526-726c"/>
+        <entryLink import="true" name="Artefacts of Power" hidden="false" id="976f-721a-ba1e-53bd" type="selectionEntryGroup" targetId="65c3-4d7d-a294-8a10"/>
+        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="aefb-574a-3315-a737" type="selectionEntryGroup" targetId="fe20-91ab-f55d-d204"/>
+        <entryLink import="true" name="Paths" hidden="false" id="9ad1-f213-f303-e584" type="selectionEntryGroup" targetId="5f4d-269f-3aa6-e31d"/>
+        <entryLink import="true" name="Warlord" hidden="false" id="b3a0-f84d-c5ee-8f44" type="selectionEntry" targetId="bb28-fa4a-bf5f-f793"/>
+        <entryLink import="true" name="Renown" hidden="false" id="2281-7688-9de2-c566" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="42d5-78d4-3aad-ea5d" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="130"/>
+      </costs>
+      <modifiers>
+        <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="lessThan" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true" includeChildForces="true"/>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="set" value="true" field="hidden">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="8f4b-1fa6-3128-8405" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <modifierGroups>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="bf4e-4b1b-7055-2ec8" field="category"/>
+          </modifiers>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifierGroup>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.1a3d-33f9-c4cc-fe0"/>
+          </modifiers>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
+          </conditions>
+        </modifierGroup>
+      </modifierGroups>
+    </entryLink>
+    <entryLink import="true" name="Maulbeast Raiders" hidden="false" id="b410-f5f2-700a-03ef" type="selectionEntry" targetId="a30d-9041-ffdb-5a33">
+      <categoryLinks>
+        <categoryLink name="ALFROSTUN" hidden="false" id="559c-427d-a9cc-4978" targetId="cf1a-5514-16a2-c2c1" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink import="true" name="Reinforced" hidden="false" id="6d29-a7da-67f7-41b8" type="selectionEntry" targetId="1b37-82b8-c062-eb82"/>
+        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="99a6-d4d9-488f-41da" type="selectionEntryGroup" targetId="fe20-91ab-f55d-d204"/>
+        <entryLink import="true" name="Paths" hidden="false" id="be31-8ef2-ed14-c0a9" type="selectionEntryGroup" targetId="5f4d-269f-3aa6-e31d"/>
+        <entryLink import="true" name="Renown" hidden="false" id="2860-dd6f-0af5-dac5" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+      </entryLinks>
+      <modifiers>
+        <modifier type="multiply" value="2" field="points">
+          <conditions>
+            <condition type="atLeast" value="1" field="selections" scope="self" childId="1b37-82b8-c062-eb82" shared="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <costs>
+        <cost name="pts" typeId="points" value="230"/>
+      </costs>
+    </entryLink>
+    <entryLink import="true" name="Hunters with Sabrefangs" hidden="false" id="c103-6c7f-cc23-4447" type="selectionEntry" targetId="cdfc-5bdb-a479-48fa">
+      <categoryLinks>
+        <categoryLink name="ALFROSTUN" hidden="false" id="1606-7012-96e5-584b" targetId="cf1a-5514-16a2-c2c1" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink import="true" name="Reinforced" hidden="false" id="11d1-c801-17ac-288d" type="selectionEntry" targetId="1b37-82b8-c062-eb82"/>
+        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="adf0-786d-d041-0c78" type="selectionEntryGroup" targetId="fe20-91ab-f55d-d204"/>
+        <entryLink import="true" name="Paths" hidden="false" id="dfb8-da69-7423-742d" type="selectionEntryGroup" targetId="5f4d-269f-3aa6-e31d"/>
+        <entryLink import="true" name="Renown" hidden="false" id="cb16-4f90-4b9e-a808" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+      </entryLinks>
+      <modifiers>
+        <modifier type="multiply" value="2" field="points">
+          <conditions>
+            <condition type="atLeast" value="1" field="selections" scope="self" childId="1b37-82b8-c062-eb82" shared="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <costs>
+        <cost name="pts" typeId="points" value="160"/>
+      </costs>
+    </entryLink>
+    <entryLink import="true" name="Battle Traits: Beastclaw Alfrostun" hidden="false" id="9acd-e585-9f76-70db" type="selectionEntry" targetId="242b-a05f-b69c-c26f"/>
+  </entryLinks>
+  <catalogueLinks>
+    <catalogueLink type="catalogue" name="Ogor Mawtribes - Library" id="8101-c3ba-e2de-0c9c" targetId="9a90-83e7-7a45-6aed"/>
+    <catalogueLink type="catalogue" name="✦ Path to Glory - Ravaged Coast" id="9879-a545-3dec-867b" importRootEntries="true" targetId="a434-b1ba-922b-7624"/>
+    <catalogueLink type="catalogue" name="❖ Lores" id="8619-8e24-0493-8916" targetId="0a11-cd61-2a4e-8e04" importRootEntries="true"/>
+    <catalogueLink type="catalogue" name="✦ Path to Glory - Ascension" id="1b65-4c3b-c162-7b5a" targetId="3a8b-7496-526f-feab" importRootEntries="true"/>
+    <catalogueLink type="catalogue" name="✦ Path to Glory - Blighted Wilds" id="9786-6ab2-5fdd-5f3e" targetId="e0ff-dc7c-8795-bfb9" importRootEntries="true"/>
+  </catalogueLinks>
+  <categoryEntries>
+    <categoryEntry name="ALFROSTUN" id="cf1a-5514-16a2-c2c1" hidden="false"/>
+  </categoryEntries>
+  <sharedSelectionEntries>
+    <selectionEntry type="upgrade" import="true" name="Battle Traits: Beastclaw Alfrostun" hidden="false" id="242b-a05f-b69c-c26f" publicationId="1ac6-e227-a186-12">
+      <profiles>
+        <profile name="Masked by the Endless White" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="83ac-d0e4-580d-49f5">
+          <characteristics>
+            <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
+            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">Friendly **^^Alfrostun^^** units are not visible to enemy units more than 12&quot; away.</characteristic>
+          </characteristics>
+          <attributes>
+            <attribute typeId="50fe-4f29-6bc3-dcc6" name="Color">Green</attribute>
+            <attribute typeId="bf11-4e10-3ab1-06f4" name="Type">Defensive</attribute>
+            <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
+          </attributes>
+        </profile>
+        <profile name="A Clan of Hunters" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="805d-d75b-00b5-b2c7">
+          <characteristics>
+            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Battle (Army), Deployment Phase</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick a friendly **Hunters with Sabrefangs** unit to be the target.</characteristic>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">The target can use the &apos;Through the Frosts&apos; ability even if another friendly **Hunters with Sabrefangs** unit has used that ability this battle.</characteristic>
+            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+          </characteristics>
+          <attributes>
+            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Black</attribute>
+            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Movement</attribute>
+            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+          </attributes>
+        </profile>
+        <profile name="Grasp of the Everwinter" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="eb3d-75d0-7685-82d9">
+          <characteristics>
+            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Turn (Army), Your Hero Phase</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick each enemy unit in combat with any friendly **^^Alfrostun^^** units to be the targets.</characteristic>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Roll a D3 for each target. On a 2+, inflict an amount of mortal damage on the target equal to the roll.</characteristic>
+            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+          </characteristics>
+          <attributes>
+            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Yellow</attribute>
+            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Offensive</attribute>
+            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+          </attributes>
+        </profile>
+        <profile name="Run 'Em Down" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="95c5-afbc-5aa6-13d4">
+          <characteristics>
+            <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
+            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">Each time an enemy unit in combat with a friendly **^^Alfrostun^^** unit uses a **^^Retreat^^** ability, after that ability has been resolved, inflict D3 mortal damage on that enemy unit.
+
+***Designer&apos;s Note**: This mortal damage is in addition to any mortal damage inflicted on that enemy unit by that **^^Retreat^^** ability.*</characteristic>
+          </characteristics>
+          <attributes>
+            <attribute typeId="50fe-4f29-6bc3-dcc6" name="Color">Black</attribute>
+            <attribute typeId="bf11-4e10-3ab1-06f4" name="Type">Offensive</attribute>
+            <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
+          </attributes>
+        </profile>
+        <profile name="Fearsome Breed" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="70dc-83eb-7bb6-e89d">
+          <characteristics>
+            <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
+            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">Subtract 1 from charge rolls for enemy units while they are within 12&quot; of a friendly **^^Alfrostun^^** **^^Monster^^**. Subtract 2 from charge rolls for enemy units while they are within 6&quot; of a friendly **^^Alfrostun^^** **^^Monster^^** instead.</characteristic>
+          </characteristics>
+          <attributes>
+            <attribute typeId="50fe-4f29-6bc3-dcc6" name="Color">Orange</attribute>
+            <attribute typeId="bf11-4e10-3ab1-06f4" name="Type">Movement</attribute>
+            <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
+          </attributes>
+        </profile>
+      </profiles>
+    </selectionEntry>
+  </sharedSelectionEntries>
+  <sharedSelectionEntryGroups>
+    <selectionEntryGroup name="Artefacts of Power" id="65c3-4d7d-a294-8a10" hidden="false">
+      <selectionEntryGroups>
+        <selectionEntryGroup name="Alfrostun Artefacts of Power" id="bacf-0da5-46ed-48e0" hidden="false">
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Alvagr Rune-Tokens" hidden="false" id="845a-9f03-54dd-e098">
+              <profiles>
+                    <profile name="Alvagr Rune-Tokens" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="499d-cc6d-15d6-6a67">
+                      <characteristics>
+                        <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Battle (Army), Your Hero Phase</characteristic>
+                        <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb"/>
+                        <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Until the start of your next turn, add 2 to chanting rolls for friendly **^^Alfrostun^^** units while they are wholly within 12&quot; of this unit.</characteristic>
+                        <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+                        <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+                      </characteristics>
+                      <attributes>
+                        <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Yellow</attribute>
+                        <attribute typeId="6d16-c86b-2698-85a4" name="Type">Special</attribute>
+                        <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+                      </attributes>
+                    </profile>
+              </profiles>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="f168-3d4c-98a7-e844" includeChildSelections="true"/>
+              </constraints>
+            </selectionEntry>
+          </selectionEntries>
+          <rules>
+            <rule name="Enhancement Restrictions" id="90df-b91f-4178-82f2" hidden="true">
+              <description>**^^Hero^^** only</description>
+            </rule>
+          </rules>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink import="true" name="Artefacts of Power" hidden="false" id="fefd-2374-8a58-4953" type="selectionEntryGroup" targetId="e1b2-cedf-56a5-6bb1" flatten="true"/>
+        <entryLink import="true" name="Artefacts of Power" hidden="false" id="86e4-9164-4487-22b6" type="selectionEntryGroup" targetId="d563-838a-a901-097e"/>
+      </entryLinks>
+      <modifiers>
+        <modifier type="set" value="-1" field="cdd3-53a1-54ba-71c1">
+          <conditions>
+            <condition type="atLeast" value="1" field="e63c-79ff-93ba-c5eb" scope="roster" childId="any" shared="true" includeChildSelections="true" includeChildForces="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="cdd3-53a1-54ba-71c1" includeChildSelections="true"/>
+        <constraint type="max" value="1" field="selections" scope="root-entry" shared="true" id="641b-936c-0d51-241e"/>
+      </constraints>
+    </selectionEntryGroup>
+    <selectionEntryGroup name="Heroic Traits" id="df6e-02f5-f526-726c" hidden="false">
+      <selectionEntryGroups>
+        <selectionEntryGroup name="Alfrostun Heroic Traits" id="2d0c-fac3-290d-1489" hidden="false">
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Hard-Bitten Chieftain" hidden="false" id="2e1a-e701-96f1-f01c">
+              <profiles>
+                    <profile name="Hard-Bitten Chieftain" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="c1b1-2fe7-d6a5-f48e">
+                      <characteristics>
+                        <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
+                        <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">Other than the **Companion** ability, weapon abilities for attacks that target this unit made by enemy units that charged in the same turn have no effect.</characteristic>
+                      </characteristics>
+                      <attributes>
+                        <attribute typeId="50fe-4f29-6bc3-dcc6" name="Color">Green</attribute>
+                        <attribute typeId="bf11-4e10-3ab1-06f4" name="Type">Defensive</attribute>
+                        <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
+                      </attributes>
+                    </profile>
+              </profiles>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="ea10-70ed-32f4-bd3d" includeChildSelections="true"/>
+              </constraints>
+            </selectionEntry>
+          </selectionEntries>
+          <rules>
+            <rule name="Enhancement Restrictions" id="5a19-0da7-625e-a9bf" hidden="true">
+              <description>**^^Hero^^** only</description>
+            </rule>
+          </rules>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink import="true" name="Heroic Traits" hidden="false" id="7304-ba55-4744-de12" type="selectionEntryGroup" targetId="c437-e34c-5e1c-95e6" flatten="true"/>
+        <entryLink import="true" name="Heroic Traits" hidden="false" id="70ca-57a9-03ce-c3e7" type="selectionEntryGroup" targetId="59df-5a5c-f4ee-ab6e"/>
+      </entryLinks>
+      <modifiers>
+        <modifier type="set" value="-1" field="97ba-96d9-239b-5f43">
+          <conditions>
+            <condition type="atLeast" value="1" field="e63c-79ff-93ba-c5eb" scope="roster" childId="any" shared="true" includeChildSelections="true" includeChildForces="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="97ba-96d9-239b-5f43" includeChildSelections="true"/>
+        <constraint type="max" value="1" field="selections" scope="root-entry" shared="true" id="1b2f-ad28-f923-7192"/>
+      </constraints>
+    </selectionEntryGroup>
+    <selectionEntryGroup name="Prayer Lores" id="9dbd-0267-d20c-2df6" hidden="false" flatten="true">
+      <selectionEntries>
+        <selectionEntry type="upgrade" import="true" name="Prayer Lore: Beastclaw Alfrostun" hidden="false" id="40bb-ad55-8955-2a93">
+          <constraints>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="1311-0e60-4689-8d55"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="points" value="0"/>
+          </costs>
+          <entryLinks>
+            <entryLink import="true" name="Prayer Lore: Beastclaw Alfrostun" hidden="false" id="8e32-a394-e2c9-c72e" type="selectionEntryGroup" targetId="2c0c-99e2-717c-d10f">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="7fd8-cd34-9f4d-765a"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="9445-e4d3-d78f-108d"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+        </selectionEntry>
+      </selectionEntries>
+      <constraints>
+        <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="3be8-db6a-ec61-9a0e" includeChildSelections="true"/>
+      </constraints>
+    </selectionEntryGroup>
+    <selectionEntryGroup name="Battle Wounds + Scars" id="fe20-91ab-f55d-d204" hidden="true" collapsible="true">
+      <modifiers>
+        <modifier type="set" value="false" field="hidden">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="atLeast" value="1" field="e63c-79ff-93ba-c5eb" scope="roster" childId="any" shared="true" includeChildSelections="true" includeChildForces="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="1bed-ddb5-0c50-16d2" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <entryLinks>
+        <entryLink import="true" name="Ravaged Coast Battle Scars" hidden="false" id="8039-7961-aa3b-021f" type="selectionEntryGroup" targetId="5559-80df-ba01-66a7" flatten="true"/>
+        <entryLink import="true" name="Blighted Wilds Battle Scars" hidden="false" id="4703-b459-b082-1ad5" type="selectionEntryGroup" targetId="374e-3b5e-1810-b56a"/>
+        <entryLink import="true" name="Blighted Wilds Paths" hidden="false" id="e830-0cb6-84ec-a19f" type="selectionEntryGroup" targetId="3f1b-26c1-aa71-73f8"/>
+      </entryLinks>
+      <selectionEntries>
+        <selectionEntry type="upgrade" import="true" name="Battle Wounds" hidden="false" id="a098-3646-48e6-b5c4"/>
+        <selectionEntry type="upgrade" import="true" name="Drained" hidden="true" id="b08e-dab7-ebbb-dce2">
+          <constraints>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="eafd-1893-17fd-78fc"/>
+          </constraints>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="root-entry" childId="6e72-1656-d554-528a" shared="true"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup name="Paths" id="5f4d-269f-3aa6-e31d" hidden="true">
+      <entryLinks>
+        <entryLink import="true" name="Ravaged Coast Paths" hidden="false" id="18b2-fe88-9850-3ebb" type="selectionEntryGroup" targetId="7bae-23cb-3977-3ece" flatten="true"/>
+        <entryLink import="true" name="Ascension Paths" hidden="false" id="5fc5-646e-b410-4ea9" type="selectionEntryGroup" targetId="9b2e-ad88-381f-5c49" flatten="true"/>
+        <entryLink import="true" name="Blighted Wilds Paths" hidden="false" id="24d3-4c3e-970c-bf2d" type="selectionEntryGroup" targetId="3f1b-26c1-aa71-73f8"/>
+      </entryLinks>
+      <modifiers>
+        <modifier type="set" value="false" field="hidden">
+          <conditions>
+            <condition type="atLeast" value="1" field="e63c-79ff-93ba-c5eb" scope="roster" childId="any" shared="true" includeChildSelections="true" includeChildForces="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6e34-26b5-53f0-598e"/>
+      </constraints>
+    </selectionEntryGroup>
+  </sharedSelectionEntryGroups>
+  <selectionEntries>
+    <selectionEntry type="upgrade" import="true" name="Manifestation Lore" hidden="true" id="ee49-59f5-9228-aae3" defaultAmount="1">
+      <entryLinks>
+        <entryLink import="true" name="Manifestation Lores" hidden="false" id="2d9b-1dc0-3ae9-c21e" type="selectionEntryGroup" targetId="748f-5d65-2d45-95c5" flatten="true"/>
+      </entryLinks>
+      <constraints>
+        <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="2bf5-018f-d850-8362"/>
+        <constraint type="max" value="1" field="selections" scope="self" shared="true" id="4a9c-d7f6-d73d-0a43"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink name="Army Composition" hidden="false" id="cd17-0d0d-2079-7d4e" targetId="ac97-b27c-7e35-7ab9" primary="true"/>
+      </categoryLinks>
+      <modifiers>
+        <modifier type="set" value="false" field="hidden">
+          <conditions>
+            <condition type="atLeast" value="1" field="de92-2099-fbf7-a156" scope="roster" childId="any" shared="true" includeChildSelections="true" includeChildForces="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+    </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Prayer Lore" hidden="true" id="156b-78c0-d980-3faf" defaultAmount="1">
+      <categoryLinks>
+        <categoryLink name="Army Composition" hidden="false" id="9871-8643-9bbb-b014" targetId="ac97-b27c-7e35-7ab9" primary="true"/>
+      </categoryLinks>
+      <constraints>
+        <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="b585-c4b1-9312-2444"/>
+        <constraint type="max" value="1" field="selections" scope="self" shared="true" id="1bd8-6d1c-9f39-2b05"/>
+      </constraints>
+      <entryLinks>
+        <entryLink import="true" name="Prayer Lores" hidden="false" id="d74e-c83d-aba5-61c7" type="selectionEntryGroup" targetId="9dbd-0267-d20c-2df6" flatten="true" collective="false"/>
+      </entryLinks>
+      <modifiers>
+        <modifier type="set" value="false" field="hidden">
+          <conditions>
+            <condition type="atLeast" value="1" field="de92-2099-fbf7-a156" scope="roster" childId="any" shared="true" includeChildSelections="true" includeChildForces="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+    </selectionEntry>
+  </selectionEntries>
+</catalogue>

--- a/Ogor Mawtribes - Beastclaw Alfrostun.cat
+++ b/Ogor Mawtribes - Beastclaw Alfrostun.cat
@@ -453,6 +453,121 @@
       </costs>
     </entryLink>
     <entryLink import="true" name="Battle Traits: Beastclaw Alfrostun" hidden="false" id="9acd-e585-9f76-70db" type="selectionEntry" targetId="242b-a05f-b69c-c26f"/>
+    <entryLink import="true" name="Frostlord on Thundertusk (Scourge of Aqshy)" hidden="false" id="65f2-eeeb-d8e7-4825" type="selectionEntry" targetId="46e1-7fbb-36bc-5ff0">
+      <categoryLinks>
+        <categoryLink name="ALFROSTUN" hidden="false" id="defc-0b94-de39-c684" targetId="cf1a-5514-16a2-c2c1" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink import="true" name="Heroic Traits" hidden="false" id="6a73-ed1f-be67-b55f" type="selectionEntryGroup" targetId="df6e-02f5-f526-726c"/>
+        <entryLink import="true" name="Artefacts of Power" hidden="false" id="4f84-795d-5258-e9d2" type="selectionEntryGroup" targetId="65c3-4d7d-a294-8a10"/>
+        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="1b5d-57cb-f8b9-b4a2" type="selectionEntryGroup" targetId="fe20-91ab-f55d-d204"/>
+        <entryLink import="true" name="Paths" hidden="false" id="a665-01ea-a9e7-dc5f" type="selectionEntryGroup" targetId="5f4d-269f-3aa6-e31d"/>
+        <entryLink import="true" name="Warlord" hidden="false" id="679e-5103-9331-7542" type="selectionEntry" targetId="bb28-fa4a-bf5f-f793"/>
+        <entryLink import="true" name="Renown" hidden="false" id="2886-010f-ab04-b9e6" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="1f06-45d6-161e-3fff" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="280"/>
+      </costs>
+      <modifiers>
+        <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="lessThan" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true" includeChildForces="true"/>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="set" value="true" field="hidden">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <modifierGroups>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.743-1bd8-e3d-ced2"/>
+          </modifiers>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
+          </conditions>
+        </modifierGroup>
+      </modifierGroups>
+    </entryLink>
+    <entryLink import="true" name="Huskard on Thundertusk (Scourge of Aqshy)" hidden="false" id="b111-691c-b839-97f1" type="selectionEntry" targetId="4097-2ee1-c3ed-7492">
+      <categoryLinks>
+        <categoryLink name="ALFROSTUN" hidden="false" id="77fb-8d2d-9f2f-e9e3" targetId="cf1a-5514-16a2-c2c1" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink import="true" name="Heroic Traits" hidden="false" id="9095-d240-d86c-560e" type="selectionEntryGroup" targetId="df6e-02f5-f526-726c"/>
+        <entryLink import="true" name="Artefacts of Power" hidden="false" id="e152-7c85-4697-1ab0" type="selectionEntryGroup" targetId="65c3-4d7d-a294-8a10"/>
+        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="7516-0a4e-d654-2a4c" type="selectionEntryGroup" targetId="fe20-91ab-f55d-d204"/>
+        <entryLink import="true" name="Paths" hidden="false" id="5a1c-9871-eb72-cc63" type="selectionEntryGroup" targetId="5f4d-269f-3aa6-e31d"/>
+        <entryLink import="true" name="Warlord" hidden="false" id="eaac-8e19-f4c0-1941" type="selectionEntry" targetId="bb28-fa4a-bf5f-f793"/>
+        <entryLink import="true" name="Renown" hidden="false" id="8f14-01b6-c185-576f" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="0974-9c07-6e4d-a0e5" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="260"/>
+      </costs>
+      <modifiers>
+        <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="lessThan" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true" includeChildForces="true"/>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="set" value="true" field="hidden">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="8f4b-1fa6-3128-8405" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <modifierGroups>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="bf4e-4b1b-7055-2ec8" field="category"/>
+          </modifiers>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifierGroup>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.1a3d-33f9-c4cc-fe0"/>
+          </modifiers>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
+          </conditions>
+        </modifierGroup>
+      </modifierGroups>
+    </entryLink>
   </entryLinks>
   <catalogueLinks>
     <catalogueLink type="catalogue" name="Ogor Mawtribes - Library" id="8101-c3ba-e2de-0c9c" targetId="9a90-83e7-7a45-6aed"/>

--- a/Ogor Mawtribes - Beastclaw Alfrostun.cat
+++ b/Ogor Mawtribes - Beastclaw Alfrostun.cat
@@ -568,6 +568,164 @@
         </modifierGroup>
       </modifierGroups>
     </entryLink>
+    <entryLink import="true" name="Icebrow Hunter" hidden="false" id="929d-96cb-b95f-e48e" type="selectionEntry" targetId="8ea1-2719-4da0-2b1f">
+      <categoryLinks>
+        <categoryLink name="ALFROSTUN" hidden="false" id="8d91-52b6-421b-f1f0" targetId="cf1a-5514-16a2-c2c1" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink import="true" name="Heroic Traits" hidden="false" id="6e83-0c5d-c3a8-746c" type="selectionEntryGroup" targetId="df6e-02f5-f526-726c"/>
+        <entryLink import="true" name="Artefacts of Power" hidden="false" id="53c4-1021-95d8-6510" type="selectionEntryGroup" targetId="65c3-4d7d-a294-8a10"/>
+        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="3a4c-1551-d1ee-bd70" type="selectionEntryGroup" targetId="fe20-91ab-f55d-d204"/>
+        <entryLink import="true" name="Paths" hidden="false" id="b12a-492d-d9a0-a699" type="selectionEntryGroup" targetId="5f4d-269f-3aa6-e31d"/>
+        <entryLink import="true" name="Warlord" hidden="false" id="5886-5e02-7eb0-4abb" type="selectionEntry" targetId="bb28-fa4a-bf5f-f793"/>
+        <entryLink import="true" name="Renown" hidden="false" id="8778-1d3a-68ef-4cc5" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="87a1-70a9-1fd6-c782" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="130"/>
+      </costs>
+      <modifiers>
+        <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="lessThan" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true" includeChildForces="true"/>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="set" value="true" field="hidden">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="8f4b-1fa6-3128-8405" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <modifierGroups>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="bf4e-4b1b-7055-2ec8" field="category"/>
+          </modifiers>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifierGroup>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.1a3d-33f9-c4cc-fe0"/>
+          </modifiers>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
+          </conditions>
+        </modifierGroup>
+      </modifierGroups>
+    </entryLink>
+    <entryLink import="true" name="Frost Sabres" hidden="false" id="fce2-6b13-9e62-bd93" type="selectionEntry" targetId="bdf9-1644-707-f0df">
+      <categoryLinks>
+        <categoryLink name="ALFROSTUN" hidden="false" id="1ad2-ec16-cb0f-6d80" targetId="cf1a-5514-16a2-c2c1" primary="false"/>
+      </categoryLinks>
+      <modifiers>
+        <modifier type="multiply" value="2" field="points">
+          <conditions>
+            <condition type="atLeast" value="1" field="selections" scope="self" childId="1b37-82b8-c062-eb82" shared="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="set" value="true" field="hidden">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="db3a-7199-c92e-f3cf" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <entryLinks>
+        <entryLink import="true" name="Reinforced" hidden="false" id="978d-3489-b9a6-49f2" type="selectionEntry" targetId="1b37-82b8-c062-eb82"/>
+        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="86d9-699d-69c2-c2af" type="selectionEntryGroup" targetId="fe20-91ab-f55d-d204"/>
+        <entryLink import="true" name="Paths" hidden="false" id="13fc-ff56-f690-fc97" type="selectionEntryGroup" targetId="5f4d-269f-3aa6-e31d"/>
+        <entryLink import="true" name="Renown" hidden="false" id="5559-6d3a-f69e-1021" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="70"/>
+      </costs>
+    </entryLink>
+    <entryLink import="true" name="Icefall Yhetees" hidden="false" id="1af5-5f08-9a79-58d9" type="selectionEntry" targetId="5fed-90de-715-e720">
+      <categoryLinks>
+        <categoryLink name="ALFROSTUN" hidden="false" id="cb14-893c-381e-6dc3" targetId="cf1a-5514-16a2-c2c1" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink import="true" name="Reinforced" hidden="false" id="0976-171a-1c10-7052" type="selectionEntry" targetId="1b37-82b8-c062-eb82"/>
+        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="da91-10d3-75e1-9630" type="selectionEntryGroup" targetId="fe20-91ab-f55d-d204"/>
+        <entryLink import="true" name="Paths" hidden="false" id="9a71-a0c6-9fa2-f7d7" type="selectionEntryGroup" targetId="5f4d-269f-3aa6-e31d"/>
+        <entryLink import="true" name="Renown" hidden="false" id="844e-69b3-5e86-266a" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+      </entryLinks>
+      <modifiers>
+        <modifier type="multiply" value="2" field="points">
+          <conditions>
+            <condition type="atLeast" value="1" field="selections" scope="self" childId="1b37-82b8-c062-eb82" shared="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="set" value="true" field="hidden">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="db3a-7199-c92e-f3cf" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <costs>
+        <cost name="pts" typeId="points" value="120"/>
+      </costs>
+    </entryLink>
+    <entryLink import="true" name="Mournfang Pack" hidden="false" id="c49e-a150-0844-efd4" type="selectionEntry" targetId="b91b-cba6-89af-7225">
+      <categoryLinks>
+        <categoryLink name="ALFROSTUN" hidden="false" id="bb63-4242-fdc5-b495" targetId="cf1a-5514-16a2-c2c1" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink import="true" name="Reinforced" hidden="false" id="0a1f-7c3b-41e0-7811" type="selectionEntry" targetId="1b37-82b8-c062-eb82"/>
+        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="aafd-40c4-07ca-cfe7" type="selectionEntryGroup" targetId="fe20-91ab-f55d-d204"/>
+        <entryLink import="true" name="Paths" hidden="false" id="69a9-9c96-5baf-24e4" type="selectionEntryGroup" targetId="5f4d-269f-3aa6-e31d"/>
+        <entryLink import="true" name="Renown" hidden="false" id="9420-822f-31d4-efb9" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+      </entryLinks>
+      <modifiers>
+        <modifier type="multiply" value="2" field="points">
+          <conditions>
+            <condition type="atLeast" value="1" field="selections" scope="self" childId="1b37-82b8-c062-eb82" shared="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="set" value="true" field="hidden">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="db3a-7199-c92e-f3cf" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <costs>
+        <cost name="pts" typeId="points" value="200"/>
+      </costs>
+    </entryLink>
   </entryLinks>
   <catalogueLinks>
     <catalogueLink type="catalogue" name="Ogor Mawtribes - Library" id="8101-c3ba-e2de-0c9c" targetId="9a90-83e7-7a45-6aed"/>

--- a/Ogor Mawtribes - Library.cat
+++ b/Ogor Mawtribes - Library.cat
@@ -1,78 +1,82 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <catalogue library="true" id="9a90-83e7-7a45-6aed" name="Ogor Mawtribes - Library" gameSystemId="e51d-b1a3-75fc-dc3g" gameSystemRevision="2" revision="19" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <sharedSelectionEntries>
-    <selectionEntry type="unit" import="true" name="Bloodpelt Hunter" hidden="false" id="a800-1a5b-4097-8f11" publicationId="1ac6-e227-a186-12">
+    <selectionEntry type="unit" import="true" name="Bloodpelt Hunter" hidden="false" id="a800-1a5b-4097-8f11" publicationId="feba-6749-6df3-ea9e">
       <entryLinks>
-        <entryLink import="true" name="General" hidden="false" id="ab66-d131-cc66-ee13" type="selectionEntry" targetId="a56b-952e-ad15-7868"/>
+        <entryLink import="true" name="General" hidden="false" id="894b-5272-2fbc-598b" type="selectionEntry" targetId="a56b-952e-ad15-7868"/>
       </entryLinks>
       <profiles>
-        <profile name="Bloodpelt Hunter" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="feb7-45cd-76a2-b57a">
+        <profile name="Bloodpelt Hunter" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="fea5-15b5-bd2a-05f2">
           <characteristics>
             <characteristic name="Move" typeId="fed0-d1b3-1bb8-c501">6&quot;</characteristic>
             <characteristic name="Health" typeId="96be-54ae-ce7b-10b7">8</characteristic>
             <characteristic name="Save" typeId="1981-ef09-96f6-7aa9">5+</characteristic>
-            <characteristic name="Control" typeId="6c6f-8510-9ce1-fc6e">5</characteristic>
+            <characteristic name="Control" typeId="6c6f-8510-9ce1-fc6e">3</characteristic>
           </characteristics>
         </profile>
-        <profile name="Beast-breaker" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="875e-6436-7de3-adc4">
+        <profile name="Biggest-Game Hunter" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="d37a-109c-5d74-6f43">
           <characteristics>
             <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
-            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">If the target is a **^^Monster^^**, the Damage characteristic of this unit's **Skullshatter Crossbow** is 3 and the Damage characteristic of its **Impaling Spear** is 6.</characteristic>
+            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">The Damage characteristic of this unit's **Skullshatter Crossbow and Impaling Spear** is 4 if the target is a **^^Monster^^**.</characteristic>
           </characteristics>
           <attributes>
-            <attribute name="Color" typeId="50fe-4f29-6bc3-dcc6">Blue</attribute>
-            <attribute name="Type" typeId="bf11-4e10-3ab1-06f4">Shooting</attribute>
+            <attribute typeId="50fe-4f29-6bc3-dcc6" name="Color">Blue</attribute>
+            <attribute typeId="bf11-4e10-3ab1-06f4" name="Type">Shooting</attribute>
             <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
           </attributes>
         </profile>
-        <profile name="Unrelenting Hunter" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="6620-8c43-4b60-20ec">
+        <profile name="The First Shot&apos;s Mine!" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="4072-b571-9ad7-a26f">
           <characteristics>
-            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Turn (Army), Enemy Movement Phase</characteristic>
-            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb"/>
-            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">If this unit is more than 9&quot; from all enemy units, it can use the 'Normal Move' ability as if it were your movement phase.</characteristic>
+            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Turn (Army), Your Shooting Phase</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick an enemy unit that had any damage points allocated to it this turn by this unit's shooting attacks to be the target.</characteristic>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">For the rest of the phase, add 1 to hit rolls for shooting attacks made by friendly **^^Beastclaw^^** units that target that enemy unit.</characteristic>
             <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
             <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
           </characteristics>
           <attributes>
-            <attribute name="Color" typeId="5a11-eab3-180c-ddf5">Gray</attribute>
-            <attribute name="Type" typeId="6d16-c86b-2698-85a4">Movement</attribute>
+            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Blue</attribute>
+            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Shooting</attribute>
             <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
           </attributes>
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink name="HERO" hidden="false" id="a67a-d0d0-6235-9709" targetId="6e72-1656-d554-528a" primary="true"/>
-        <categoryLink name="DESTRUCTION" hidden="false" id="f44b-9e55-e881-346f" targetId="9057-5a29-dda5-3c28" primary="false"/>
-        <categoryLink name="OGOR MAWTRIBES" hidden="false" id="8933-ffa1-e7f-24fb" targetId="743-1bd8-e3d-ced2" primary="false"/>
-        <categoryLink name="INFANTRY" hidden="false" id="26d6-9567-5334-1404" targetId="75d6-6995-dfcc-3898" primary="false"/>
-        <categoryLink name="OGOR" hidden="false" id="8c62-13c0-ed4a-87c5" targetId="ddcb-3c91-472f-c35a" primary="false"/>
-        <categoryLink name="GUTBUSTERS" hidden="false" id="bd76-7961-bc58-d29b" targetId="5c0d-5e93-d71f-f0da" primary="false"/>
+        <categoryLink name="HERO" hidden="false" id="57c0-ad60-4fe6-ead4" targetId="6e72-1656-d554-528a" primary="true"/>
+        <categoryLink name="INFANTRY" hidden="false" id="c99d-4621-2630-5448" targetId="75d6-6995-dfcc-3898" primary="false"/>
+        <categoryLink name="DESTRUCTION" hidden="false" id="08a5-ec61-a245-5c96" targetId="9057-5a29-dda5-3c28" primary="false"/>
+        <categoryLink name="OGOR MAWTRIBES" hidden="false" id="1551-846a-ec68-fad4" targetId="743-1bd8-e3d-ced2" primary="false"/>
+        <categoryLink name="OGOR" hidden="false" id="30a6-7e79-5192-63f1" targetId="ddcb-3c91-472f-c35a" primary="false"/>
+        <categoryLink name="BEASTCLAW" hidden="false" id="321a-0392-454c-35d1" targetId="410d-6b15-3cf4-88d0" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry type="model" import="true" name="Bloodpelt Hunter" hidden="false" id="6ef0-d73a-5415-88c1">
+        <selectionEntry type="model" import="true" name="Bloodpelt Hunter" hidden="false" id="78f0-6161-6266-ffdd">
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="60af-1f43-3649-6786"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6270-3c28-3e60-0c6c"/>
+          </constraints>
           <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Skullshatter Crossbow" hidden="false" id="dca4-5c02-d43b-7e62">
+            <selectionEntry type="upgrade" import="true" name="Skullshatter Crossbow and Impaling Spear" hidden="false" id="c8a0-b5af-a88b-e96c">
               <profiles>
-                <profile name="Skullshatter Crossbow" typeId="1fd-a42f-41d3-fe05" typeName="Ranged Weapon" hidden="false" id="1cbb-e38b-3a7c-73e2">
+                <profile name="Skullshatter Crossbow and Impaling Spear" typeId="1fd-a42f-41d3-fe05" typeName="Ranged Weapon" hidden="false" id="38cb-2982-728b-f991">
                   <characteristics>
-                    <characteristic name="Rng" typeId="c6b5-908c-a604-1a98">18&quot;</characteristic>
-                    <characteristic name="Atk" typeId="aa17-4296-2887-e05d">2</characteristic>
+                    <characteristic name="Rng" typeId="c6b5-908c-a604-1a98">15&quot;</characteristic>
+                    <characteristic name="Atk" typeId="aa17-4296-2887-e05d">4</characteristic>
                     <characteristic name="Hit" typeId="194d-aeb6-5ba7-83b4">4+</characteristic>
                     <characteristic name="Wnd" typeId="d3d5-9dc6-13de-8d1">3+</characteristic>
                     <characteristic name="Rnd" typeId="d03f-a9ae-3eec-755">1</characteristic>
-                    <characteristic name="Dmg" typeId="96c2-d0a5-ea1e-653b">D3</characteristic>
-                    <characteristic name="Ability" typeId="d793-3dd7-9c13-741e">-</characteristic>
+                    <characteristic name="Dmg" typeId="96c2-d0a5-ea1e-653b">D3+1</characteristic>
+                    <characteristic name="Ability" typeId="d793-3dd7-9c13-741e">Anti-**^^Monster^^** (+1 Rend)</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="ebdf-f951-3b5a-7d1d"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4809-d385-b2ad-8c04"/>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="38a2-8bba-6cc8-15b9"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="1692-b9e7-487c-e6f8"/>
               </constraints>
             </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Hacker-axe and Meatblade" hidden="false" id="2a0b-5442-bcc3-fdf4">
+            <selectionEntry type="upgrade" import="true" name="Hacker-axe and Meatblade" hidden="false" id="52b5-ced4-d594-4b6b">
               <profiles>
-                <profile name="Hacker-axe and Meatblade" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="b970-64a1-f704-a792">
+                <profile name="Hacker-axe and Meatblade" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="4b01-f1fa-c62c-cda3">
                   <characteristics>
                     <characteristic name="Atk" typeId="60e-35aa-31ed-e488">5</characteristic>
                     <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">4+</characteristic>
@@ -84,48 +88,25 @@
                 </profile>
               </profiles>
               <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="b18-6fc5-8dae-b02e"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="15bb-d970-2b3a-37df"/>
-              </constraints>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Impaling Spear" hidden="false" id="ab03-6ba3-2254-f1e8">
-              <profiles>
-                <profile name="Impaling Spear" typeId="1fd-a42f-41d3-fe05" typeName="Ranged Weapon" hidden="false" id="c93e-e3aa-4eb2-6302">
-                  <characteristics>
-                    <characteristic name="Rng" typeId="c6b5-908c-a604-1a98">12&quot;</characteristic>
-                    <characteristic name="Atk" typeId="aa17-4296-2887-e05d">1</characteristic>
-                    <characteristic name="Hit" typeId="194d-aeb6-5ba7-83b4">4+</characteristic>
-                    <characteristic name="Wnd" typeId="d3d5-9dc6-13de-8d1">2+</characteristic>
-                    <characteristic name="Rnd" typeId="d03f-a9ae-3eec-755">1</characteristic>
-                    <characteristic name="Dmg" typeId="96c2-d0a5-ea1e-653b">D6</characteristic>
-                    <characteristic name="Ability" typeId="d793-3dd7-9c13-741e">Anti-**^^Monster^^** (+1 Rend)</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="a9dd-e271-8576-848d"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="e755-3d7a-71d5-4237"/>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="cabb-450c-10c7-19a7"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="b8c5-5b6e-01be-b97a"/>
               </constraints>
             </selectionEntry>
           </selectionEntries>
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="214-9dec-33df-a3ea"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="9492-6469-73c4-6923"/>
-          </constraints>
           <rules>
-            <rule name="Base Size" id="fa26-0ff7-fd3c-52d4" hidden="true">
+            <rule name="Base Size" id="15bf-c987-5e7b-619b" hidden="true">
               <description>40mm</description>
             </rule>
           </rules>
         </selectionEntry>
       </selectionEntries>
     </selectionEntry>
-    <selectionEntry type="unit" import="true" name="Kragnos, the End of Empires" hidden="false" id="7231-fb13-c283-ff9d" publicationId="1ac6-e227-a186-12">
+    <selectionEntry type="unit" import="true" name="Kragnos, the End of Empires" hidden="false" id="7231-fb13-c283-ff9d" publicationId="feba-6749-6df3-ea9e">
       <entryLinks>
-        <entryLink import="true" name="General" hidden="false" id="6e6e-7428-663d-5133" type="selectionEntry" targetId="a56b-952e-ad15-7868"/>
+        <entryLink import="true" name="General" hidden="false" id="8020-5dcb-dbbd-cac1" type="selectionEntry" targetId="a56b-952e-ad15-7868"/>
       </entryLinks>
       <profiles>
-        <profile name="Kragnos, the End of Empires" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="42-aa16-f2c7-3ea5">
+        <profile name="Kragnos, the End of Empires" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="e9ac-4334-45d0-3078">
           <characteristics>
             <characteristic name="Move" typeId="fed0-d1b3-1bb8-c501">10&quot;</characteristic>
             <characteristic name="Health" typeId="96be-54ae-ce7b-10b7">18</characteristic>
@@ -133,91 +114,95 @@
             <characteristic name="Control" typeId="6c6f-8510-9ce1-fc6e">15</characteristic>
           </characteristics>
         </profile>
-        <profile name="Battle Damaged" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="acc-abe0-9fec-49ab">
-          <characteristics>
-            <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
-            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">While this unit has 10 or more damage points, the Attacks characteristic of **The Dread Mace** is 4 and this unit has a Control characteristic of 10.</characteristic>
-          </characteristics>
-          <attributes>
-            <attribute name="Color" typeId="50fe-4f29-6bc3-dcc6">Black</attribute>
-            <attribute name="Type" typeId="bf11-4e10-3ab1-06f4">Damage</attribute>
-            <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
-          </attributes>
-        </profile>
-        <profile name="Avatar of Destruction" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="5039-3f80-d460-640b">
-          <characteristics>
-            <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
-            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">If this unit would be automatically destroyed, it is not automatically destroyed. Instead, allocate 6 damage points to it (ward rolls cannot be made for those damage points).</characteristic>
-          </characteristics>
-          <attributes>
-            <attribute name="Color" typeId="50fe-4f29-6bc3-dcc6">Green</attribute>
-            <attribute name="Type" typeId="bf11-4e10-3ab1-06f4">Defensive</attribute>
-            <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
-          </attributes>
-        </profile>
-        <profile name="Rampaging Destruction" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="bf98-7816-73a8-3a85">
+        <profile name="Rampaging Destruction" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="342e-60c1-326e-b8ff">
           <characteristics>
             <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Turn (Army), Any Charge Phase</characteristic>
             <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb"/>
-            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">If this unit charged this phase, pick 1 of the following effects:
-• Roll a dice for each enemy unit within 1&quot; of this unit. On a 2+, inflict an amount of mortal damage on that unit equal to the roll.
-• Pick an enemy **^^Monster^^** in combat with this unit and roll 2D6. On a 7, this ability has no effect. Otherwise, inflict an amount of mortal damage on that unit equal to the results on the dice used for the 2D6 roll multiplied together. For example, a 2D6 roll of 2 and 6 would inflict 12 mortal damage (2 × 6).</characteristic>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">If this unit charged this phase, pick 1 of the following effects:
+• Roll a dice for each enemy unit within 1&quot; of this unit. On a 2+, inflict an amount of mortal damage on that unit equal to the roll.
+• Pick an enemy **^^Monster^^** in combat with this unit and roll 2D6. On a 7, this ability has no effect. Otherwise, inflict an amount of mortal damage on that unit equal to the results on the dice used for the 2D6 roll multiplied together. For example, a 2D6 roll of 2 and 6 would inflict 12 mortal damage (2 x 6).</characteristic>
             <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f">**^^Rampage^^**</characteristic>
             <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
           </characteristics>
           <attributes>
-            <attribute name="Color" typeId="5a11-eab3-180c-ddf5">Orange</attribute>
-            <attribute name="Type" typeId="6d16-c86b-2698-85a4">Offensive</attribute>
+            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Orange</attribute>
+            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Offensive</attribute>
             <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
           </attributes>
         </profile>
-        <profile name="The End of Empires" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="cdbf-142e-66a-bb6f">
+        <profile name="The End of Empires" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="0046-d643-4257-2a49">
           <characteristics>
             <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Your Charge Phase</characteristic>
             <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb"/>
-            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">For the rest of the turn, add 1 to the number of dice rolled when making charge rolls for friendly **^^Destruction^^** units while they are wholly within 12&quot; of this unit, to a maximum of 3.</characteristic>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">For the rest of the turn, add 1 to the number of dice rolled when making charge rolls for friendly **^^Destruction^^** units while they are wholly within 12&quot; of this unit, to a maximum of 3.</characteristic>
             <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
             <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
           </characteristics>
           <attributes>
-            <attribute name="Color" typeId="5a11-eab3-180c-ddf5">Orange</attribute>
-            <attribute name="Type" typeId="6d16-c86b-2698-85a4">Movement</attribute>
+            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Orange</attribute>
+            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Movement</attribute>
             <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
           </attributes>
         </profile>
-        <profile name="The Shield Inviolate" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="7fe0-a1d4-491d-6053">
+        <profile name="Battle Damaged" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="3aa4-b1cd-41ed-e200">
           <characteristics>
-            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Reaction: Opponent declared a **^^Spell^^** ability</characteristic>
+            <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
+            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">While this unit has 10 or more damage points, the Attacks characteristic of **The Dread Mace** is 4 and this unit has a Control characteristic of 10.</characteristic>
+          </characteristics>
+          <attributes>
+            <attribute typeId="50fe-4f29-6bc3-dcc6" name="Color">Black</attribute>
+            <attribute typeId="bf11-4e10-3ab1-06f4" name="Type">Damage</attribute>
+            <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
+          </attributes>
+        </profile>
+        <profile name="The Shield Inviolate" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="6fda-ed71-b85a-f97a">
+          <characteristics>
+            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Reaction: Opponent declared a Spell ability</characteristic>
             <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb"/>
-            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">If this unit was picked to be the target of that spell, roll a dice. On a 3+, ignore the effect of that spell on this unit. This unit can use this ability more than once per phase but only once per **^^Spell^^** ability.</characteristic>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">If this unit was picked to be the target of that spell, roll a dice. On a 3+, ignore the effect of that spell on this unit. This unit can use this ability more than once per phase but only once per **^^Spell^^** ability.</characteristic>
             <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
             <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
           </characteristics>
           <attributes>
-            <attribute name="Color" typeId="5a11-eab3-180c-ddf5">Yellow</attribute>
-            <attribute name="Type" typeId="6d16-c86b-2698-85a4">Defensive</attribute>
+            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Yellow</attribute>
+            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Defensive</attribute>
             <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+          </attributes>
+        </profile>
+        <profile name="Avatar of Destruction" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="2e13-c749-ccf0-13fa">
+          <characteristics>
+            <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
+            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">If this unit would be automatically destroyed, it is not automatically destroyed. Instead, allocate 6 damage points to it (ward rolls cannot be made for those damage points).</characteristic>
+          </characteristics>
+          <attributes>
+            <attribute typeId="50fe-4f29-6bc3-dcc6" name="Color">Green</attribute>
+            <attribute typeId="bf11-4e10-3ab1-06f4" name="Type">Defensive</attribute>
+            <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
           </attributes>
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink name="HERO" hidden="false" id="9ece-50ba-cbdf-4ed8" targetId="6e72-1656-d554-528a" primary="true"/>
-        <categoryLink name="UNIQUE" hidden="false" id="909-ed42-8867-6bea" targetId="72ce-2188-70bf-2dbd" primary="false"/>
-        <categoryLink name="MONSTER" hidden="false" id="c78-e9eb-96d-fb75" targetId="6d54-625c-d063-13e2" primary="false"/>
-        <categoryLink name="WARMASTER" hidden="false" id="a26a-d1ca-174-603f" targetId="c203-51a0-3d44-6b07" primary="false"/>
-        <categoryLink name="WARD (5+)" hidden="false" id="fecd-6e16-4147-d110" targetId="52cc-95fd-6cd3-8f72" primary="false"/>
-        <categoryLink name="DESTRUCTION" hidden="false" id="30f6-865f-e5f1-baf3" targetId="9057-5a29-dda5-3c28" primary="false"/>
-        <categoryLink name="OGOR MAWTRIBES" hidden="false" id="f420-8e29-cdc9-9916" targetId="743-1bd8-e3d-ced2" primary="false"/>
+        <categoryLink name="HERO" hidden="false" id="05e5-a05f-3f84-40f2" targetId="6e72-1656-d554-528a" primary="true"/>
+        <categoryLink name="WARMASTER" hidden="false" id="2a8f-c8ef-08f3-aad3" targetId="c203-51a0-3d44-6b07" primary="false"/>
+        <categoryLink name="UNIQUE" hidden="false" id="3791-3cdd-0315-c9ee" targetId="72ce-2188-70bf-2dbd" primary="false"/>
+        <categoryLink name="MONSTER" hidden="false" id="a95c-9e09-e3f1-d08b" targetId="6d54-625c-d063-13e2" primary="false"/>
+        <categoryLink name="DESTRUCTION" hidden="false" id="3f60-c3c1-8b5f-017b" targetId="9057-5a29-dda5-3c28" primary="false"/>
+        <categoryLink name="OGOR MAWTRIBES" hidden="false" id="2d6c-045d-b658-2bb5" targetId="743-1bd8-e3d-ced2" primary="false"/>
+        <categoryLink name="WARD (5+)" hidden="false" id="a2bb-9df7-ead0-8a0c" targetId="52cc-95fd-6cd3-8f72" primary="false"/>
       </categoryLinks>
       <constraints>
-        <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="38e0-5ada-cd51-b7b8" includeChildSelections="true"/>
+        <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="9841-f7f8-0b0b-c49d" includeChildSelections="true"/>
       </constraints>
       <selectionEntries>
-        <selectionEntry type="model" import="true" name="Kragnos, the End of Empires" hidden="false" id="d631-8073-7384-790d">
+        <selectionEntry type="model" import="true" name="Kragnos, the End of Empires" hidden="false" id="245c-3b35-367e-50ab">
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="5b13-fb8a-c1c5-e92d"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="06cd-3236-fb22-bdb0"/>
+          </constraints>
           <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="The Dread Mace" hidden="false" id="64de-2735-878d-67ff">
+            <selectionEntry type="upgrade" import="true" name="The Dread Mace" hidden="false" id="a0af-7bc0-1e6f-7438">
               <profiles>
-                <profile name="The Dread Mace" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="4abf-fe65-3816-7e75">
+                <profile name="The Dread Mace" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="4b81-07df-0327-4e94">
                   <characteristics>
                     <characteristic name="Atk" typeId="60e-35aa-31ed-e488">6</characteristic>
                     <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">3+</characteristic>
@@ -229,13 +214,13 @@
                 </profile>
               </profiles>
               <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="5903-645f-ee69-ea7a"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6635-7110-c08e-f1d9"/>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="faf1-2cde-6d51-aeb8"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8c5b-1ca4-90be-1076"/>
               </constraints>
             </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Tuskbreaker" hidden="false" id="1fdc-7bd4-204a-ff06">
+            <selectionEntry type="upgrade" import="true" name="Tuskbreaker" hidden="false" id="f7c8-7525-8f60-004b">
               <profiles>
-                <profile name="Tuskbreaker" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="5e2f-47e9-2c99-19aa">
+                <profile name="Tuskbreaker" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="52ce-8ce3-db3f-b8c1">
                   <characteristics>
                     <characteristic name="Atk" typeId="60e-35aa-31ed-e488">3</characteristic>
                     <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">4+</characteristic>
@@ -247,13 +232,13 @@
                 </profile>
               </profiles>
               <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="e818-beee-193d-4c1e"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="edf-c00-867c-c2c5"/>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="882c-7fc4-a2d7-89d5"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ca0f-4c73-8411-38c0"/>
               </constraints>
             </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Hooves of Wrack and Ruin" hidden="false" id="4e19-1964-db33-e29b">
+            <selectionEntry type="upgrade" import="true" name="Hooves of Wrack and Ruin" hidden="false" id="d131-a44d-2c28-5220">
               <profiles>
-                <profile name="Hooves of Wrack and Ruin" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="b414-3414-a4d7-1f4e">
+                <profile name="Hooves of Wrack and Ruin" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="3b58-d4d9-977b-7b22">
                   <characteristics>
                     <characteristic name="Atk" typeId="60e-35aa-31ed-e488">6</characteristic>
                     <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">3+</characteristic>
@@ -265,26 +250,22 @@
                 </profile>
               </profiles>
               <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="648d-9513-de35-3af"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="23a9-2e7f-fc24-5c90"/>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="7df1-a003-2eb7-741a"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="1313-fd81-b6cd-6954"/>
               </constraints>
             </selectionEntry>
           </selectionEntries>
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="f629-ce8-dcf7-bfc"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="c806-3249-53c9-17ba"/>
-          </constraints>
           <rules>
-            <rule name="Base Size" id="7fd4-974e-4547-9585" hidden="true">
+            <rule name="Base Size" id="8a05-5ff0-f224-a275" hidden="true">
               <description>130mm</description>
             </rule>
           </rules>
         </selectionEntry>
       </selectionEntries>
     </selectionEntry>
-    <selectionEntry type="unit" import="true" name="Gnoblar Scraplauncher" hidden="false" id="206-8e8e-f77d-e786" publicationId="1ac6-e227-a186-12">
+    <selectionEntry type="unit" import="true" name="Gnoblar Scraplauncher" hidden="false" id="206-8e8e-f77d-e786" publicationId="feba-6749-6df3-ea9e">
       <profiles>
-        <profile name="Gnoblar Scraplauncher" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="1e41-8795-279-2af6">
+        <profile name="Gnoblar Scraplauncher" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="63e7-8098-8c73-a99a">
           <characteristics>
             <characteristic name="Move" typeId="fed0-d1b3-1bb8-c501">9&quot;</characteristic>
             <characteristic name="Health" typeId="96be-54ae-ce7b-10b7">9</characteristic>
@@ -292,35 +273,59 @@
             <characteristic name="Control" typeId="6c6f-8510-9ce1-fc6e">2</characteristic>
           </characteristics>
         </profile>
-        <profile name="Load It Up!" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="a0fa-986d-852c-fecc">
+        <profile name="Rain of Scrap" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="4c55-c20f-acaa-0b12">
           <characteristics>
-            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Your Shooting Phase</characteristic>
-            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb"/>
-            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">If this unit is within the combat range of a friendly **Gnoblars** unit, this unit's shooting attacks score critical hits on unmodified hit rolls of 5+ until the start of your next turn.</characteristic>
+            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Turn (Army), Any Shooting Phase</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick an enemy unit that had any damage points allocated to it this phase by this unit's shooting attacks to be the target.</characteristic>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Until the start of your next turn, subtract X&quot; from the target's Move characteristic (to a minimum Move characteristic of 1&quot;), where X is the number of damage points allocated to the target this phase by this unit's shooting attacks.
+
+Then, roll a dice. On a 3+, until the start of your next turn, the target cannot use **^^Run^^** or **^^Retreat^^** abilities and cannot use or be picked to be the target of abilities that would allow it to be set up on the battlefield.</characteristic>
             <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
             <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
           </characteristics>
           <attributes>
-            <attribute name="Color" typeId="5a11-eab3-180c-ddf5">Blue</attribute>
-            <attribute name="Type" typeId="6d16-c86b-2698-85a4">Shooting</attribute>
+            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Blue</attribute>
+            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Movement</attribute>
             <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
           </attributes>
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink name="DESTRUCTION" hidden="false" id="663d-7c91-c0b7-e2b6" targetId="9057-5a29-dda5-3c28" primary="false"/>
-        <categoryLink name="OGOR MAWTRIBES" hidden="false" id="535-3f9b-8b4e-acd6" targetId="743-1bd8-e3d-ced2" primary="false"/>
-        <categoryLink name="RHINOX" hidden="false" id="c093-3390-5e50-3741" targetId="1ffa-4941-1338-9cf2" primary="false"/>
-        <categoryLink name="WAR MACHINE" hidden="false" id="f601-d531-8637-53e8" targetId="f7bc-b618-4b5d-2bae" primary="true"/>
+        <categoryLink name="WAR MACHINE" hidden="false" id="a2b1-b6fe-56cd-1612" targetId="f7bc-b618-4b5d-2bae" primary="true"/>
+        <categoryLink name="DESTRUCTION" hidden="false" id="79da-f3c0-8f94-6260" targetId="9057-5a29-dda5-3c28" primary="false"/>
+        <categoryLink name="OGOR MAWTRIBES" hidden="false" id="3353-77c0-556b-6dfc" targetId="743-1bd8-e3d-ced2" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry type="model" import="true" name="Gnoblar Scraplauncher" hidden="false" id="1321-e46d-e079-c04b">
+        <selectionEntry type="model" import="true" name="Gnoblar Scraplauncher" hidden="false" id="ae8d-9dee-1cb6-4ab8">
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="b91d-787e-ab20-8502"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="e2ef-9a94-1541-5025"/>
+          </constraints>
           <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Rhinox&apos;s Sharp Horns" hidden="false" id="7f22-9ee5-93b6-1aba">
+            <selectionEntry type="upgrade" import="true" name="Piles of Old Scrap" hidden="false" id="b3ab-02d7-dc15-aa30">
               <profiles>
-                <profile name="Rhinox&apos;s Sharp Horns" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="e5a5-be9c-1122-e84e">
+                <profile name="Piles of Old Scrap" typeId="1fd-a42f-41d3-fe05" typeName="Ranged Weapon" hidden="false" id="66a7-c9a0-cd49-ea4d">
                   <characteristics>
-                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">1</characteristic>
+                    <characteristic name="Rng" typeId="c6b5-908c-a604-1a98">18&quot;</characteristic>
+                    <characteristic name="Atk" typeId="aa17-4296-2887-e05d">12</characteristic>
+                    <characteristic name="Hit" typeId="194d-aeb6-5ba7-83b4">4+</characteristic>
+                    <characteristic name="Wnd" typeId="d3d5-9dc6-13de-8d1">2+</characteristic>
+                    <characteristic name="Rnd" typeId="d03f-a9ae-3eec-755">1</characteristic>
+                    <characteristic name="Dmg" typeId="96c2-d0a5-ea1e-653b">1</characteristic>
+                    <characteristic name="Ability" typeId="d793-3dd7-9c13-741e">Crit (2 Hits)</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="7b73-a396-8780-d640"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="e6ce-2028-c884-e992"/>
+              </constraints>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Rhinox&apos;s Sharp Horns and Crew&apos;s Weapons" hidden="false" id="bc47-135c-b824-a4a9">
+              <profiles>
+                <profile name="Rhinox&apos;s Sharp Horns and Crew&apos;s Weapons" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="21dd-3422-39a3-ffcd">
+                  <characteristics>
+                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">3</characteristic>
                     <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">4+</characteristic>
                     <characteristic name="Wnd" typeId="61c1-22cc-40af-2847">2+</characteristic>
                     <characteristic name="Rnd" typeId="eccc-10fa-6958-fb73">1</characteristic>
@@ -330,54 +335,13 @@
                 </profile>
               </profiles>
               <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="c44b-bc10-eb71-2ec2"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="7024-e15e-50a-c7a5"/>
-              </constraints>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Scrappers&apos; Stabbers" hidden="false" id="e0b-2fff-cb25-82ce">
-              <profiles>
-                <profile name="Scrappers&apos; Stabbers" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="a567-98a0-d881-653b">
-                  <characteristics>
-                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">7</characteristic>
-                    <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">5+</characteristic>
-                    <characteristic name="Wnd" typeId="61c1-22cc-40af-2847">5+</characteristic>
-                    <characteristic name="Rnd" typeId="eccc-10fa-6958-fb73">-</characteristic>
-                    <characteristic name="Dmg" typeId="e948-9c71-12a6-6be4">1</characteristic>
-                    <characteristic name="Ability" typeId="eda3-7332-5db1-4159">-</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="67a0-80ed-eb21-deb3"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="d6d8-b1a1-f0d3-949"/>
-              </constraints>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Piles of Old Scrap" hidden="false" id="a292-b186-7dbc-8f37">
-              <profiles>
-                <profile name="Piles of Old Scrap" typeId="1fd-a42f-41d3-fe05" typeName="Ranged Weapon" hidden="false" id="4b4-104b-33e-6216">
-                  <characteristics>
-                    <characteristic name="Rng" typeId="c6b5-908c-a604-1a98">24&quot;</characteristic>
-                    <characteristic name="Atk" typeId="aa17-4296-2887-e05d">3D6</characteristic>
-                    <characteristic name="Hit" typeId="194d-aeb6-5ba7-83b4">4+</characteristic>
-                    <characteristic name="Wnd" typeId="d3d5-9dc6-13de-8d1">4+</characteristic>
-                    <characteristic name="Rnd" typeId="d03f-a9ae-3eec-755">-</characteristic>
-                    <characteristic name="Dmg" typeId="96c2-d0a5-ea1e-653b">1</characteristic>
-                    <characteristic name="Ability" typeId="d793-3dd7-9c13-741e">Anti-**^^Infantry^^** (+1 Rend), Crit (Auto-wound)</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="7515-11bf-a444-d"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="1568-5022-8f20-ab06"/>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="3f77-ebae-b6e3-4b1c"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="a419-b65e-c4df-93bd"/>
               </constraints>
             </selectionEntry>
           </selectionEntries>
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="f15d-257d-8a4a-b815"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="c542-afcc-e380-c4b7"/>
-          </constraints>
           <rules>
-            <rule name="Base Size" id="91d2-eaf8-acab-e8fa" hidden="true">
+            <rule name="Base Size" id="939f-8e55-7214-d3b7" hidden="true">
               <description>120x92mm</description>
             </rule>
           </rules>
@@ -486,77 +450,95 @@
         </selectionEntry>
       </selectionEntries>
     </selectionEntry>
-    <selectionEntry type="unit" import="true" name="Butcher" hidden="false" id="1688-fcbe-1470-a4ee" publicationId="1ac6-e227-a186-12">
+    <selectionEntry type="unit" import="true" name="Butcher" hidden="false" id="1688-fcbe-1470-a4ee" publicationId="feba-6749-6df3-ea9e">
       <entryLinks>
-        <entryLink import="true" name="General" hidden="false" id="cc7f-305e-f647-28a3" type="selectionEntry" targetId="a56b-952e-ad15-7868"/>
+        <entryLink import="true" name="General" hidden="false" id="5bfb-95b8-ddb3-fbae" type="selectionEntry" targetId="a56b-952e-ad15-7868"/>
       </entryLinks>
       <profiles>
-        <profile name="Butcher" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="19ef-49bc-e678-f599">
+        <profile name="Butcher" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="8c00-4375-5cbd-0674">
           <characteristics>
             <characteristic name="Move" typeId="fed0-d1b3-1bb8-c501">6&quot;</characteristic>
-            <characteristic name="Health" typeId="96be-54ae-ce7b-10b7">7</characteristic>
+            <characteristic name="Health" typeId="96be-54ae-ce7b-10b7">8</characteristic>
             <characteristic name="Save" typeId="1981-ef09-96f6-7aa9">5+</characteristic>
-            <characteristic name="Control" typeId="6c6f-8510-9ce1-fc6e">5</characteristic>
+            <characteristic name="Control" typeId="6c6f-8510-9ce1-fc6e">3</characteristic>
           </characteristics>
         </profile>
-        <profile name="Savage Hunger" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="3cfb-8e55-c35e-aebd">
+        <profile name="Trogg-Guts" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="5492-983a-0f0b-2bf2">
           <characteristics>
-            <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
-            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">While they are wholly within 12&quot; of this unit, friendly **^^Gutbusters^^** units can use **^^Charge^^** abilities even if they used a **^^Run^^** ability in the same turn.</characteristic>
+            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Turn (Army), Any Movement Phase</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick a visible friendly **^^Ogor Mawtribes^^** unit wholly within 12&quot; of this unit to be the target.</characteristic>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Roll a dice. On a 3+, the target has **^^Ward (6+)^^** until the start of your next turn. If you picked a **^^Mawseekers^^** unit, it has **^^Ward (5+)^^** until the start of your next turn instead.</characteristic>
+            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
           </characteristics>
           <attributes>
-            <attribute name="Color" typeId="50fe-4f29-6bc3-dcc6">Orange</attribute>
-            <attribute name="Type" typeId="bf11-4e10-3ab1-06f4">Movement</attribute>
-            <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
+            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Gray</attribute>
+            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Defensive</attribute>
+            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+          </attributes>
+        </profile>
+        <profile name="More Meat for the Pot..." typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="24c7-8ca3-0d43-930a">
+          <characteristics>
+            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Battle (Army), End of Any Turn</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb"/>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">If any damage points were allocated to an enemy unit this turn by this unit's combat attacks or by combat attacks made by a **^^Manifestation^^** summoned by this unit, and that enemy unit has been destroyed, add 1 to this unit's power level for the rest of the battle.</characteristic>
+            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+          </characteristics>
+          <attributes>
+            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Purple</attribute>
+            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Special</attribute>
+            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
           </attributes>
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink name="HERO" hidden="false" id="5fcb-70a3-f21-52a" targetId="6e72-1656-d554-528a" primary="true"/>
-        <categoryLink name="DESTRUCTION" hidden="false" id="8923-4a5-2b57-61b5" targetId="9057-5a29-dda5-3c28" primary="false"/>
-        <categoryLink name="OGOR MAWTRIBES" hidden="false" id="3c6b-224a-598-5073" targetId="743-1bd8-e3d-ced2" primary="false"/>
-        <categoryLink name="INFANTRY" hidden="false" id="2a8c-f076-6989-105d" targetId="75d6-6995-dfcc-3898" primary="false"/>
-        <categoryLink name="OGOR" hidden="false" id="3453-459c-9194-6ad3" targetId="ddcb-3c91-472f-c35a" primary="false"/>
-        <categoryLink name="GUTBUSTERS" hidden="false" id="9268-fa7c-df8a-ad8d" targetId="5c0d-5e93-d71f-f0da" primary="false"/>
-        <categoryLink name="WIZARD (1)" hidden="false" id="1e7a-272f-33a-9b36" targetId="6f28-c3f6-4b1b-8aff" primary="false"/>
+        <categoryLink name="HERO" hidden="false" id="db99-ded2-ae67-7ec5" targetId="6e72-1656-d554-528a" primary="true"/>
+        <categoryLink name="WIZARD (1)" hidden="false" id="11c4-c6ed-6b18-c304" targetId="6f28-c3f6-4b1b-8aff" primary="false"/>
+        <categoryLink name="INFANTRY" hidden="false" id="1847-89b6-428b-10c6" targetId="75d6-6995-dfcc-3898" primary="false"/>
+        <categoryLink name="DESTRUCTION" hidden="false" id="0530-0c63-d621-fc95" targetId="9057-5a29-dda5-3c28" primary="false"/>
+        <categoryLink name="OGOR MAWTRIBES" hidden="false" id="a127-53d2-3058-3281" targetId="743-1bd8-e3d-ced2" primary="false"/>
+        <categoryLink name="OGOR" hidden="false" id="dd73-2827-c50c-9034" targetId="ddcb-3c91-472f-c35a" primary="false"/>
+        <categoryLink name="MAWSEEKERS" hidden="false" id="9921-7f5f-4af5-751c" targetId="b50b-6a98-f92a-c99c" primary="false"/>
+        <categoryLink name="WARD (6+)" hidden="false" id="0503-23c4-8f8a-42c3" targetId="70a4-383f-421f-52cd" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry type="model" import="true" name="Butcher" hidden="false" id="e6a5-11e2-9eb6-f1e4">
+        <selectionEntry type="model" import="true" name="Butcher" hidden="false" id="aff1-3552-d07d-9d10">
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="262d-b222-3312-7d1a"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="14be-84ae-91bf-6ef5"/>
+          </constraints>
           <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Butcher&apos;s Tools" hidden="false" id="f7ec-a811-3df3-9917">
+            <selectionEntry type="upgrade" import="true" name="Butcher&apos;s Tools" hidden="false" id="d9ee-5d9d-0997-7d48">
               <profiles>
-                <profile name="Butcher&apos;s Tools" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="34f1-dcd-8558-c7e">
+                <profile name="Butcher&apos;s Tools" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="a3e8-124d-3eaa-40f0">
                   <characteristics>
-                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">3</characteristic>
+                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">4</characteristic>
                     <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">4+</characteristic>
                     <characteristic name="Wnd" typeId="61c1-22cc-40af-2847">2+</characteristic>
-                    <characteristic name="Rnd" typeId="eccc-10fa-6958-fb73">1</characteristic>
+                    <characteristic name="Rnd" typeId="eccc-10fa-6958-fb73">2</characteristic>
                     <characteristic name="Dmg" typeId="e948-9c71-12a6-6be4">3</characteristic>
                     <characteristic name="Ability" typeId="eda3-7332-5db1-4159">-</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="eb2b-e147-ecc3-7e09"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="2c2e-a6c7-cd3f-40af"/>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="bc3a-1a4c-77ff-ae5f"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ebed-dddc-639f-c991"/>
               </constraints>
             </selectionEntry>
           </selectionEntries>
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="75dd-7b4a-93c5-c6f0"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="16ca-c5ec-53c7-e7fe"/>
-          </constraints>
           <rules>
-            <rule name="Base Size" id="1f8d-3979-8b35-f36c" hidden="true">
+            <rule name="Base Size" id="4c00-6428-b1f4-b693" hidden="true">
               <description>50mm</description>
             </rule>
           </rules>
         </selectionEntry>
       </selectionEntries>
     </selectionEntry>
-    <selectionEntry type="unit" import="true" name="Maneaters" hidden="false" id="f4ef-9156-1fd1-4b91" publicationId="1ac6-e227-a186-12">
+    <selectionEntry type="unit" import="true" name="Gluttons" hidden="false" id="e93b-4897-f014-9b88" publicationId="feba-6749-6df3-ea9e">
       <profiles>
-        <profile name="Maneaters" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="5108-f68-b882-ff9f">
+        <profile name="Gluttons" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="f211-7407-ca30-300c">
           <characteristics>
             <characteristic name="Move" typeId="fed0-d1b3-1bb8-c501">6&quot;</characteristic>
             <characteristic name="Health" typeId="96be-54ae-ce7b-10b7">4</characteristic>
@@ -564,338 +546,49 @@
             <characteristic name="Control" typeId="6c6f-8510-9ce1-fc6e">2</characteristic>
           </characteristics>
         </profile>
-        <profile name="Been There, Done That" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="250a-62aa-c07d-da93">
-          <characteristics>
-            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Turn (Army), Reaction: This unit was picked as the target of a non-**^^Core^^** ability</characteristic>
-            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb"/>
-            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Roll a dice. On a 4+, that ability has no effect on this unit.</characteristic>
-            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
-            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
-          </characteristics>
-          <attributes>
-            <attribute name="Color" typeId="5a11-eab3-180c-ddf5">Green</attribute>
-            <attribute name="Type" typeId="6d16-c86b-2698-85a4">Defensive</attribute>
-            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
-          </attributes>
-        </profile>
-      </profiles>
-      <categoryLinks>
-        <categoryLink name="INFANTRY" hidden="false" id="1634-1134-8da1-120f" targetId="75d6-6995-dfcc-3898" primary="true"/>
-        <categoryLink name="OGOR MAWTRIBES" hidden="false" id="8a29-12ba-d139-6ca6" targetId="743-1bd8-e3d-ced2" primary="false"/>
-        <categoryLink name="DESTRUCTION" hidden="false" id="99f6-5f47-1b4-fc64" targetId="9057-5a29-dda5-3c28" primary="false"/>
-        <categoryLink name="OGOR" hidden="false" id="8d5f-aae8-e6ea-2b6b" targetId="ddcb-3c91-472f-c35a" primary="false"/>
-      </categoryLinks>
-      <selectionEntries>
-        <selectionEntry type="model" import="true" name="Maneater" hidden="false" id="228-71e4-5e10-bea5" defaultAmount="3">
-          <constraints>
-            <constraint type="min" value="3" field="selections" scope="parent" shared="false" id="f7c0-d527-9900-42bc"/>
-            <constraint type="max" value="3" field="selections" scope="parent" shared="false" id="2fd0-988-86de-c023"/>
-          </constraints>
-          <modifiers>
-            <modifier type="increment" value="3" field="f7c0-d527-9900-42bc">
-              <repeats>
-                <repeat value="1" repeats="1" field="selections" scope="f4ef-9156-1fd1-4b91" childId="1b37-82b8-c062-eb82" shared="true" roundUp="false"/>
-              </repeats>
-            </modifier>
-            <modifier type="increment" value="3" field="2fd0-988-86de-c023">
-              <repeats>
-                <repeat value="1" repeats="1" field="selections" scope="f4ef-9156-1fd1-4b91" childId="1b37-82b8-c062-eb82" shared="true" roundUp="false"/>
-              </repeats>
-            </modifier>
-          </modifiers>
-          <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Pistols or Throwing Weapons" hidden="false" id="5de9-7c5a-8446-20fe">
-              <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="80c9-898e-99a8-94c1"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6e2f-c0b4-5771-5960"/>
-              </constraints>
-              <profiles>
-                <profile name="Pistols or Throwing Weapons" typeId="1fd-a42f-41d3-fe05" typeName="Ranged Weapon" hidden="false" id="cbcc-815f-f2dd-ecc5">
-                  <characteristics>
-                    <characteristic name="Rng" typeId="c6b5-908c-a604-1a98">10&quot;</characteristic>
-                    <characteristic name="Atk" typeId="aa17-4296-2887-e05d">1</characteristic>
-                    <characteristic name="Hit" typeId="194d-aeb6-5ba7-83b4">3+</characteristic>
-                    <characteristic name="Wnd" typeId="d3d5-9dc6-13de-8d1">3+</characteristic>
-                    <characteristic name="Rnd" typeId="d03f-a9ae-3eec-755">1</characteristic>
-                    <characteristic name="Dmg" typeId="96c2-d0a5-ea1e-653b">D3</characteristic>
-                    <characteristic name="Ability" typeId="d793-3dd7-9c13-741e">Shoot in Combat</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Maneater Weapons" hidden="false" id="f59e-e83f-25c5-7b6a">
-              <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="5895-6e2f-41fd-99a2"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="f205-f395-4c1f-2e1b"/>
-              </constraints>
-              <profiles>
-                <profile name="Maneater Weapons" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="130-9cb-91f6-82c5">
-                  <characteristics>
-                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">4</characteristic>
-                    <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">4+</characteristic>
-                    <characteristic name="Wnd" typeId="61c1-22cc-40af-2847">2+</characteristic>
-                    <characteristic name="Rnd" typeId="eccc-10fa-6958-fb73">1</characteristic>
-                    <characteristic name="Dmg" typeId="e948-9c71-12a6-6be4">2</characteristic>
-                    <characteristic name="Ability" typeId="eda3-7332-5db1-4159">-</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-          </selectionEntries>
-          <rules>
-            <rule name="Base Size" id="3199-9ff5-56e4-4605" hidden="true">
-              <description>50mm</description>
-            </rule>
-          </rules>
-        </selectionEntry>
-      </selectionEntries>
-    </selectionEntry>
-    <selectionEntry type="unit" import="true" name="Gnoblars" hidden="false" id="5d4b-756c-2229-3dd9" publicationId="1ac6-e227-a186-12">
-      <profiles>
-        <profile name="Gnoblars" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="87a-6fb7-c2d8-390e">
-          <characteristics>
-            <characteristic name="Move" typeId="fed0-d1b3-1bb8-c501">5&quot;</characteristic>
-            <characteristic name="Health" typeId="96be-54ae-ce7b-10b7">1</characteristic>
-            <characteristic name="Save" typeId="1981-ef09-96f6-7aa9">6+</characteristic>
-            <characteristic name="Control" typeId="6c6f-8510-9ce1-fc6e">1</characteristic>
-          </characteristics>
-        </profile>
-        <profile name="Nasty Traps and Tricks" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="7e21-a3f-d35e-eb57">
-          <characteristics>
-            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Any Charge Phase</characteristic>
-            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick an enemy unit within 6&quot; of this unit and that used a **^^Move^^** ability this turn to be the target. You cannot pick the same unit to be the target of this ability more than once per turn.</characteristic>
-            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Roll a D3. On a 2+, inflict an amount of mortal damage on the target equal to the roll.</characteristic>
-            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
-            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
-          </characteristics>
-          <attributes>
-            <attribute name="Color" typeId="5a11-eab3-180c-ddf5">Orange</attribute>
-            <attribute name="Type" typeId="6d16-c86b-2698-85a4">Offensive</attribute>
-            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
-          </attributes>
-        </profile>
-      </profiles>
-      <categoryLinks>
-        <categoryLink name="INFANTRY" hidden="false" id="4f8f-e30-4c75-d020" targetId="75d6-6995-dfcc-3898" primary="true"/>
-        <categoryLink name="OGOR MAWTRIBES" hidden="false" id="4b13-c29d-65ed-a361" targetId="743-1bd8-e3d-ced2" primary="false"/>
-        <categoryLink name="DESTRUCTION" hidden="false" id="eba-e0c1-61e0-c82e" targetId="9057-5a29-dda5-3c28" primary="false"/>
-        <categoryLink name="CHAMPION" hidden="false" id="11-8130-ff14-2dff" targetId="f679-3bcb-d664-9ac3" primary="false"/>
-      </categoryLinks>
-      <selectionEntries>
-        <selectionEntry type="model" import="true" name="Gnoblar" hidden="false" id="ce03-420-a035-4327" defaultAmount="1,19">
-          <constraints>
-            <constraint type="min" value="20" field="selections" scope="parent" shared="false" id="3c54-863a-cddb-6fe4"/>
-            <constraint type="max" value="20" field="selections" scope="parent" shared="false" id="e3fa-18b0-1061-48f9"/>
-          </constraints>
-          <modifiers>
-            <modifier type="increment" value="20" field="3c54-863a-cddb-6fe4">
-              <repeats>
-                <repeat value="1" repeats="1" field="selections" scope="5d4b-756c-2229-3dd9" childId="1b37-82b8-c062-eb82" shared="true" roundUp="false"/>
-              </repeats>
-            </modifier>
-            <modifier type="increment" value="20" field="e3fa-18b0-1061-48f9">
-              <repeats>
-                <repeat value="1" repeats="1" field="selections" scope="5d4b-756c-2229-3dd9" childId="1b37-82b8-c062-eb82" shared="true" roundUp="false"/>
-              </repeats>
-            </modifier>
-          </modifiers>
-          <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Sharp Stuff" hidden="false" id="f1c4-67d3-d408-bb0d">
-              <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="e38-ab8f-f89f-c453"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4fcc-ab16-6679-728c"/>
-              </constraints>
-              <profiles>
-                <profile name="Sharp Stuff" typeId="1fd-a42f-41d3-fe05" typeName="Ranged Weapon" hidden="false" id="580a-b610-a19f-6a8a">
-                  <characteristics>
-                    <characteristic name="Rng" typeId="c6b5-908c-a604-1a98">8&quot;</characteristic>
-                    <characteristic name="Atk" typeId="aa17-4296-2887-e05d">1</characteristic>
-                    <characteristic name="Hit" typeId="194d-aeb6-5ba7-83b4">4+</characteristic>
-                    <characteristic name="Wnd" typeId="d3d5-9dc6-13de-8d1">5+</characteristic>
-                    <characteristic name="Rnd" typeId="d03f-a9ae-3eec-755">-</characteristic>
-                    <characteristic name="Dmg" typeId="96c2-d0a5-ea1e-653b">1</characteristic>
-                    <characteristic name="Ability" typeId="d793-3dd7-9c13-741e">-</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Motley Assortment of Weapons" hidden="false" id="5561-763f-1fcf-729">
-              <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="a907-f671-dba4-f6d6"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="81db-bdb6-4ea9-97e"/>
-              </constraints>
-              <profiles>
-                <profile name="Motley Assortment of Weapons" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="4de8-7ad9-7563-18d8">
-                  <characteristics>
-                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">1</characteristic>
-                    <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">5+</characteristic>
-                    <characteristic name="Wnd" typeId="61c1-22cc-40af-2847">5+</characteristic>
-                    <characteristic name="Rnd" typeId="eccc-10fa-6958-fb73">-</characteristic>
-                    <characteristic name="Dmg" typeId="e948-9c71-12a6-6be4">1</characteristic>
-                    <characteristic name="Ability" typeId="eda3-7332-5db1-4159">-</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups>
-            <selectionEntryGroup name="Command Models" id="4acc-725-71cf-afe1" hidden="false">
-              <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6424-7289-b3e3-971b"/>
-              </constraints>
-              <entryLinks>
-                <entryLink import="true" name="Champion" hidden="false" id="6943-180a-f7fb-871f" type="selectionEntry" targetId="9c21-1746-9873-a5b5" defaultAmount="1,0">
-                  <constraints>
-                    <constraint type="max" value="1" field="selections" scope="5d4b-756c-2229-3dd9" shared="true" id="d5fd-4968-e0dd-a935" includeChildSelections="true"/>
-                  </constraints>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <rules>
-            <rule name="Base Size" id="bf1a-22e0-8cd8-a2d6" hidden="true">
-              <description>25mm</description>
-            </rule>
-          </rules>
-        </selectionEntry>
-      </selectionEntries>
-    </selectionEntry>
-    <selectionEntry type="unit" import="true" name="Icefall Yhetees" hidden="false" id="5fed-90de-715-e720" publicationId="1ac6-e227-a186-12">
-      <profiles>
-        <profile name="Icefall Yhetees" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="f517-99cf-b23a-e92c">
-          <characteristics>
-            <characteristic name="Move" typeId="fed0-d1b3-1bb8-c501">6&quot;</characteristic>
-            <characteristic name="Health" typeId="96be-54ae-ce7b-10b7">4</characteristic>
-            <characteristic name="Save" typeId="1981-ef09-96f6-7aa9">6+</characteristic>
-            <characteristic name="Control" typeId="6c6f-8510-9ce1-fc6e">1</characteristic>
-          </characteristics>
-        </profile>
-        <profile name="Bounding Leaps" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="4725-1412-71e9-fefb">
-          <characteristics>
-            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Enemy Combat Phase</characteristic>
-            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb"/>
-            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">This unit can move up to 3&quot;. It can move into combat.</characteristic>
-            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
-            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
-          </characteristics>
-          <attributes>
-            <attribute name="Color" typeId="5a11-eab3-180c-ddf5">Red</attribute>
-            <attribute name="Type" typeId="6d16-c86b-2698-85a4">Movement</attribute>
-            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
-          </attributes>
-        </profile>
-      </profiles>
-      <categoryLinks>
-        <categoryLink name="OGOR MAWTRIBES" hidden="false" id="9564-b525-f870-d7d" targetId="743-1bd8-e3d-ced2" primary="false"/>
-        <categoryLink name="DESTRUCTION" hidden="false" id="5267-3363-61e6-989e" targetId="9057-5a29-dda5-3c28" primary="false"/>
-        <categoryLink name="BEASTCLAW RAIDERS" hidden="false" id="4a-5403-2c22-17d1" targetId="1a3d-33f9-c4cc-fe0" primary="false"/>
-        <categoryLink name="INFANTRY" hidden="false" id="27e6-f6c1-8e02-f8ce" targetId="75d6-6995-dfcc-3898" primary="true"/>
-        <categoryLink name="WARD (6+)" hidden="false" id="79d5-99c8-5df6-ad95" targetId="70a4-383f-421f-52cd" primary="false"/>
-      </categoryLinks>
-      <selectionEntries>
-        <selectionEntry type="model" import="true" name="Icefall Yhetee" hidden="false" id="9e89-4d5f-6604-4a47" defaultAmount="3">
-          <constraints>
-            <constraint type="min" value="3" field="selections" scope="parent" shared="false" id="9bb8-d985-c80d-2d1d"/>
-            <constraint type="max" value="3" field="selections" scope="parent" shared="false" id="f6f3-6487-12ad-9c78"/>
-          </constraints>
-          <modifiers>
-            <modifier type="increment" value="3" field="9bb8-d985-c80d-2d1d">
-              <repeats>
-                <repeat value="1" repeats="1" field="selections" scope="5fed-90de-715-e720" childId="1b37-82b8-c062-eb82" shared="true" roundUp="false"/>
-              </repeats>
-            </modifier>
-            <modifier type="increment" value="3" field="f6f3-6487-12ad-9c78">
-              <repeats>
-                <repeat value="1" repeats="1" field="selections" scope="5fed-90de-715-e720" childId="1b37-82b8-c062-eb82" shared="true" roundUp="false"/>
-              </repeats>
-            </modifier>
-          </modifiers>
-          <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Claws and Ice‑encrusted Weapons" hidden="false" id="8d2c-6b95-b316-59d">
-              <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="72ba-fa85-a66f-72c0"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="3ebe-90f3-1bd3-20e0"/>
-              </constraints>
-              <profiles>
-                <profile name="Claws and Ice‑encrusted Weapons" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="f057-a600-e068-bab8">
-                  <characteristics>
-                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">3</characteristic>
-                    <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">4+</characteristic>
-                    <characteristic name="Wnd" typeId="61c1-22cc-40af-2847">3+</characteristic>
-                    <characteristic name="Rnd" typeId="eccc-10fa-6958-fb73">1</characteristic>
-                    <characteristic name="Dmg" typeId="e948-9c71-12a6-6be4">2</characteristic>
-                    <characteristic name="Ability" typeId="eda3-7332-5db1-4159">-</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-          </selectionEntries>
-          <rules>
-            <rule name="Base Size" id="71c5-08f2-92d1-3fed" hidden="true">
-              <description>50mm</description>
-            </rule>
-          </rules>
-        </selectionEntry>
-      </selectionEntries>
-    </selectionEntry>
-    <selectionEntry type="unit" import="true" name="Ogor Gluttons" hidden="false" id="e93b-4897-f014-9b88" publicationId="1ac6-e227-a186-12">
-      <profiles>
-        <profile name="Ogor Gluttons" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="8015-e835-1cc-367c">
-          <characteristics>
-            <characteristic name="Move" typeId="fed0-d1b3-1bb8-c501">6&quot;</characteristic>
-            <characteristic name="Health" typeId="96be-54ae-ce7b-10b7">4</characteristic>
-            <characteristic name="Save" typeId="1981-ef09-96f6-7aa9">5+</characteristic>
-            <characteristic name="Control" typeId="6c6f-8510-9ce1-fc6e">2</characteristic>
-          </characteristics>
-        </profile>
-        <profile name="Insatiable Gluttony" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="6d59-c4e4-1531-d34b">
+        <profile name="Wall of Meat" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="307f-20ab-84cb-abb5">
           <characteristics>
             <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
-            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">If you have used the 'Feast on Flesh' ability this battle, add 1 to the control score of this unit for each model in this unit.</characteristic>
+            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">Add 1 to save rolls for this unit if it has not charged this turn.</characteristic>
           </characteristics>
           <attributes>
-            <attribute name="Color" typeId="50fe-4f29-6bc3-dcc6">Purple</attribute>
-            <attribute name="Type" typeId="bf11-4e10-3ab1-06f4">Control</attribute>
+            <attribute typeId="50fe-4f29-6bc3-dcc6" name="Color">Green</attribute>
+            <attribute typeId="bf11-4e10-3ab1-06f4" name="Type">Defensive</attribute>
             <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
           </attributes>
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink name="INFANTRY" hidden="false" id="4ac3-e564-e7a5-cd12" targetId="75d6-6995-dfcc-3898" primary="true"/>
-        <categoryLink name="CHAMPION" hidden="false" id="d876-ed88-a5be-861" targetId="f679-3bcb-d664-9ac3" primary="false"/>
-        <categoryLink name="MUSICIAN (1/6)" hidden="false" id="cc3d-84b4-7726-b9e3" targetId="a9bc-adc0-42a0-e843" primary="false"/>
-        <categoryLink name="STANDARD BEARER (1/6)" hidden="false" id="ced8-53b-2e7-cd7b" targetId="7002-4169-eb88-6e0" primary="false"/>
-        <categoryLink name="OGOR MAWTRIBES" hidden="false" id="fc00-1ec2-7844-747d" targetId="743-1bd8-e3d-ced2" primary="false"/>
-        <categoryLink name="DESTRUCTION" hidden="false" id="ea97-4f1b-fbc6-eba3" targetId="9057-5a29-dda5-3c28" primary="false"/>
-        <categoryLink name="OGOR" hidden="false" id="463-d116-52da-a2a8" targetId="ddcb-3c91-472f-c35a" primary="false"/>
-        <categoryLink name="GUTBUSTERS" hidden="false" id="4c1c-c89d-93d3-4511" targetId="5c0d-5e93-d71f-f0da" primary="false"/>
+        <categoryLink name="INFANTRY" hidden="false" id="a38a-3ce1-8c3e-e1b0" targetId="75d6-6995-dfcc-3898" primary="true"/>
+        <categoryLink name="CHAMPION" hidden="false" id="f5c8-6c52-ae49-c1e4" targetId="f679-3bcb-d664-9ac3" primary="false"/>
+        <categoryLink name="MUSICIAN (1/5)" hidden="false" id="59fb-a475-71b7-9c28" targetId="dd6f-27e9-b16e-24ee" primary="false"/>
+        <categoryLink name="DESTRUCTION" hidden="false" id="382b-aa96-d873-4c08" targetId="9057-5a29-dda5-3c28" primary="false"/>
+        <categoryLink name="OGOR MAWTRIBES" hidden="false" id="baab-8d11-b591-b795" targetId="743-1bd8-e3d-ced2" primary="false"/>
+        <categoryLink name="OGOR" hidden="false" id="d388-842b-6b15-4a13" targetId="ddcb-3c91-472f-c35a" primary="false"/>
+        <categoryLink name="GUTBUSTERS" hidden="false" id="f5e0-0219-7ba6-0383" targetId="5c0d-5e93-d71f-f0da" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry type="model" import="true" name="Ogor Glutton" hidden="false" id="dfe-8e5d-552f-ad46" defaultAmount="1,1,1,3">
+        <selectionEntry type="model" import="true" name="Glutton" hidden="false" id="2a36-8297-b036-9210" defaultAmount="1,1,3">
           <constraints>
-            <constraint type="min" value="6" field="selections" scope="parent" shared="false" id="5761-e3a5-6471-78c7"/>
-            <constraint type="max" value="6" field="selections" scope="parent" shared="false" id="a369-647d-cd2-37f9"/>
+            <constraint type="min" value="5" field="selections" scope="parent" shared="false" id="4dab-560e-ad1f-1b64"/>
+            <constraint type="max" value="5" field="selections" scope="parent" shared="false" id="989c-4279-5630-cc08"/>
           </constraints>
           <modifiers>
-            <modifier type="increment" value="6" field="5761-e3a5-6471-78c7">
+            <modifier type="increment" value="5" field="4dab-560e-ad1f-1b64">
               <repeats>
                 <repeat value="1" repeats="1" field="selections" scope="e93b-4897-f014-9b88" childId="1b37-82b8-c062-eb82" shared="true" roundUp="false"/>
               </repeats>
             </modifier>
-            <modifier type="increment" value="6" field="a369-647d-cd2-37f9">
+            <modifier type="increment" value="5" field="989c-4279-5630-cc08">
               <repeats>
                 <repeat value="1" repeats="1" field="selections" scope="e93b-4897-f014-9b88" childId="1b37-82b8-c062-eb82" shared="true" roundUp="false"/>
               </repeats>
             </modifier>
           </modifiers>
           <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Glutton Weapons" hidden="false" id="4ab0-916d-cd23-a1ae">
-              <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="b5ea-4055-2b26-9d58"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="a02a-5805-3ddc-d237"/>
-              </constraints>
+            <selectionEntry type="upgrade" import="true" name="Glutton Weapons" hidden="false" id="d9e8-560c-3b16-9e71">
               <profiles>
-                <profile name="Glutton Weapons" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="bfed-f29-43a0-ba2e">
+                <profile name="Glutton Weapons" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="38dd-e0e6-3b62-0c94">
                   <characteristics>
                     <characteristic name="Atk" typeId="60e-35aa-31ed-e488">4</characteristic>
                     <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">4+</characteristic>
@@ -906,39 +599,30 @@
                   </characteristics>
                 </profile>
               </profiles>
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="e3b0-402a-0069-1cd5"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="fad5-9530-c54f-51e1"/>
+              </constraints>
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups>
-            <selectionEntryGroup name="Command Models" id="74a5-430c-3bb0-8a02" hidden="false">
+            <selectionEntryGroup name="Command Models" id="7298-22d6-4c14-b783" hidden="false">
               <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="acf8-82c6-4db6-e5c"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="55cd-1ce9-3847-1e1b"/>
               </constraints>
               <entryLinks>
-                <entryLink import="true" name="Champion" hidden="false" id="a169-3ee0-be04-bd33" type="selectionEntry" targetId="9c21-1746-9873-a5b5" defaultAmount="1,0,0,0">
+                <entryLink import="true" name="Champion" hidden="false" id="3b97-f2ef-076e-25b4" type="selectionEntry" targetId="9c21-1746-9873-a5b5" defaultAmount="1,0,0">
                   <constraints>
-                    <constraint type="max" value="1" field="selections" scope="e93b-4897-f014-9b88" shared="true" id="1f1a-fee7-24b-bd67" includeChildSelections="true"/>
+                    <constraint type="max" value="1" field="selections" scope="e93b-4897-f014-9b88" shared="true" id="6c21-60ff-cadf-4b1e" includeChildSelections="true"/>
                   </constraints>
                 </entryLink>
-                <entryLink import="true" name="Standard Bearer" hidden="false" id="5723-67c8-a629-ce69" type="selectionEntry" targetId="7f34-77c9-597-62c3" defaultAmount="0,0,1,0">
+                <entryLink import="true" name="Musician" hidden="false" id="7663-a1f8-7b7b-b3c0" type="selectionEntry" targetId="2475-183b-3802-4431" defaultAmount="0,1,0">
                   <constraints>
-                    <constraint type="max" value="1" field="selections" scope="e93b-4897-f014-9b88" shared="true" id="b4d0-616a-3d54-3cc1" includeChildSelections="true"/>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ece-19fe-3889-769b"/>
+                    <constraint type="max" value="1" field="selections" scope="e93b-4897-f014-9b88" shared="true" id="4a71-02c8-f711-2d0e" includeChildSelections="true"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4670-8039-3069-3881"/>
                   </constraints>
                   <modifiers>
-                    <modifier type="increment" value="1" field="b4d0-616a-3d54-3cc1">
-                      <repeats>
-                        <repeat value="1" repeats="1" field="selections" scope="root-entry" childId="1b37-82b8-c062-eb82" shared="true" roundUp="false"/>
-                      </repeats>
-                    </modifier>
-                  </modifiers>
-                </entryLink>
-                <entryLink import="true" name="Musician" hidden="false" id="9378-633b-e8fa-b53" type="selectionEntry" targetId="2475-183b-3802-4431" defaultAmount="0,1,0,0">
-                  <constraints>
-                    <constraint type="max" value="1" field="selections" scope="e93b-4897-f014-9b88" shared="true" id="5ea5-6f7e-e4a7-58e9" includeChildSelections="true"/>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="e905-8992-dc95-6e7c"/>
-                  </constraints>
-                  <modifiers>
-                    <modifier type="increment" value="1" field="5ea5-6f7e-e4a7-58e9">
+                    <modifier type="increment" value="1" field="4a71-02c8-f711-2d0e">
                       <repeats>
                         <repeat value="1" repeats="1" field="selections" scope="root-entry" childId="1b37-82b8-c062-eb82" shared="true" roundUp="false"/>
                       </repeats>
@@ -949,16 +633,16 @@
             </selectionEntryGroup>
           </selectionEntryGroups>
           <rules>
-            <rule name="Base Size" id="ce23-c9f5-4953-1ed9" hidden="true">
+            <rule name="Base Size" id="4366-7b6b-8bce-4b69" hidden="true">
               <description>40mm</description>
             </rule>
           </rules>
         </selectionEntry>
       </selectionEntries>
     </selectionEntry>
-    <selectionEntry type="unit" import="true" name="Gorger Mawpack" hidden="false" id="8d6b-1912-d60a-5163" publicationId="1ac6-e227-a186-12">
+    <selectionEntry type="unit" import="true" name="Gorger Mawpack" hidden="false" id="8d6b-1912-d60a-5163" publicationId="feba-6749-6df3-ea9e">
       <profiles>
-        <profile name="Gorger Mawpack" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="67ca-7f59-1abe-de13">
+        <profile name="Gorger Mawpack" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="a689-6987-e8c5-d4e5">
           <characteristics>
             <characteristic name="Move" typeId="fed0-d1b3-1bb8-c501">6&quot;</characteristic>
             <characteristic name="Health" typeId="96be-54ae-ce7b-10b7">5</characteristic>
@@ -966,69 +650,55 @@
             <characteristic name="Control" typeId="6c6f-8510-9ce1-fc6e">2</characteristic>
           </characteristics>
         </profile>
-        <profile name="Troglodytic Lurkers" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="d7cb-c86-82b3-9a0c">
+        <profile name="Troglodytic Lurkers" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="71b8-0bc3-1a5b-3b2f">
           <characteristics>
             <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Deployment Phase</characteristic>
-            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick this unit if it has not been deployed.</characteristic>
-            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Set up this unit in reserve **lurking on the fringes**. It has now been deployed.</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick this unit if it has not been deployed.</characteristic>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Set up this unit in reserve **lurking on the fringes**. It has now been deployed.</characteristic>
             <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f">**^^Deploy^^**</characteristic>
             <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
           </characteristics>
           <attributes>
-            <attribute name="Color" typeId="5a11-eab3-180c-ddf5">Black</attribute>
-            <attribute name="Type" typeId="6d16-c86b-2698-85a4">Special</attribute>
+            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Black</attribute>
+            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Special</attribute>
             <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
           </attributes>
         </profile>
-        <profile name="Frenzied Hunters" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="aea5-a3ca-4899-8779">
+        <profile name="Frenzied Hunters" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="0502-a40a-ffe2-a55c">
           <characteristics>
             <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Your Movement Phase</characteristic>
-            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick this unit if it is **lurking on the fringes**.</characteristic>
-            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Set up this unit on the battlefield wholly within 9&quot; of a battlefield edge and more than 9&quot; from all enemy units.</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick this unit if it is **lurking on the fringes**.</characteristic>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Set up this unit on the battlefield wholly within 9&quot; of a battlefield edge and more than 9&quot; from all enemy units.</characteristic>
             <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
             <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
           </characteristics>
           <attributes>
-            <attribute name="Color" typeId="5a11-eab3-180c-ddf5">Grey</attribute>
-            <attribute name="Type" typeId="6d16-c86b-2698-85a4">Movement</attribute>
+            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Gray</attribute>
+            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Movement</attribute>
             <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
           </attributes>
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink name="INFANTRY" hidden="false" id="80a1-225a-71b4-944" targetId="75d6-6995-dfcc-3898" primary="true"/>
-        <categoryLink name="OGOR MAWTRIBES" hidden="false" id="13c3-6d22-86bf-9bbb" targetId="743-1bd8-e3d-ced2" primary="false"/>
-        <categoryLink name="DESTRUCTION" hidden="false" id="2c94-16aa-c240-e3d5" targetId="9057-5a29-dda5-3c28" primary="false"/>
-        <categoryLink name="OGOR" hidden="false" id="223d-19e9-694c-65a7" targetId="ddcb-3c91-472f-c35a" primary="false"/>
-        <categoryLink name="CHAMPION (1/5)" hidden="false" id="8dd-32fd-f9cb-4030" targetId="11c3-dbff-a3f7-ab" primary="false"/>
-        <categoryLink name="MUSICIAN (1/5)" hidden="false" id="d28-867d-86c0-c62b" targetId="dd6f-27e9-b16e-24ee" primary="false"/>
+        <categoryLink name="INFANTRY" hidden="false" id="2050-599b-1035-f8a5" targetId="75d6-6995-dfcc-3898" primary="true"/>
+        <categoryLink name="CHAMPION (1/5)" hidden="false" id="c112-2a7a-3251-c3a0" targetId="11c3-dbff-a3f7-ab" primary="false"/>
+        <categoryLink name="MUSICIAN (1/5)" hidden="false" id="e2e9-e86c-58d7-f914" targetId="dd6f-27e9-b16e-24ee" primary="false"/>
+        <categoryLink name="DESTRUCTION" hidden="false" id="de4d-2329-2d7f-2115" targetId="9057-5a29-dda5-3c28" primary="false"/>
+        <categoryLink name="OGOR MAWTRIBES" hidden="false" id="93f0-9ee1-285b-d687" targetId="743-1bd8-e3d-ced2" primary="false"/>
+        <categoryLink name="OGOR" hidden="false" id="059a-86ad-89e2-4ee3" targetId="ddcb-3c91-472f-c35a" primary="false"/>
+        <categoryLink name="MAWSEEKERS" hidden="false" id="ddde-576a-2b4b-21ab" targetId="b50b-6a98-f92a-c99c" primary="false"/>
+        <categoryLink name="WARD (6+)" hidden="false" id="ac70-b3e0-7e19-68f2" targetId="70a4-383f-421f-52cd" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry type="model" import="true" name="Gorger" hidden="false" id="f973-1619-d15b-d393" defaultAmount="1,1,3">
+        <selectionEntry type="model" import="true" name="Gorger" hidden="false" id="3ccc-bf11-cbda-5ead" defaultAmount="1,1,3">
           <constraints>
-            <constraint type="min" value="5" field="selections" scope="parent" shared="false" id="99f0-d017-2387-5992"/>
-            <constraint type="max" value="5" field="selections" scope="parent" shared="false" id="f630-fb2f-c0be-dd20"/>
+            <constraint type="min" value="5" field="selections" scope="parent" shared="false" id="346c-27ed-ee75-e7e4"/>
+            <constraint type="max" value="5" field="selections" scope="parent" shared="false" id="3f59-5b82-dae8-b749"/>
           </constraints>
-          <modifiers>
-            <modifier type="increment" value="5" field="99f0-d017-2387-5992">
-              <repeats>
-                <repeat value="1" repeats="1" field="selections" scope="8d6b-1912-d60a-5163" childId="1b37-82b8-c062-eb82" shared="true" roundUp="false"/>
-              </repeats>
-            </modifier>
-            <modifier type="increment" value="5" field="f630-fb2f-c0be-dd20">
-              <repeats>
-                <repeat value="1" repeats="1" field="selections" scope="8d6b-1912-d60a-5163" childId="1b37-82b8-c062-eb82" shared="true" roundUp="false"/>
-              </repeats>
-            </modifier>
-          </modifiers>
           <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Clubs, Claws and Jaws" hidden="false" id="2f6b-8bdd-4508-8953">
-              <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="564d-61ae-2713-2233"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="fab7-cf47-e00a-a3b5"/>
-              </constraints>
+            <selectionEntry type="upgrade" import="true" name="Club, Claws and Jaws" hidden="false" id="17ae-e459-b7cc-ad4a">
               <profiles>
-                <profile name="Clubs, Claws and Jaws" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="2936-b63d-7ce8-c9c1">
+                <profile name="Club, Claws and Jaws" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="119c-ca01-37cf-37b1">
                   <characteristics>
                     <characteristic name="Atk" typeId="60e-35aa-31ed-e488">5</characteristic>
                     <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">4+</characteristic>
@@ -1039,46 +709,43 @@
                   </characteristics>
                 </profile>
               </profiles>
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="7210-fe58-b128-b3a2"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="de28-8b7f-82e4-e59a"/>
+              </constraints>
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups>
-            <selectionEntryGroup name="Command Models" id="5eb8-9302-658-27fb" hidden="false">
+            <selectionEntryGroup name="Command Models" id="d2d3-e91d-d7b8-9d59" hidden="false">
               <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="507f-4cb9-d283-15f"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ede9-3683-796a-bfc3"/>
               </constraints>
               <entryLinks>
-                <entryLink import="true" name="Champion" hidden="false" id="5ed6-d451-7721-33b8" type="selectionEntry" targetId="9c21-1746-9873-a5b5" defaultAmount="1,0,0">
+                <entryLink import="true" name="Champion" hidden="false" id="6065-56ab-5c3c-f21c" type="selectionEntry" targetId="9c21-1746-9873-a5b5" defaultAmount="1,0,0">
                   <constraints>
-                    <constraint type="max" value="1" field="selections" scope="8d6b-1912-d60a-5163" shared="true" id="57fb-ba05-2107-7102" includeChildSelections="true"/>
+                    <constraint type="max" value="1" field="selections" scope="8d6b-1912-d60a-5163" shared="true" id="4783-9409-8173-39e6" includeChildSelections="true"/>
                   </constraints>
                 </entryLink>
-                <entryLink import="true" name="Musician" hidden="false" id="9d5a-4af-8119-2448" type="selectionEntry" targetId="2475-183b-3802-4431" defaultAmount="0,1,0">
+                <entryLink import="true" name="Musician" hidden="false" id="9184-9d35-addc-b6ec" type="selectionEntry" targetId="2475-183b-3802-4431" defaultAmount="0,1,0">
                   <constraints>
-                    <constraint type="max" value="1" field="selections" scope="8d6b-1912-d60a-5163" shared="true" id="ea52-8866-90fc-420c" includeChildSelections="true"/>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="bf86-b960-744-6214"/>
+                    <constraint type="max" value="1" field="selections" scope="8d6b-1912-d60a-5163" shared="true" id="44a0-d04e-4b39-20fc" includeChildSelections="true"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="a46f-a454-8d70-c769"/>
                   </constraints>
-                  <modifiers>
-                    <modifier type="increment" value="1" field="ea52-8866-90fc-420c">
-                      <repeats>
-                        <repeat value="1" repeats="1" field="selections" scope="root-entry" childId="1b37-82b8-c062-eb82" shared="true" roundUp="false"/>
-                      </repeats>
-                    </modifier>
-                  </modifiers>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <rules>
-            <rule name="Base Size" id="1117-0003-ae81-f3e0" hidden="true">
+            <rule name="Base Size" id="b951-5391-55ce-d1c8" hidden="true">
               <description>50mm</description>
             </rule>
           </rules>
         </selectionEntry>
       </selectionEntries>
     </selectionEntry>
-    <selectionEntry type="unit" import="true" name="Thundertusk Beastriders" hidden="false" id="e5a2-5b7c-b7af-8da6" publicationId="1ac6-e227-a186-12">
+    <selectionEntry type="unit" import="true" name="Thundertusk Beastriders" hidden="false" id="e5a2-5b7c-b7af-8da6" publicationId="feba-6749-6df3-ea9e">
       <profiles>
-        <profile name="Thundertusk Beastriders" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="3fa7-b82d-429c-c724">
+        <profile name="Thundertusk Beastriders" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="87e1-a314-cc4b-119b">
           <characteristics>
             <characteristic name="Move" typeId="fed0-d1b3-1bb8-c501">10&quot;</characteristic>
             <characteristic name="Health" typeId="96be-54ae-ce7b-10b7">14</characteristic>
@@ -1086,47 +753,82 @@
             <characteristic name="Control" typeId="6c6f-8510-9ce1-fc6e">10</characteristic>
           </characteristics>
         </profile>
-        <profile name="Battle Damaged" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="b9f6-a7ae-44db-71ee">
+        <profile name="Battle Damaged" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="7e28-20b1-00ec-cb7e">
           <characteristics>
             <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
-            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">While this unit has 10 or more damage points, the Attacks characteristic of its **Thundertusk's Colossal Tusks** is 2.</characteristic>
+            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">While this unit has 10 or more damage points, the Attacks characteristic of its **Thundertusk's Colossal Tusks** is 2.</characteristic>
           </characteristics>
           <attributes>
-            <attribute name="Color" typeId="50fe-4f29-6bc3-dcc6">Black</attribute>
-            <attribute name="Type" typeId="bf11-4e10-3ab1-06f4">Damage</attribute>
+            <attribute typeId="50fe-4f29-6bc3-dcc6" name="Color">Black</attribute>
+            <attribute typeId="bf11-4e10-3ab1-06f4" name="Type">Damage</attribute>
             <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
           </attributes>
         </profile>
-        <profile name="Everwinter&apos;s Assault" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="9996-a4c8-2cb8-dbce">
+        <profile name="Plough the Icepath" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="fb29-d25a-6e0a-a286">
           <characteristics>
-            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Turn (Army), End of Any Turn</characteristic>
-            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">If this unit charged this turn, pick an enemy unit in combat with it to be the target.</characteristic>
-            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Roll a dice. On a 3+, for the rest of the turn:
-• If the target is a **^^Monster^^**, subtract 3 from its control score.
-• If the target is a non-**^^Monster^^** unit, subtract 5 from its control score.</characteristic>
+            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Turn (Army), Reaction: You declared a non-Charge Move ability for this unit in your movement phase</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb"/>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Pick a friendly **^^Ogor Mawtribes Infantry^^** unit that has not been reinforced, is wholly within 6&quot; of this unit and has not been set up this turn to be the target. Remove the target from the battlefield. After this unit ends its move, you must set up the target unit wholly within 6&quot; of this unit and not in combat. The target cannot use **^^Charge^^** abilities for the rest of the turn.</characteristic>
+            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+          </characteristics>
+          <attributes>
+            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Gray</attribute>
+            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Movement</attribute>
+            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+          </attributes>
+        </profile>
+        <profile name="Chilling Onslaught" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="6dbd-886e-7bcb-1579">
+          <characteristics>
+            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Turn (Army), Any Combat Phase</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">If this unit charged this turn, pick an enemy unit in combat with it to be the target.</characteristic>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Roll a dice. On a 4+, for the rest of the turn, subtract 1 from rolls for the target's attacks.</characteristic>
             <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f">**^^Rampage^^**</characteristic>
             <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
           </characteristics>
           <attributes>
-            <attribute name="Color" typeId="5a11-eab3-180c-ddf5">Purple</attribute>
-            <attribute name="Type" typeId="6d16-c86b-2698-85a4">Control</attribute>
+            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Red</attribute>
+            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Defensive</attribute>
             <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
           </attributes>
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink name="DESTRUCTION" hidden="false" id="1ddc-1dd2-8566-44e" targetId="9057-5a29-dda5-3c28" primary="false"/>
-        <categoryLink name="OGOR MAWTRIBES" hidden="false" id="fba6-325b-c866-bab5" targetId="743-1bd8-e3d-ced2" primary="false"/>
-        <categoryLink name="OGOR" hidden="false" id="b5a-d7e4-f7ae-14f2" targetId="ddcb-3c91-472f-c35a" primary="false"/>
-        <categoryLink name="MONSTER" hidden="false" id="32c6-9769-713a-c6ee" targetId="6d54-625c-d063-13e2" primary="true"/>
-        <categoryLink name="BEASTCLAW RAIDERS" hidden="false" id="8b3e-b110-3884-fce" targetId="1a3d-33f9-c4cc-fe0" primary="false"/>
+        <categoryLink name="MONSTER" hidden="false" id="9eef-526d-cb05-6e54" targetId="6d54-625c-d063-13e2" primary="true"/>
+        <categoryLink name="DESTRUCTION" hidden="false" id="1242-21c5-27d4-8eff" targetId="9057-5a29-dda5-3c28" primary="false"/>
+        <categoryLink name="OGOR MAWTRIBES" hidden="false" id="0c4e-4089-7eed-0051" targetId="743-1bd8-e3d-ced2" primary="false"/>
+        <categoryLink name="OGOR" hidden="false" id="241c-7aea-f786-e000" targetId="ddcb-3c91-472f-c35a" primary="false"/>
+        <categoryLink name="BEASTCLAW" hidden="false" id="2311-1bcb-0b6a-7c5e" targetId="410d-6b15-3cf4-88d0" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry type="model" import="true" name="Thundertusk Beastriders" hidden="false" id="32f0-73fc-735a-950">
+        <selectionEntry type="model" import="true" name="Thundertusk Beastrider" hidden="false" id="6e8d-a163-d3ca-4712">
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="d58e-7c4c-b3fc-76ee"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="835b-fcd3-c42a-8f09"/>
+          </constraints>
           <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Ice Blast" hidden="false" id="bba0-f3ab-b268-eb4">
+            <selectionEntry type="upgrade" import="true" name="Chaintrap, Harpoon Launcher or Blood Vulture" hidden="false" id="7202-3d40-fa74-9b49">
               <profiles>
-                <profile name="Ice Blast" typeId="1fd-a42f-41d3-fe05" typeName="Ranged Weapon" hidden="false" id="ce53-b5d6-9514-16fa">
+                <profile name="Chaintrap, Harpoon Launcher or Blood Vulture" typeId="1fd-a42f-41d3-fe05" typeName="Ranged Weapon" hidden="false" id="22df-b6cc-db5c-0247">
+                  <characteristics>
+                    <characteristic name="Rng" typeId="c6b5-908c-a604-1a98">15&quot;</characteristic>
+                    <characteristic name="Atk" typeId="aa17-4296-2887-e05d">1</characteristic>
+                    <characteristic name="Hit" typeId="194d-aeb6-5ba7-83b4">4+</characteristic>
+                    <characteristic name="Wnd" typeId="d3d5-9dc6-13de-8d1">3+</characteristic>
+                    <characteristic name="Rnd" typeId="d03f-a9ae-3eec-755">1</characteristic>
+                    <characteristic name="Dmg" typeId="96c2-d0a5-ea1e-653b">3</characteristic>
+                    <characteristic name="Ability" typeId="d793-3dd7-9c13-741e">-</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="e46b-04c0-a353-f28d"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6d24-bb6e-fa19-85df"/>
+              </constraints>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Ice Blast" hidden="false" id="3e5e-ab79-13f1-9e16">
+              <profiles>
+                <profile name="Ice Blast" typeId="1fd-a42f-41d3-fe05" typeName="Ranged Weapon" hidden="false" id="c529-85d7-8da1-8f8b">
                   <characteristics>
                     <characteristic name="Rng" typeId="c6b5-908c-a604-1a98">12&quot;</characteristic>
                     <characteristic name="Atk" typeId="aa17-4296-2887-e05d">1</characteristic>
@@ -1139,150 +841,58 @@
                 </profile>
               </profiles>
               <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="84fb-868c-9200-c76b"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="dc7f-f0b2-439b-622d"/>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="b1d4-63bd-fe25-0e21"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="a872-0bfa-0bc4-4dca"/>
               </constraints>
             </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Thundertusk&apos;s Colossal Tusks" hidden="false" id="d8d1-6358-2301-9369">
+            <selectionEntry type="upgrade" import="true" name="Punches and Kicks" hidden="false" id="784a-fca7-a458-d78e">
               <profiles>
-                <profile name="Thundertusk&apos;s Colossal Tusks" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="b144-1700-74b4-3172">
+                <profile name="Punches and Kicks" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="7e04-0a92-8ff0-2310">
                   <characteristics>
-                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">3</characteristic>
+                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">4</characteristic>
                     <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">4+</characteristic>
                     <characteristic name="Wnd" typeId="61c1-22cc-40af-2847">2+</characteristic>
                     <characteristic name="Rnd" typeId="eccc-10fa-6958-fb73">1</characteristic>
-                    <characteristic name="Dmg" typeId="e948-9c71-12a6-6be4">5</characteristic>
-                    <characteristic name="Ability" typeId="eda3-7332-5db1-4159">Anti-**^^Infantry^^** (+1 Rend), Companion</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="b94b-b135-6cb5-937a"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="9475-9b48-b660-e0d"/>
-              </constraints>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Punches and Kicks" hidden="false" id="6078-b21f-e1e-7154">
-              <profiles>
-                <profile name="Punches and Kicks" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="d1db-eb2-93cb-904f">
-                  <characteristics>
-                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">6</characteristic>
-                    <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">4+</characteristic>
-                    <characteristic name="Wnd" typeId="61c1-22cc-40af-2847">2+</characteristic>
-                    <characteristic name="Rnd" typeId="eccc-10fa-6958-fb73">-</characteristic>
                     <characteristic name="Dmg" typeId="e948-9c71-12a6-6be4">1</characteristic>
                     <characteristic name="Ability" typeId="eda3-7332-5db1-4159">-</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="5fdf-48ad-c8d9-5473"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="2f4c-a01-a5f9-f062"/>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="3ec6-b7c4-27ed-f19d"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="de80-f503-2494-3961"/>
               </constraints>
             </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Harpoon Launcher" hidden="false" id="4528-c7a9-185d-5219">
+            <selectionEntry type="upgrade" import="true" name="Thundertusk&apos;s Colossal Tusks" hidden="false" id="6e2f-db6b-8379-796d">
+              <profiles>
+                <profile name="Thundertusk&apos;s Colossal Tusks" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="f970-1537-c3ea-dad8">
+                  <characteristics>
+                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">3</characteristic>
+                    <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">4+</characteristic>
+                    <characteristic name="Wnd" typeId="61c1-22cc-40af-2847">2+</characteristic>
+                    <characteristic name="Rnd" typeId="eccc-10fa-6958-fb73">1</characteristic>
+                    <characteristic name="Dmg" typeId="e948-9c71-12a6-6be4">5</characteristic>
+                    <characteristic name="Ability" typeId="eda3-7332-5db1-4159">Anti-**^^Infantry^^** (+1 Rend), Companion</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
               <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="a67d-2bf9-c719-3e4d"/>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="06e7-63b6-2075-f88b"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6368-1120-1a71-78a3"/>
               </constraints>
-              <selectionEntries>
-                <selectionEntry type="upgrade" import="true" name="Harpoon Launcher" hidden="false" id="8093-16bb-dd71-ecaa">
-                  <profiles>
-                    <profile name="Harpoon Launcher" typeId="1fd-a42f-41d3-fe05" typeName="Ranged Weapon" hidden="false" id="9ddd-2f16-453e-4399">
-                      <characteristics>
-                        <characteristic name="Rng" typeId="c6b5-908c-a604-1a98">18&quot;</characteristic>
-                        <characteristic name="Atk" typeId="aa17-4296-2887-e05d">1</characteristic>
-                        <characteristic name="Hit" typeId="194d-aeb6-5ba7-83b4">4+</characteristic>
-                        <characteristic name="Wnd" typeId="d3d5-9dc6-13de-8d1">3+</characteristic>
-                        <characteristic name="Rnd" typeId="d03f-a9ae-3eec-755">1</characteristic>
-                        <characteristic name="Dmg" typeId="96c2-d0a5-ea1e-653b">D3</characteristic>
-                        <characteristic name="Ability" typeId="d793-3dd7-9c13-741e">-</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <constraints>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="e491-2ad7-670e-85cc"/>
-                    <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="207b-71a0-d985-d522"/>
-                  </constraints>
-                </selectionEntry>
-              </selectionEntries>
             </selectionEntry>
           </selectionEntries>
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="4e65-6b5a-57c3-1382"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="1da6-fec3-3dac-f456"/>
-          </constraints>
-          <selectionEntryGroups>
-            <selectionEntryGroup name="Wargear Options" id="54eb-a290-7f33-f31e" hidden="false" flatten="true">
-              <selectionEntries>
-                <selectionEntry type="upgrade" import="true" name="Chaintrap" hidden="false" id="dbf7-3e8e-d18a-1489">
-                  <selectionEntries>
-                    <selectionEntry type="upgrade" import="true" name="Chaintrap" hidden="false" id="b9e0-8d0d-caf4-8f4b">
-                      <profiles>
-                        <profile name="Chaintrap" typeId="1fd-a42f-41d3-fe05" typeName="Ranged Weapon" hidden="false" id="696c-fbf3-13de-3d5b">
-                          <characteristics>
-                            <characteristic name="Rng" typeId="c6b5-908c-a604-1a98">12&quot;</characteristic>
-                            <characteristic name="Atk" typeId="aa17-4296-2887-e05d">1</characteristic>
-                            <characteristic name="Hit" typeId="194d-aeb6-5ba7-83b4">4+</characteristic>
-                            <characteristic name="Wnd" typeId="d3d5-9dc6-13de-8d1">3+</characteristic>
-                            <characteristic name="Rnd" typeId="d03f-a9ae-3eec-755">1</characteristic>
-                            <characteristic name="Dmg" typeId="96c2-d0a5-ea1e-653b">3</characteristic>
-                            <characteristic name="Ability" typeId="d793-3dd7-9c13-741e">Anti‑**^^Monster^^** (+1 Rend)</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                      <constraints>
-                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="c49f-9649-dbc9-ac35"/>
-                        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="eb14-4232-889a-936c"/>
-                      </constraints>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <constraints>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="54dd-371a-ebc2-fb69"/>
-                  </constraints>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Blood Vulture" hidden="false" id="62a6-5096-62c9-8284">
-                  <constraints>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4784-3cb9-e497-d0cf"/>
-                  </constraints>
-                  <selectionEntries>
-                    <selectionEntry type="upgrade" import="true" name="Blood Vulture" hidden="false" id="f375-4650-b630-97dc">
-                      <profiles>
-                        <profile name="Blood Vulture" typeId="1fd-a42f-41d3-fe05" typeName="Ranged Weapon" hidden="false" id="c4c6-224c-4cec-ba3">
-                          <characteristics>
-                            <characteristic name="Rng" typeId="c6b5-908c-a604-1a98">24&quot;</characteristic>
-                            <characteristic name="Atk" typeId="aa17-4296-2887-e05d">1</characteristic>
-                            <characteristic name="Hit" typeId="194d-aeb6-5ba7-83b4">2+</characteristic>
-                            <characteristic name="Wnd" typeId="d3d5-9dc6-13de-8d1">3+</characteristic>
-                            <characteristic name="Rnd" typeId="d03f-a9ae-3eec-755">-</characteristic>
-                            <characteristic name="Dmg" typeId="96c2-d0a5-ea1e-653b">1</characteristic>
-                            <characteristic name="Ability" typeId="d793-3dd7-9c13-741e">-</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                      <constraints>
-                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="9e17-f315-d077-a8aa"/>
-                        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="8762-6c2e-13ac-3904"/>
-                      </constraints>
-                    </selectionEntry>
-                  </selectionEntries>
-                </selectionEntry>
-              </selectionEntries>
-              <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="21bf-9315-4ec-911d"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8313-be44-1ce1-4b69"/>
-              </constraints>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
           <rules>
-            <rule name="Base Size" id="7ad3-e02f-244f-71e2" hidden="true">
+            <rule name="Base Size" id="3980-6405-e126-0553" hidden="true">
               <description>120x92mm</description>
             </rule>
           </rules>
         </selectionEntry>
       </selectionEntries>
     </selectionEntry>
-    <selectionEntry type="unit" import="true" name="Ironblaster" hidden="false" id="7f12-bfdf-bff5-c0fd" publicationId="1ac6-e227-a186-12">
+    <selectionEntry type="unit" import="true" name="Ironblaster" hidden="false" id="7f12-bfdf-bff5-c0fd" publicationId="feba-6749-6df3-ea9e">
       <profiles>
-        <profile name="Ironblaster" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="8ad6-2fb-8a82-820d">
+        <profile name="Ironblaster" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="fed4-c208-1a91-df97">
           <characteristics>
             <characteristic name="Move" typeId="fed0-d1b3-1bb8-c501">9&quot;</characteristic>
             <characteristic name="Health" typeId="96be-54ae-ce7b-10b7">9</characteristic>
@@ -1290,34 +900,79 @@
             <characteristic name="Control" typeId="6c6f-8510-9ce1-fc6e">2</characteristic>
           </characteristics>
         </profile>
-        <profile name="Lethal Payload" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="8875-728c-41de-ef1f">
+        <profile name="Obliterating Blast" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="ebd9-7cae-8ad0-9c6f">
           <characteristics>
-            <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
-            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">Each time this unit uses a **^^Shoot^^** ability, pick either the **Big Shot** or **Hail Shot** weapon characteristics for all the attacks it makes with its **Ironblaster Cannon**.</characteristic>
+            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Turn (Army), Your Shooting Phase</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">If this unit has not used a **^^Run^^** or **^^Retreat^^** ability this turn, pick a visible enemy unit within 18&quot; of it to be the target. Then, draw a straight line between the closest points on the bases of this unit and the target. Each other unit (friendly and enemy) that the line passes across is a **collateral damage target**.</characteristic>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Roll a dice. On a 3+:
+• Inflict an amount of mortal damage on the target equal to the roll.
+• Inflict D3 damage on each **collateral damage target**.</characteristic>
+            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f">**^^Core^^**, **^^Attack^^**, **^^Shoot^^**</characteristic>
+            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
           </characteristics>
           <attributes>
-            <attribute name="Color" typeId="50fe-4f29-6bc3-dcc6">Blue</attribute>
-            <attribute name="Type" typeId="bf11-4e10-3ab1-06f4">Shooting</attribute>
-            <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
+            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Blue</attribute>
+            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Shooting</attribute>
+            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
           </attributes>
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink name="DESTRUCTION" hidden="false" id="a46c-c485-27e8-f269" targetId="9057-5a29-dda5-3c28" primary="false"/>
-        <categoryLink name="OGOR MAWTRIBES" hidden="false" id="81fa-4510-b866-6ad2" targetId="743-1bd8-e3d-ced2" primary="false"/>
-        <categoryLink name="OGOR" hidden="false" id="a619-270a-87f-b1aa" targetId="ddcb-3c91-472f-c35a" primary="false"/>
-        <categoryLink name="GUTBUSTERS" hidden="false" id="1bfc-f19b-a31-53e" targetId="5c0d-5e93-d71f-f0da" primary="false"/>
-        <categoryLink name="RHINOX" hidden="false" id="805f-dd32-da2a-28c" targetId="1ffa-4941-1338-9cf2" primary="false"/>
-        <categoryLink name="WAR MACHINE" hidden="false" id="6f3b-6d02-3650-161" targetId="f7bc-b618-4b5d-2bae" primary="true"/>
+        <categoryLink name="WAR MACHINE" hidden="false" id="4b89-e0c4-ac5e-afc6" targetId="f7bc-b618-4b5d-2bae" primary="true"/>
+        <categoryLink name="DESTRUCTION" hidden="false" id="748c-1b76-48cb-b771" targetId="9057-5a29-dda5-3c28" primary="false"/>
+        <categoryLink name="OGOR MAWTRIBES" hidden="false" id="a6ae-7037-5933-4418" targetId="743-1bd8-e3d-ced2" primary="false"/>
+        <categoryLink name="OGOR" hidden="false" id="a40c-d214-0c22-5177" targetId="ddcb-3c91-472f-c35a" primary="false"/>
+        <categoryLink name="GUTBUSTERS" hidden="false" id="64ad-b3ed-6ce5-14a7" targetId="5c0d-5e93-d71f-f0da" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry type="model" import="true" name="Ironblaster" hidden="false" id="8c9c-55f6-64c2-3f5c">
+        <selectionEntry type="model" import="true" name="Ironblaster" hidden="false" id="f7b8-e3cb-bbdb-f86a">
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="86ba-dc61-a833-36f2"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="52f9-57cb-dd79-5e6f"/>
+          </constraints>
           <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Rhinox&apos;s Sharp Horns" hidden="false" id="adbc-1836-61c4-3ba2">
+            <selectionEntry type="upgrade" import="true" name="Ironblaster Cannon Shot" hidden="false" id="d06b-16a8-a26a-3f32">
               <profiles>
-                <profile name="Rhinox&apos;s Sharp Horns" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="6bfc-6af7-1ed2-1fb7">
+                <profile name="Ironblaster Cannon Shot" typeId="1fd-a42f-41d3-fe05" typeName="Ranged Weapon" hidden="false" id="6a8e-b542-a731-335c">
                   <characteristics>
-                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">1</characteristic>
+                    <characteristic name="Rng" typeId="c6b5-908c-a604-1a98">18&quot;</characteristic>
+                    <characteristic name="Atk" typeId="aa17-4296-2887-e05d">2</characteristic>
+                    <characteristic name="Hit" typeId="194d-aeb6-5ba7-83b4">4+</characteristic>
+                    <characteristic name="Wnd" typeId="d3d5-9dc6-13de-8d1">2+</characteristic>
+                    <characteristic name="Rnd" typeId="d03f-a9ae-3eec-755">2</characteristic>
+                    <characteristic name="Dmg" typeId="96c2-d0a5-ea1e-653b">5</characteristic>
+                    <characteristic name="Ability" typeId="d793-3dd7-9c13-741e">-</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="c9a4-5a23-b63e-8ef1"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="0d10-ada3-c7c1-16b0"/>
+              </constraints>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Clubbers" hidden="false" id="8ba0-6e28-fb02-842d">
+              <profiles>
+                <profile name="Clubbers" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="3a82-1e47-ed1f-1d25">
+                  <characteristics>
+                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">2</characteristic>
+                    <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">4+</characteristic>
+                    <characteristic name="Wnd" typeId="61c1-22cc-40af-2847">2+</characteristic>
+                    <characteristic name="Rnd" typeId="eccc-10fa-6958-fb73">1</characteristic>
+                    <characteristic name="Dmg" typeId="e948-9c71-12a6-6be4">2</characteristic>
+                    <characteristic name="Ability" typeId="eda3-7332-5db1-4159">-</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="6524-1890-b3d3-ba9c"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="3e98-e56a-a15f-2e6d"/>
+              </constraints>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Rhinox&apos;s Sharp Horns" hidden="false" id="f7ff-8bfe-8f92-6e2d">
+              <profiles>
+                <profile name="Rhinox&apos;s Sharp Horns" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="6585-292e-cc2e-4945">
+                  <characteristics>
+                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">4</characteristic>
                     <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">4+</characteristic>
                     <characteristic name="Wnd" typeId="61c1-22cc-40af-2847">2+</characteristic>
                     <characteristic name="Rnd" typeId="eccc-10fa-6958-fb73">1</characteristic>
@@ -1327,162 +982,22 @@
                 </profile>
               </profiles>
               <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="4952-c4e7-5f10-5165"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8a34-3d83-c0a6-25ba"/>
-              </constraints>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Clubber" hidden="false" id="9f2-18b5-a396-21b1">
-              <profiles>
-                <profile name="Clubber" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="65f0-712f-5b49-7385">
-                  <characteristics>
-                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">2</characteristic>
-                    <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">4+</characteristic>
-                    <characteristic name="Wnd" typeId="61c1-22cc-40af-2847">2+</characteristic>
-                    <characteristic name="Rnd" typeId="eccc-10fa-6958-fb73">-</characteristic>
-                    <characteristic name="Dmg" typeId="e948-9c71-12a6-6be4">2</characteristic>
-                    <characteristic name="Ability" typeId="eda3-7332-5db1-4159">-</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="cdf3-5566-4d70-5ca0"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="b2-d503-b0d1-837f"/>
-              </constraints>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Ironblaster Cannon" hidden="false" id="cdec-6d6a-cfcd-aef2">
-              <profiles>
-                <profile name="Ironblaster Cannon: Big Shot" typeId="1fd-a42f-41d3-fe05" typeName="Ranged Weapon" hidden="false" id="460e-af32-6c57-ef4a">
-                  <characteristics>
-                    <characteristic name="Rng" typeId="c6b5-908c-a604-1a98">18&quot;</characteristic>
-                    <characteristic name="Atk" typeId="aa17-4296-2887-e05d">2</characteristic>
-                    <characteristic name="Hit" typeId="194d-aeb6-5ba7-83b4">4+</characteristic>
-                    <characteristic name="Wnd" typeId="d3d5-9dc6-13de-8d1">2+</characteristic>
-                    <characteristic name="Rnd" typeId="d03f-a9ae-3eec-755">2</characteristic>
-                    <characteristic name="Dmg" typeId="96c2-d0a5-ea1e-653b">D3+3</characteristic>
-                    <characteristic name="Ability" typeId="d793-3dd7-9c13-741e">-</characteristic>
-                  </characteristics>
-                  <alias/>
-                </profile>
-                <profile name="Ironblaster Cannon: Hail Shot" typeId="1fd-a42f-41d3-fe05" typeName="Ranged Weapon" hidden="false" id="eb87-9b33-9ffc-fae9">
-                  <characteristics>
-                    <characteristic name="Rng" typeId="c6b5-908c-a604-1a98">12&quot;</characteristic>
-                    <characteristic name="Atk" typeId="aa17-4296-2887-e05d">8</characteristic>
-                    <characteristic name="Hit" typeId="194d-aeb6-5ba7-83b4">4+</characteristic>
-                    <characteristic name="Wnd" typeId="d3d5-9dc6-13de-8d1">3+</characteristic>
-                    <characteristic name="Rnd" typeId="d03f-a9ae-3eec-755">1</characteristic>
-                    <characteristic name="Dmg" typeId="96c2-d0a5-ea1e-653b">2</characteristic>
-                    <characteristic name="Ability" typeId="d793-3dd7-9c13-741e">-</characteristic>
-                  </characteristics>
-                  <alias/>
-                </profile>
-              </profiles>
-              <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="3d17-7d41-53c9-8dc6"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="bb4-d00f-87b4-abba"/>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="ee33-c2db-a12c-58d6"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4782-d5b1-f6b5-4b24"/>
               </constraints>
             </selectionEntry>
           </selectionEntries>
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="a742-25d-b701-9b6e"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="be34-3136-702c-fb58"/>
-          </constraints>
           <rules>
-            <rule name="Base Size" id="7020-c743-0044-1c7a" hidden="true">
+            <rule name="Base Size" id="09bc-6429-88ed-88db" hidden="true">
               <description>120x92mm</description>
             </rule>
           </rules>
         </selectionEntry>
       </selectionEntries>
     </selectionEntry>
-    <selectionEntry type="unit" import="true" name="Firebelly" hidden="false" id="d5f3-a7f1-7345-ee4b" publicationId="1ac6-e227-a186-12">
-      <entryLinks>
-        <entryLink import="true" name="General" hidden="false" id="865f-cc20-a5e0-c728" type="selectionEntry" targetId="a56b-952e-ad15-7868"/>
-      </entryLinks>
+    <selectionEntry type="unit" import="true" name="Stonehorn Beastriders" hidden="false" id="8b95-893a-4c1a-9224" publicationId="feba-6749-6df3-ea9e">
       <profiles>
-        <profile name="Firebelly" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="2958-d07d-bc66-6747">
-          <characteristics>
-            <characteristic name="Move" typeId="fed0-d1b3-1bb8-c501">6&quot;</characteristic>
-            <characteristic name="Health" typeId="96be-54ae-ce7b-10b7">7</characteristic>
-            <characteristic name="Save" typeId="1981-ef09-96f6-7aa9">5+</characteristic>
-            <characteristic name="Control" typeId="6c6f-8510-9ce1-fc6e">5</characteristic>
-          </characteristics>
-        </profile>
-        <profile name="Torrent of Flame" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="8b2e-fc78-685-78b4">
-          <characteristics>
-            <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
-            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">Add 1 to the Damage characteristic of this unit's **Fire Breath** for attacks that target **^^Infantry^^**.</characteristic>
-          </characteristics>
-          <attributes>
-            <attribute name="Color" typeId="50fe-4f29-6bc3-dcc6">Blue</attribute>
-            <attribute name="Type" typeId="bf11-4e10-3ab1-06f4">Shooting</attribute>
-            <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
-          </attributes>
-        </profile>
-      </profiles>
-      <categoryLinks>
-        <categoryLink name="HERO" hidden="false" id="6bb3-8d4d-d217-88d3" targetId="6e72-1656-d554-528a" primary="true"/>
-        <categoryLink name="DESTRUCTION" hidden="false" id="5b6a-b415-a4e6-db20" targetId="9057-5a29-dda5-3c28" primary="false"/>
-        <categoryLink name="OGOR MAWTRIBES" hidden="false" id="ea30-e422-7d9e-89ed" targetId="743-1bd8-e3d-ced2" primary="false"/>
-        <categoryLink name="INFANTRY" hidden="false" id="f474-7dd3-c9f5-2617" targetId="75d6-6995-dfcc-3898" primary="false"/>
-        <categoryLink name="OGOR" hidden="false" id="4955-50e5-1900-e3de" targetId="ddcb-3c91-472f-c35a" primary="false"/>
-        <categoryLink name="WIZARD (1)" hidden="false" id="e306-a79e-9af5-c2df" targetId="6f28-c3f6-4b1b-8aff" primary="false"/>
-      </categoryLinks>
-      <selectionEntries>
-        <selectionEntry type="model" import="true" name="Firebelly" hidden="false" id="f0d1-9063-8c9a-d0f6">
-          <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Basalt Hammer" hidden="false" id="c24-66b0-8815-56db">
-              <profiles>
-                <profile name="Basalt Hammer" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="f18c-1456-2035-ade2">
-                  <characteristics>
-                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">3</characteristic>
-                    <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">4+</characteristic>
-                    <characteristic name="Wnd" typeId="61c1-22cc-40af-2847">2+</characteristic>
-                    <characteristic name="Rnd" typeId="eccc-10fa-6958-fb73">1</characteristic>
-                    <characteristic name="Dmg" typeId="e948-9c71-12a6-6be4">D3</characteristic>
-                    <characteristic name="Ability" typeId="eda3-7332-5db1-4159">-</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="ecd0-42e9-16b4-6458"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="7a9-f0be-16da-bbb"/>
-              </constraints>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Fire Breath" hidden="false" id="65bc-2922-ba40-1500">
-              <profiles>
-                <profile name="Fire Breath" typeId="1fd-a42f-41d3-fe05" typeName="Ranged Weapon" hidden="false" id="51ca-d54-3a37-d00">
-                  <characteristics>
-                    <characteristic name="Rng" typeId="c6b5-908c-a604-1a98">8&quot;</characteristic>
-                    <characteristic name="Atk" typeId="aa17-4296-2887-e05d">6</characteristic>
-                    <characteristic name="Hit" typeId="194d-aeb6-5ba7-83b4">2+</characteristic>
-                    <characteristic name="Wnd" typeId="d3d5-9dc6-13de-8d1">3+</characteristic>
-                    <characteristic name="Rnd" typeId="d03f-a9ae-3eec-755">-</characteristic>
-                    <characteristic name="Dmg" typeId="96c2-d0a5-ea1e-653b">1</characteristic>
-                    <characteristic name="Ability" typeId="d793-3dd7-9c13-741e">Shoot in Combat</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="d78d-2d4c-4370-16c"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="d913-78b-72dc-f834"/>
-              </constraints>
-            </selectionEntry>
-          </selectionEntries>
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="ffed-8784-f559-b554"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="2f6f-e2d3-9fb5-1a8"/>
-          </constraints>
-          <rules>
-            <rule name="Base Size" id="ef78-eac8-1f73-4c29" hidden="true">
-              <description>50mm</description>
-            </rule>
-          </rules>
-        </selectionEntry>
-      </selectionEntries>
-    </selectionEntry>
-    <selectionEntry type="unit" import="true" name="Stonehorn Beastriders" hidden="false" id="8b95-893a-4c1a-9224" publicationId="1ac6-e227-a186-12">
-      <profiles>
-        <profile name="Stonehorn Beastriders" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="e516-fca5-ea8-da71">
+        <profile name="Stonehorn Beastriders" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="900b-0955-4ed5-9fb1">
           <characteristics>
             <characteristic name="Move" typeId="fed0-d1b3-1bb8-c501">10&quot;</characteristic>
             <characteristic name="Health" typeId="96be-54ae-ce7b-10b7">14</characteristic>
@@ -1490,207 +1005,129 @@
             <characteristic name="Control" typeId="6c6f-8510-9ce1-fc6e">10</characteristic>
           </characteristics>
         </profile>
-        <profile name="Battle Damaged" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="badb-874c-ba71-ac6f">
+        <profile name="Battle Damaged" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="f460-f6d6-1391-ed7a">
           <characteristics>
             <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
-            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">While this unit has 10 or more damage points, the Attacks characteristic of its **Stonehorn's Rock-hard Horns** is 4.</characteristic>
+            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">While this unit has 10 or more damage points, the Attacks characteristic of its **Stonehorn's Rock-hard Horns and Hooves** is 4.</characteristic>
           </characteristics>
           <attributes>
-            <attribute name="Color" typeId="50fe-4f29-6bc3-dcc6">Black</attribute>
-            <attribute name="Type" typeId="bf11-4e10-3ab1-06f4">Damage</attribute>
+            <attribute typeId="50fe-4f29-6bc3-dcc6" name="Color">Black</attribute>
+            <attribute typeId="bf11-4e10-3ab1-06f4" name="Type">Damage</attribute>
             <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
           </attributes>
         </profile>
-        <profile name="Stone Skeleton" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="3538-363a-267a-bd94">
+        <profile name="Stone Skeleton" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="70ba-d81e-d125-6477">
           <characteristics>
             <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
-            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">Ignore the first damage point that would be allocated to this unit in each phase.</characteristic>
+            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">Ignore the first damage point that would be allocated to this unit in each phase.</characteristic>
           </characteristics>
           <attributes>
-            <attribute name="Color" typeId="50fe-4f29-6bc3-dcc6">Green</attribute>
-            <attribute name="Type" typeId="bf11-4e10-3ab1-06f4">Defensive</attribute>
+            <attribute typeId="50fe-4f29-6bc3-dcc6" name="Color">Green</attribute>
+            <attribute typeId="bf11-4e10-3ab1-06f4" name="Type">Defensive</attribute>
             <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
           </attributes>
         </profile>
-        <profile name="Stonehorn Avalanche" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="9e14-b9c8-cdfe-acd2">
+        <profile name="Stonehorn Avalanche" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="1750-b4b1-9817-221b">
           <characteristics>
-            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Turn (Army), Any Combat Phase</characteristic>
-            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb"/>
-            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">If this unit charged this turn, roll a dice. On a 3+, when this unit makes a pile-in move this phase, add D6&quot; to the distance it can move.</characteristic>
+            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Turn (Army), Any Charge Phase</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">If this unit charged this turn and has not used the 'Bull Charge' ability this turn, pick an enemy unit in combat with this unit or an enemy faction terrain feature within this unit's combat range to be the target.</characteristic>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Roll a dice. On a 3+:
+• If the target is a unit, inflict 3 mortal damage on it.
+• If the target is a faction terrain feature, inflict 6 mortal damage on it.</characteristic>
             <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f">**^^Rampage^^**</characteristic>
             <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
           </characteristics>
           <attributes>
-            <attribute name="Color" typeId="5a11-eab3-180c-ddf5">Red</attribute>
-            <attribute name="Type" typeId="6d16-c86b-2698-85a4">Movement</attribute>
+            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Red</attribute>
+            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Offensive</attribute>
             <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
           </attributes>
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink name="DESTRUCTION" hidden="false" id="b1e2-92f6-75d9-2288" targetId="9057-5a29-dda5-3c28" primary="false"/>
-        <categoryLink name="OGOR MAWTRIBES" hidden="false" id="8108-5c7b-f714-314b" targetId="743-1bd8-e3d-ced2" primary="false"/>
-        <categoryLink name="OGOR" hidden="false" id="12c6-c5f3-caed-c6b3" targetId="ddcb-3c91-472f-c35a" primary="false"/>
-        <categoryLink name="MONSTER" hidden="false" id="8161-8907-21fc-c3f8" targetId="6d54-625c-d063-13e2" primary="true"/>
-        <categoryLink name="BEASTCLAW RAIDERS" hidden="false" id="4099-9333-1b6d-a5ff" targetId="1a3d-33f9-c4cc-fe0" primary="false"/>
+        <categoryLink name="MONSTER" hidden="false" id="274d-6dff-b05e-bb23" targetId="6d54-625c-d063-13e2" primary="true"/>
+        <categoryLink name="DESTRUCTION" hidden="false" id="3a42-9c44-ed74-ce3d" targetId="9057-5a29-dda5-3c28" primary="false"/>
+        <categoryLink name="OGOR MAWTRIBES" hidden="false" id="db08-8111-e19e-19f8" targetId="743-1bd8-e3d-ced2" primary="false"/>
+        <categoryLink name="OGOR" hidden="false" id="4014-89bf-85da-08a5" targetId="ddcb-3c91-472f-c35a" primary="false"/>
+        <categoryLink name="BEASTCLAW" hidden="false" id="f8b2-b516-fa81-b49d" targetId="410d-6b15-3cf4-88d0" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry type="model" import="true" name="Stonehorn Beastrider" hidden="false" id="f674-6072-7b0b-6dc6">
+        <selectionEntry type="model" import="true" name="Stonehorn Beastrider" hidden="false" id="50be-7147-836b-73b8">
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="fee4-dae2-9908-934c"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="7c47-f447-c13f-030b"/>
+          </constraints>
           <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Stonehorn&apos;s Hooves" hidden="false" id="8be6-ba34-d4ec-81f0">
+            <selectionEntry type="upgrade" import="true" name="Chaintrap, Harpoon Launcher or Blood Vulture" hidden="false" id="f419-13bc-ef33-94fa">
               <profiles>
-                <profile name="Stonehorn&apos;s Hooves" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="b7d2-2df4-acce-3f98">
+                <profile name="Chaintrap, Harpoon Launcher or Blood Vulture" typeId="1fd-a42f-41d3-fe05" typeName="Ranged Weapon" hidden="false" id="9a86-d5cb-cdca-d4be">
                   <characteristics>
-                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">D6</characteristic>
-                    <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">4+</characteristic>
-                    <characteristic name="Wnd" typeId="61c1-22cc-40af-2847">2+</characteristic>
-                    <characteristic name="Rnd" typeId="eccc-10fa-6958-fb73">1</characteristic>
-                    <characteristic name="Dmg" typeId="e948-9c71-12a6-6be4">D3</characteristic>
-                    <characteristic name="Ability" typeId="eda3-7332-5db1-4159">Companion</characteristic>
+                    <characteristic name="Rng" typeId="c6b5-908c-a604-1a98">15&quot;</characteristic>
+                    <characteristic name="Atk" typeId="aa17-4296-2887-e05d">1</characteristic>
+                    <characteristic name="Hit" typeId="194d-aeb6-5ba7-83b4">4+</characteristic>
+                    <characteristic name="Wnd" typeId="d3d5-9dc6-13de-8d1">3+</characteristic>
+                    <characteristic name="Rnd" typeId="d03f-a9ae-3eec-755">1</characteristic>
+                    <characteristic name="Dmg" typeId="96c2-d0a5-ea1e-653b">3</characteristic>
+                    <characteristic name="Ability" typeId="d793-3dd7-9c13-741e">-</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="3452-4ff2-3317-2b2b"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ccd-749b-2215-51a2"/>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="c0e8-a000-0a13-e639"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="55c2-1e74-f2b4-ff63"/>
               </constraints>
             </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Punches and Kicks" hidden="false" id="c6e5-b107-3705-20a2">
+            <selectionEntry type="upgrade" import="true" name="Punches and Kicks" hidden="false" id="b4c5-a0fb-267b-35aa">
               <profiles>
-                <profile name="Punches and Kicks" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="c82a-a5c1-7efd-e913">
+                <profile name="Punches and Kicks" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="9c5a-e61e-d69f-4aad">
                   <characteristics>
-                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">6</characteristic>
+                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">4</characteristic>
                     <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">4+</characteristic>
                     <characteristic name="Wnd" typeId="61c1-22cc-40af-2847">2+</characteristic>
-                    <characteristic name="Rnd" typeId="eccc-10fa-6958-fb73">-</characteristic>
+                    <characteristic name="Rnd" typeId="eccc-10fa-6958-fb73">1</characteristic>
                     <characteristic name="Dmg" typeId="e948-9c71-12a6-6be4">1</characteristic>
                     <characteristic name="Ability" typeId="eda3-7332-5db1-4159">-</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="814d-2c2b-73c7-6dae"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8a30-3ab2-7814-c6d5"/>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="6685-3340-4fbf-fe2e"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="72e1-e201-a811-db7e"/>
               </constraints>
             </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Stonehorn&apos;s Rock-hard Horns" hidden="false" id="d948-572f-be97-85d1">
+            <selectionEntry type="upgrade" import="true" name="Stonehorn&apos;s Rock-hard Horns and Hooves" hidden="false" id="dcf6-b111-12ca-72ee">
               <profiles>
-                <profile name="Stonehorn&apos;s Rock-hard Horns" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="4e16-4c5-d0bd-37bf">
+                <profile name="Stonehorn&apos;s Rock-hard Horns and Hooves" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="7747-55e7-31e7-16ee">
                   <characteristics>
-                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">6</characteristic>
+                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">7</characteristic>
                     <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">4+</characteristic>
                     <characteristic name="Wnd" typeId="61c1-22cc-40af-2847">2+</characteristic>
                     <characteristic name="Rnd" typeId="eccc-10fa-6958-fb73">2</characteristic>
                     <characteristic name="Dmg" typeId="e948-9c71-12a6-6be4">3</characteristic>
-                    <characteristic name="Ability" typeId="eda3-7332-5db1-4159">Charge (+1 Damage), Companion</characteristic>
+                    <characteristic name="Ability" typeId="eda3-7332-5db1-4159">Charge (+1 Damage), Companion</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="23e2-77c-898c-6f6c"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6e96-dc9b-ebc6-22d3"/>
-              </constraints>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Harpoon Launcher" hidden="false" id="94a6-b022-bdab-e9a1">
-              <profiles>
-                <profile name="Harpoon Launcher" typeId="1fd-a42f-41d3-fe05" typeName="Ranged Weapon" hidden="false" id="b718-f16-4f61-7764">
-                  <characteristics>
-                    <characteristic name="Rng" typeId="c6b5-908c-a604-1a98">18&quot;</characteristic>
-                    <characteristic name="Atk" typeId="aa17-4296-2887-e05d">1</characteristic>
-                    <characteristic name="Hit" typeId="194d-aeb6-5ba7-83b4">4+</characteristic>
-                    <characteristic name="Wnd" typeId="d3d5-9dc6-13de-8d1">3+</characteristic>
-                    <characteristic name="Rnd" typeId="d03f-a9ae-3eec-755">1</characteristic>
-                    <characteristic name="Dmg" typeId="96c2-d0a5-ea1e-653b">D3</characteristic>
-                    <characteristic name="Ability" typeId="d793-3dd7-9c13-741e">-</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ba68-da9e-5c98-1da8"/>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="540d-36de-6fce-5f7b"/>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="8bff-3393-bd48-c069"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="2543-fb79-0988-3800"/>
               </constraints>
             </selectionEntry>
           </selectionEntries>
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="ac1c-f7b4-2c17-4c55"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="60d2-df8d-a54e-18e1"/>
-          </constraints>
-          <selectionEntryGroups>
-            <selectionEntryGroup name="Wargear Options" id="dfb-f87e-4e37-1d2f" hidden="false" flatten="true">
-              <selectionEntries>
-                <selectionEntry type="upgrade" import="true" name="Chaintrap" hidden="false" id="1fb-b506-f5bb-3d58">
-                  <selectionEntries>
-                    <selectionEntry type="upgrade" import="true" name="Chaintrap" hidden="false" id="bf30-527d-2c92-e272">
-                      <profiles>
-                        <profile name="Chaintrap" typeId="1fd-a42f-41d3-fe05" typeName="Ranged Weapon" hidden="false" id="fdae-12a7-5e6b-313a">
-                          <characteristics>
-                            <characteristic name="Rng" typeId="c6b5-908c-a604-1a98">12&quot;</characteristic>
-                            <characteristic name="Atk" typeId="aa17-4296-2887-e05d">1</characteristic>
-                            <characteristic name="Hit" typeId="194d-aeb6-5ba7-83b4">4+</characteristic>
-                            <characteristic name="Wnd" typeId="d3d5-9dc6-13de-8d1">3+</characteristic>
-                            <characteristic name="Rnd" typeId="d03f-a9ae-3eec-755">1</characteristic>
-                            <characteristic name="Dmg" typeId="96c2-d0a5-ea1e-653b">3</characteristic>
-                            <characteristic name="Ability" typeId="d793-3dd7-9c13-741e">Anti‑**^^Monster^^** (+1 Rend)</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                      <constraints>
-                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="444c-59b5-d918-8f19"/>
-                        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="110c-752a-60c6-58c6"/>
-                      </constraints>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <constraints>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="c97f-7954-d674-a38"/>
-                  </constraints>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Blood Vulture" hidden="false" id="e42b-39a8-aa38-5c37">
-                  <constraints>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="1760-977-f091-4391"/>
-                  </constraints>
-                  <selectionEntries>
-                    <selectionEntry type="upgrade" import="true" name="Blood Vulture" hidden="false" id="138c-ad6c-b604-6fae">
-                      <profiles>
-                        <profile name="Blood Vulture" typeId="1fd-a42f-41d3-fe05" typeName="Ranged Weapon" hidden="false" id="d302-9272-d24e-1002">
-                          <characteristics>
-                            <characteristic name="Rng" typeId="c6b5-908c-a604-1a98">24&quot;</characteristic>
-                            <characteristic name="Atk" typeId="aa17-4296-2887-e05d">1</characteristic>
-                            <characteristic name="Hit" typeId="194d-aeb6-5ba7-83b4">2+</characteristic>
-                            <characteristic name="Wnd" typeId="d3d5-9dc6-13de-8d1">3+</characteristic>
-                            <characteristic name="Rnd" typeId="d03f-a9ae-3eec-755">-</characteristic>
-                            <characteristic name="Dmg" typeId="96c2-d0a5-ea1e-653b">1</characteristic>
-                            <characteristic name="Ability" typeId="d793-3dd7-9c13-741e">-</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                      <constraints>
-                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="45df-709e-69cf-ef96"/>
-                        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="892a-e6aa-d144-632c"/>
-                      </constraints>
-                    </selectionEntry>
-                  </selectionEntries>
-                </selectionEntry>
-              </selectionEntries>
-              <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="9ec2-f53d-ab78-718a"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="a15e-6014-1880-f41b"/>
-              </constraints>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
           <rules>
-            <rule name="Base Size" id="cc06-0628-55d3-2e83" hidden="true">
+            <rule name="Base Size" id="9428-6ee8-b1d7-e4ed" hidden="true">
               <description>120x92mm</description>
             </rule>
           </rules>
         </selectionEntry>
       </selectionEntries>
     </selectionEntry>
-    <selectionEntry type="unit" import="true" name="Frostlord on Stonehorn" hidden="false" id="e445-5f3b-4228-8bd3" publicationId="1ac6-e227-a186-12">
+    <selectionEntry type="unit" import="true" name="Frostlord on Stonehorn" hidden="false" id="e445-5f3b-4228-8bd3" publicationId="feba-6749-6df3-ea9e">
       <entryLinks>
-        <entryLink import="true" name="General" hidden="false" id="e172-2a53-aae-9a07" type="selectionEntry" targetId="a56b-952e-ad15-7868"/>
+        <entryLink import="true" name="General" hidden="false" id="c0e1-d9dd-a19e-752c" type="selectionEntry" targetId="a56b-952e-ad15-7868"/>
       </entryLinks>
       <profiles>
-        <profile name="Frostlord on Stonehorn" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="277d-e546-fe44-e93c">
+        <profile name="Frostlord on Stonehorn" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="15ea-15c9-cc96-0181">
           <characteristics>
             <characteristic name="Move" typeId="fed0-d1b3-1bb8-c501">10&quot;</characteristic>
             <characteristic name="Health" typeId="96be-54ae-ce7b-10b7">15</characteristic>
@@ -1698,86 +1135,72 @@
             <characteristic name="Control" typeId="6c6f-8510-9ce1-fc6e">10</characteristic>
           </characteristics>
         </profile>
-        <profile name="Battle Damaged" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="bbb4-5cb5-81ce-e59b">
+        <profile name="Stone Skeleton" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="8fed-f7ce-eda5-ebd9">
           <characteristics>
             <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
-            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">While this unit has 10 or more damage points, the Attacks characteristic of its **Stonehorn's Rock-hard Horns** is 4.</characteristic>
+            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">Ignore the first damage point that would be allocated to this unit in each phase.</characteristic>
           </characteristics>
           <attributes>
-            <attribute name="Color" typeId="50fe-4f29-6bc3-dcc6">Black</attribute>
-            <attribute name="Type" typeId="bf11-4e10-3ab1-06f4">Damage</attribute>
+            <attribute typeId="50fe-4f29-6bc3-dcc6" name="Color">Green</attribute>
+            <attribute typeId="bf11-4e10-3ab1-06f4" name="Type">Defensive</attribute>
             <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
           </attributes>
         </profile>
-        <profile name="Frost Spear" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="bef1-d647-9b0-e1c4">
+        <profile name="Battle Damaged" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="e18a-7ee6-3240-d7f4">
           <characteristics>
             <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
-            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">If any damage points are allocated to an enemy **^^Hero^^** or **^^Monster^^** by attacks made with this unit's **Frost Spear**, subtract 1 from the Attacks characteristic of that enemy unit's melee weapons until the start of your next turn.</characteristic>
+            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">While this unit has 10 or more damage points, the Attacks characteristic of its **Stonehorn's Rock-hard Horns and Hooves** is 4.</characteristic>
           </characteristics>
           <attributes>
-            <attribute name="Color" typeId="50fe-4f29-6bc3-dcc6">Red</attribute>
-            <attribute name="Type" typeId="bf11-4e10-3ab1-06f4">Defensive</attribute>
+            <attribute typeId="50fe-4f29-6bc3-dcc6" name="Color">Black</attribute>
+            <attribute typeId="bf11-4e10-3ab1-06f4" name="Type">Damage</attribute>
             <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
           </attributes>
         </profile>
-        <profile name="Stone Skeleton" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="3e0-f7cd-69c1-3c77">
-          <characteristics>
-            <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
-            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">Ignore the first damage point that would be allocated to this unit in each phase.</characteristic>
-          </characteristics>
-          <attributes>
-            <attribute name="Color" typeId="50fe-4f29-6bc3-dcc6">Green</attribute>
-            <attribute name="Type" typeId="bf11-4e10-3ab1-06f4">Defensive</attribute>
-            <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
-          </attributes>
-        </profile>
-        <profile name="Earth-shattering Charge" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="21e3-bb0d-b595-662c">
+        <profile name="Earth-Shattering Charge" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="ca37-732e-6739-65e5">
           <characteristics>
             <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Turn (Army), Any Charge Phase</characteristic>
-            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">If this unit charged this phase, pick an enemy unit within 1&quot; of it to be the target.</characteristic>
-            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Inflict D3 mortal damage on the target. Then, roll 2D6. This unit can move a distance up to the value of the roll. During that move, it can pass through models in the target unit but must end that move in combat.</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">If this unit charged this turn and has not used the 'Bull Charge' ability this turn, pick a visible enemy unit within 1&quot; of it to be the target.</characteristic>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Inflict D3 mortal damage on the target and then roll 2D6. This unit can move a distance in inches up to the value of the roll. It can pass through models in the target unit but must end that move in combat.</characteristic>
             <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f">**^^Rampage^^**</characteristic>
             <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
           </characteristics>
           <attributes>
-            <attribute name="Color" typeId="5a11-eab3-180c-ddf5">Orange</attribute>
-            <attribute name="Type" typeId="6d16-c86b-2698-85a4">Offensive</attribute>
+            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Orange</attribute>
+            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Offensive</attribute>
             <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+          </attributes>
+        </profile>
+        <profile name="Enraged Roar" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="44bb-535d-e916-0b38">
+          <characteristics>
+            <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
+            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">While this unit is damaged, add 1 to the Attacks characteristic of **Companion** weapons used by other friendly **^^Ogor Mawtribes^^** units while they are within this unit's combat range.</characteristic>
+          </characteristics>
+          <attributes>
+            <attribute typeId="50fe-4f29-6bc3-dcc6" name="Color">Red</attribute>
+            <attribute typeId="bf11-4e10-3ab1-06f4" name="Type">Offensive</attribute>
+            <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
           </attributes>
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink name="HERO" hidden="false" id="8abe-9673-6833-ee1f" targetId="6e72-1656-d554-528a" primary="true"/>
-        <categoryLink name="DESTRUCTION" hidden="false" id="4261-f144-84a4-f8a1" targetId="9057-5a29-dda5-3c28" primary="false"/>
-        <categoryLink name="OGOR MAWTRIBES" hidden="false" id="19e7-63ea-459b-30e1" targetId="743-1bd8-e3d-ced2" primary="false"/>
-        <categoryLink name="OGOR" hidden="false" id="f45e-3b6-c866-1d64" targetId="ddcb-3c91-472f-c35a" primary="false"/>
-        <categoryLink name="MONSTER" hidden="false" id="ca05-ad09-544e-feef" targetId="6d54-625c-d063-13e2" primary="false"/>
-        <categoryLink name="BEASTCLAW RAIDERS" hidden="false" id="f14-305a-6a6-2092" targetId="1a3d-33f9-c4cc-fe0" primary="false"/>
+        <categoryLink name="HERO" hidden="false" id="b92e-0a25-31e2-8c78" targetId="6e72-1656-d554-528a" primary="true"/>
+        <categoryLink name="MONSTER" hidden="false" id="f856-9e56-4e4b-fee9" targetId="6d54-625c-d063-13e2" primary="false"/>
+        <categoryLink name="DESTRUCTION" hidden="false" id="a912-e2b9-5028-00ca" targetId="9057-5a29-dda5-3c28" primary="false"/>
+        <categoryLink name="OGOR MAWTRIBES" hidden="false" id="d0a0-dc9d-afeb-4cda" targetId="743-1bd8-e3d-ced2" primary="false"/>
+        <categoryLink name="OGOR" hidden="false" id="5ba0-cc9d-94d3-e84c" targetId="ddcb-3c91-472f-c35a" primary="false"/>
+        <categoryLink name="BEASTCLAW" hidden="false" id="1906-40db-0096-7744" targetId="410d-6b15-3cf4-88d0" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry type="model" import="true" name="Frostlord on Stonehorn" hidden="false" id="98a6-3cbf-f2c-260b">
+        <selectionEntry type="model" import="true" name="Frostlord on Stonehorn" hidden="false" id="d20d-686c-009c-3f5d">
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="7c61-bb4d-1b32-852c"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="c9f6-269d-2c3d-01dd"/>
+          </constraints>
           <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Stonehorn&apos;s Hooves" hidden="false" id="d4e4-cd01-f093-7f93">
+            <selectionEntry type="upgrade" import="true" name="Frost Spear" hidden="false" id="38ac-b87c-967f-0c6f">
               <profiles>
-                <profile name="Stonehorn&apos;s Hooves" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="a8d2-e5e1-68ee-ca29">
-                  <characteristics>
-                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">D6</characteristic>
-                    <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">4+</characteristic>
-                    <characteristic name="Wnd" typeId="61c1-22cc-40af-2847">2+</characteristic>
-                    <characteristic name="Rnd" typeId="eccc-10fa-6958-fb73">1</characteristic>
-                    <characteristic name="Dmg" typeId="e948-9c71-12a6-6be4">D3</characteristic>
-                    <characteristic name="Ability" typeId="eda3-7332-5db1-4159">Companion</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="ec9a-f785-1024-b8cc"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="89f2-f3b1-e2ef-8dd3"/>
-              </constraints>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Frost Spear" hidden="false" id="ac2e-9a85-9ab9-58ab">
-              <profiles>
-                <profile name="Frost Spear" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="7eb5-3db5-b751-c609">
+                <profile name="Frost Spear" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="1d2a-66b5-927e-1baa">
                   <characteristics>
                     <characteristic name="Atk" typeId="60e-35aa-31ed-e488">4</characteristic>
                     <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">4+</characteristic>
@@ -1789,47 +1212,43 @@
                 </profile>
               </profiles>
               <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="2d75-7c9-fcca-5885"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="dc3-d007-19c2-e1ae"/>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="8e07-3fa7-880f-4436"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4f62-c03d-4195-9e4e"/>
               </constraints>
             </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Stonehorn&apos;s Rock-hard Horns" hidden="false" id="cb3f-a627-3c7f-7eeb">
+            <selectionEntry type="upgrade" import="true" name="Stonehorn&apos;s Rock-hard Horns and Hooves" hidden="false" id="6881-60cd-3f8b-71df">
               <profiles>
-                <profile name="Stonehorn&apos;s Rock-hard Horns" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="145e-2831-ba83-a5ce">
+                <profile name="Stonehorn&apos;s Rock-hard Horns and Hooves" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="94b5-4f88-d0ce-8937">
                   <characteristics>
-                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">6</characteristic>
+                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">7</characteristic>
                     <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">4+</characteristic>
                     <characteristic name="Wnd" typeId="61c1-22cc-40af-2847">2+</characteristic>
                     <characteristic name="Rnd" typeId="eccc-10fa-6958-fb73">2</characteristic>
                     <characteristic name="Dmg" typeId="e948-9c71-12a6-6be4">3</characteristic>
-                    <characteristic name="Ability" typeId="eda3-7332-5db1-4159">Charge (+1 Damage), Companion</characteristic>
+                    <characteristic name="Ability" typeId="eda3-7332-5db1-4159">Charge (+1 Damage), Companion</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="1de3-af12-9065-af62"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="b41f-5a54-cc59-f151"/>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="7fe4-b7b8-769f-e613"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="7166-d223-718a-562a"/>
               </constraints>
             </selectionEntry>
           </selectionEntries>
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="e72e-7e6d-2bde-a0f1"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="5a7d-f459-c0a0-2d66"/>
-          </constraints>
           <rules>
-            <rule name="Base Size" id="a695-6052-ac34-8106" hidden="true">
+            <rule name="Base Size" id="3231-3165-4988-fb03" hidden="true">
               <description>120x92mm</description>
             </rule>
           </rules>
         </selectionEntry>
       </selectionEntries>
     </selectionEntry>
-    <selectionEntry type="unit" import="true" name="Frostlord on Thundertusk" hidden="false" id="e1b4-2fef-26cc-81c4" publicationId="1ac6-e227-a186-12">
+    <selectionEntry type="unit" import="true" name="Frostlord on Thundertusk" hidden="false" id="e1b4-2fef-26cc-81c4" publicationId="feba-6749-6df3-ea9e">
       <entryLinks>
-        <entryLink import="true" name="General" hidden="false" id="f6d2-1c60-7a58-f581" type="selectionEntry" targetId="a56b-952e-ad15-7868"/>
+        <entryLink import="true" name="General" hidden="false" id="1ed5-717e-0c70-f65d" type="selectionEntry" targetId="a56b-952e-ad15-7868"/>
       </entryLinks>
       <profiles>
-        <profile name="Frostlord on Thundertusk" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="57b6-c920-412b-5999">
+        <profile name="Frostlord on Thundertusk" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="d32b-bd59-ce42-6999">
           <characteristics>
             <characteristic name="Move" typeId="fed0-d1b3-1bb8-c501">10&quot;</characteristic>
             <characteristic name="Health" typeId="96be-54ae-ce7b-10b7">15</characteristic>
@@ -1837,60 +1256,64 @@
             <characteristic name="Control" typeId="6c6f-8510-9ce1-fc6e">10</characteristic>
           </characteristics>
         </profile>
-        <profile name="Battle Damaged" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="b9a9-8b96-7f20-ca96">
+        <profile name="Battle Damaged" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="9513-e557-8a9d-8441">
           <characteristics>
             <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
-            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">While this unit has 10 or more damage points, the Attacks characteristic of its **Thundertusk's Colossal Tusks** is 2.</characteristic>
+            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">While this unit has 10 or more damage points, the Attacks characteristic of its **Thundertusk's Colossal Tusks** is 2.</characteristic>
           </characteristics>
           <attributes>
-            <attribute name="Color" typeId="50fe-4f29-6bc3-dcc6">Black</attribute>
-            <attribute name="Type" typeId="bf11-4e10-3ab1-06f4">Damage</attribute>
+            <attribute typeId="50fe-4f29-6bc3-dcc6" name="Color">Black</attribute>
+            <attribute typeId="bf11-4e10-3ab1-06f4" name="Type">Damage</attribute>
             <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
           </attributes>
         </profile>
-        <profile name="Bellowing Voice" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="8e5d-b62f-7ae6-3db2">
+        <profile name="Blessed of the Old Ice" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="296f-bf42-7edc-d487">
           <characteristics>
-            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Battle (Army), Your Charge Phase</characteristic>
-            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick any number of friendly **^^Beastclaw Raiders^^** units wholly within 12&quot; of this unit to be the targets.</characteristic>
-            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Each target can add 1 to the D3 roll made if that unit uses the 'Trampling Charge' ability this turn.</characteristic>
+            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Turn (Army), Your Movement Phase</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick a visible friendly **^^Ogor Mawtribes^^** unit wholly within 12&quot; of this unit to be the target.</characteristic>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Roll a dice. On a 3+, for the rest of the turn, the target can still use **^^Shoot^^** and/or **^^Charge^^** abilities even if it used a **^^Retreat^^** or **^^Run^^** ability in the same turn.</characteristic>
             <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
             <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
           </characteristics>
           <attributes>
-            <attribute name="Color" typeId="5a11-eab3-180c-ddf5">Orange</attribute>
-            <attribute name="Type" typeId="6d16-c86b-2698-85a4">Offensive</attribute>
+            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Gray</attribute>
+            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Special</attribute>
             <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
           </attributes>
         </profile>
-        <profile name="Sweeping Tusks" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="eb67-1be3-39d7-d9c6">
+        <profile name="Sweeping Tusks" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="62e8-c626-390a-f782">
           <characteristics>
             <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Turn (Army), Any Movement Phase</characteristic>
-            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick an enemy unit in combat with this unit to be the target.</characteristic>
-            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Roll a dice. On a 3+, roll a dice for each model in the target unit. For each 5+, inflict 1 mortal damage on the target.</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick an enemy unit in combat with this unit to be the target.</characteristic>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Roll a dice for each model in the target unit. For each 5+, inflict 1 mortal damage on the target.</characteristic>
             <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f">**^^Rampage^^**</characteristic>
             <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
           </characteristics>
           <attributes>
-            <attribute name="Color" typeId="5a11-eab3-180c-ddf5">Gray</attribute>
-            <attribute name="Type" typeId="6d16-c86b-2698-85a4">Offensive</attribute>
+            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Gray</attribute>
+            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Special</attribute>
             <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
           </attributes>
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink name="HERO" hidden="false" id="c194-c8a7-df93-47cb" targetId="6e72-1656-d554-528a" primary="true"/>
-        <categoryLink name="DESTRUCTION" hidden="false" id="a7ac-8fbe-26fc-bcba" targetId="9057-5a29-dda5-3c28" primary="false"/>
-        <categoryLink name="OGOR MAWTRIBES" hidden="false" id="734e-790-700f-78a6" targetId="743-1bd8-e3d-ced2" primary="false"/>
-        <categoryLink name="OGOR" hidden="false" id="a707-81d8-1886-b12e" targetId="ddcb-3c91-472f-c35a" primary="false"/>
-        <categoryLink name="MONSTER" hidden="false" id="b1ad-d455-ea83-d249" targetId="6d54-625c-d063-13e2" primary="false"/>
-        <categoryLink name="BEASTCLAW RAIDERS" hidden="false" id="1b8f-1919-e1ed-551c" targetId="1a3d-33f9-c4cc-fe0" primary="false"/>
+        <categoryLink name="HERO" hidden="false" id="b19d-9754-2f0f-dbe5" targetId="6e72-1656-d554-528a" primary="true"/>
+        <categoryLink name="MONSTER" hidden="false" id="19dc-7b93-a770-27bb" targetId="6d54-625c-d063-13e2" primary="false"/>
+        <categoryLink name="DESTRUCTION" hidden="false" id="f515-36a3-cd98-9bf6" targetId="9057-5a29-dda5-3c28" primary="false"/>
+        <categoryLink name="OGOR MAWTRIBES" hidden="false" id="71a6-a8f1-c697-50d2" targetId="743-1bd8-e3d-ced2" primary="false"/>
+        <categoryLink name="OGOR" hidden="false" id="3984-0dc8-a448-b645" targetId="ddcb-3c91-472f-c35a" primary="false"/>
+        <categoryLink name="BEASTCLAW" hidden="false" id="b061-fca9-7a56-48e9" targetId="410d-6b15-3cf4-88d0" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry type="model" import="true" name="Frostlord on Thundertusk" hidden="false" id="2eba-317c-f3b6-85b7">
+        <selectionEntry type="model" import="true" name="Frostlord on Thundertusk" hidden="false" id="4784-c119-1321-fcae">
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="7b98-891d-e557-600c"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="e05d-b501-883b-3f95"/>
+          </constraints>
           <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Ice Blast" hidden="false" id="9299-8e91-c50-aede">
+            <selectionEntry type="upgrade" import="true" name="Ice Blast" hidden="false" id="db05-3433-d3ad-84af">
               <profiles>
-                <profile name="Ice Blast" typeId="1fd-a42f-41d3-fe05" typeName="Ranged Weapon" hidden="false" id="4917-eb64-3ee8-aeff">
+                <profile name="Ice Blast" typeId="1fd-a42f-41d3-fe05" typeName="Ranged Weapon" hidden="false" id="79bd-daa4-209d-3b8e">
                   <characteristics>
                     <characteristic name="Rng" typeId="c6b5-908c-a604-1a98">12&quot;</characteristic>
                     <characteristic name="Atk" typeId="aa17-4296-2887-e05d">1</characteristic>
@@ -1903,13 +1326,13 @@
                 </profile>
               </profiles>
               <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="8a3b-57f3-e5fd-8b2e"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="1992-e24b-cbac-c37b"/>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="cf2d-1832-6153-f5c2"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="085f-e094-4ab5-aa34"/>
               </constraints>
             </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Frost Spear" hidden="false" id="e63d-9a9d-fa01-e58a">
+            <selectionEntry type="upgrade" import="true" name="Frost Spear" hidden="false" id="6258-2262-2a5d-e5bf">
               <profiles>
-                <profile name="Frost Spear" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="f62d-c1c8-c4f6-17a4">
+                <profile name="Frost Spear" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="1dad-4cff-6641-57bb">
                   <characteristics>
                     <characteristic name="Atk" typeId="60e-35aa-31ed-e488">4</characteristic>
                     <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">4+</characteristic>
@@ -1921,35 +1344,31 @@
                 </profile>
               </profiles>
               <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="5c8e-7236-daa9-2020"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="b6a8-125f-ca36-9ef5"/>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="e4f6-01c0-e4cf-923d"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="93f3-f951-8298-68f2"/>
               </constraints>
             </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Thundertusk&apos;s Colossal Tusks" hidden="false" id="cefc-765-a9cc-a94b">
+            <selectionEntry type="upgrade" import="true" name="Thundertusk&apos;s Colossal Tusks" hidden="false" id="fe5e-b3fd-fd78-8f69">
               <profiles>
-                <profile name="Thundertusk&apos;s Colossal Tusks" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="f680-ba7c-7cec-c5a6">
+                <profile name="Thundertusk&apos;s Colossal Tusks" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="853c-7d3c-d7d1-f61a">
                   <characteristics>
                     <characteristic name="Atk" typeId="60e-35aa-31ed-e488">3</characteristic>
                     <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">4+</characteristic>
                     <characteristic name="Wnd" typeId="61c1-22cc-40af-2847">2+</characteristic>
                     <characteristic name="Rnd" typeId="eccc-10fa-6958-fb73">1</characteristic>
                     <characteristic name="Dmg" typeId="e948-9c71-12a6-6be4">5</characteristic>
-                    <characteristic name="Ability" typeId="eda3-7332-5db1-4159">Anti-**^^Infantry^^** (+1 Rend), Companion</characteristic>
+                    <characteristic name="Ability" typeId="eda3-7332-5db1-4159">Anti-**^^Infantry^^** (+1 Rend), Companion</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="e874-1ced-bf2d-9937"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="3e06-9564-15eb-d716"/>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="3fb6-01b5-13a1-04e9"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="fe6a-759a-a0d4-4b3c"/>
               </constraints>
             </selectionEntry>
           </selectionEntries>
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="cc8a-e7dd-de2b-9a32"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="c4b5-ef2-c50f-1efd"/>
-          </constraints>
           <rules>
-            <rule name="Base Size" id="5e78-7206-b8cf-b8c5" hidden="true">
+            <rule name="Base Size" id="f9d4-6da2-91bf-f6d6" hidden="true">
               <description>120x92mm</description>
             </rule>
           </rules>
@@ -2107,12 +1526,12 @@
         </modifier>
       </modifiers>
     </selectionEntry>
-    <selectionEntry type="unit" import="true" name="Huskard on Stonehorn" hidden="false" id="8bfb-791d-158b-35a2" publicationId="2d6e-3ea2-52fe-a38">
+    <selectionEntry type="unit" import="true" name="Huskard on Stonehorn" hidden="false" id="8bfb-791d-158b-35a2" publicationId="feba-6749-6df3-ea9e">
       <entryLinks>
-        <entryLink import="true" name="General" hidden="false" id="954-1e7d-3b8f-477e" type="selectionEntry" targetId="a56b-952e-ad15-7868"/>
+        <entryLink import="true" name="General" hidden="false" id="f0ab-332e-fd2c-8e5a" type="selectionEntry" targetId="a56b-952e-ad15-7868"/>
       </entryLinks>
       <profiles>
-        <profile name="Huskard on Stonehorn" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="f077-7ab1-81a4-1138">
+        <profile name="Huskard on Stonehorn" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="244b-f19f-11df-686c">
           <characteristics>
             <characteristic name="Move" typeId="fed0-d1b3-1bb8-c501">10&quot;</characteristic>
             <characteristic name="Health" typeId="96be-54ae-ce7b-10b7">14</characteristic>
@@ -2120,218 +1539,131 @@
             <characteristic name="Control" typeId="6c6f-8510-9ce1-fc6e">10</characteristic>
           </characteristics>
         </profile>
-        <profile name="Battle Damaged" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="2f52-ab9b-9f84-e391">
+        <profile name="Battle Damaged" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="f966-df5a-b463-5d8f">
           <characteristics>
             <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
-            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">While this unit has 10 or more damage points, the Attacks characteristic of its **Stonehorn's Rock-hard Horns** is 4.</characteristic>
+            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">While this unit has 10 or more damage points, the Attacks characteristic of its **Stonehorn's Rock-hard Horns and Hooves** is 4.</characteristic>
           </characteristics>
           <attributes>
-            <attribute name="Color" typeId="50fe-4f29-6bc3-dcc6">Black</attribute>
-            <attribute name="Type" typeId="bf11-4e10-3ab1-06f4">Damage</attribute>
+            <attribute typeId="50fe-4f29-6bc3-dcc6" name="Color">Black</attribute>
+            <attribute typeId="bf11-4e10-3ab1-06f4" name="Type">Damage</attribute>
             <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
           </attributes>
         </profile>
-        <profile name="Stone Skeleton" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="4eb0-da3b-ec1a-c0da">
+        <profile name="Stone Skeleton" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="b772-aa70-7172-f460">
           <characteristics>
             <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
-            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">Ignore the first damage point that would be allocated to this unit in each phase.</characteristic>
+            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">Ignore the first damage point that would be allocated to this unit in each phase.</characteristic>
           </characteristics>
           <attributes>
-            <attribute name="Color" typeId="50fe-4f29-6bc3-dcc6">Green</attribute>
-            <attribute name="Type" typeId="bf11-4e10-3ab1-06f4">Defensive</attribute>
+            <attribute typeId="50fe-4f29-6bc3-dcc6" name="Color">Green</attribute>
+            <attribute typeId="bf11-4e10-3ab1-06f4" name="Type">Defensive</attribute>
             <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
           </attributes>
         </profile>
-        <profile name="Everwinter&apos;s Goad" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="c7b8-9cd0-cdaf-efe8">
+        <profile name="Primal Bellow" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="bccf-3dcb-8a3c-cb98">
           <characteristics>
             <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Turn (Army), Any Combat Phase</characteristic>
-            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick each friendly and enemy **^^Monster^^** within this unit's combat range to be the targets.</characteristic>
-            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Roll a dice for each target. On a 3+:
-• If the target is a friendly **^^Ogor Mawtribes^^** unit, its **Companion** weapons have Crit (2 Hits) for the rest of the turn.
-• If the target is an enemy unit, subtract 1 from hit rolls for attacks made with its **Companion** weapons for the rest of the turn.</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick a friendly **^^Ogor Mawtribes^^** unit within this unit's combat range to be the target or pick an enemy unit in combat with this unit to be the target.</characteristic>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Roll a dice. Add 2 to the roll if this unit charged this turn. On a 4+:
+• If the target is a friendly unit, its **Companion** weapons have Crit (2 Hits) for the rest of the turn.
+• If the target is an enemy unit, subtract 1 from hit rolls for the target's attacks for the rest of the turn.</characteristic>
             <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f">**^^Rampage^^**</characteristic>
             <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
           </characteristics>
           <attributes>
-            <attribute name="Color" typeId="5a11-eab3-180c-ddf5">Red</attribute>
-            <attribute name="Type" typeId="6d16-c86b-2698-85a4">Special</attribute>
+            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Red</attribute>
+            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Special</attribute>
             <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
           </attributes>
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink name="HERO" hidden="false" id="55e5-8a7a-2500-6db5" targetId="6e72-1656-d554-528a" primary="true"/>
-        <categoryLink name="DESTRUCTION" hidden="false" id="c5ae-3e49-a88e-ee3c" targetId="9057-5a29-dda5-3c28" primary="false"/>
-        <categoryLink name="OGOR MAWTRIBES" hidden="false" id="36ff-3c2e-9307-fedf" targetId="743-1bd8-e3d-ced2" primary="false"/>
-        <categoryLink name="OGOR" hidden="false" id="af64-84fa-fd49-4093" targetId="ddcb-3c91-472f-c35a" primary="false"/>
-        <categoryLink name="MONSTER" hidden="false" id="ce0c-4b83-30d8-fc99" targetId="6d54-625c-d063-13e2" primary="false"/>
-        <categoryLink name="BEASTCLAW RAIDERS" hidden="false" id="20c8-1e7c-5958-f40f" targetId="1a3d-33f9-c4cc-fe0" primary="false"/>
-        <categoryLink name="PRIEST (1)" hidden="false" id="a28a-37be-9c67-c1f2" targetId="3fe-84f4-cec6-a1c1" primary="false"/>
+        <categoryLink name="HERO" hidden="false" id="9d18-7b15-0852-78be" targetId="6e72-1656-d554-528a" primary="true"/>
+        <categoryLink name="MONSTER" hidden="false" id="6986-221d-f767-19d1" targetId="6d54-625c-d063-13e2" primary="false"/>
+        <categoryLink name="PRIEST (1)" hidden="false" id="abd9-3db7-3fb6-cd7e" targetId="3fe-84f4-cec6-a1c1" primary="false"/>
+        <categoryLink name="DESTRUCTION" hidden="false" id="57ca-75c8-2f4d-a348" targetId="9057-5a29-dda5-3c28" primary="false"/>
+        <categoryLink name="OGOR MAWTRIBES" hidden="false" id="90a9-da1b-9218-be7c" targetId="743-1bd8-e3d-ced2" primary="false"/>
+        <categoryLink name="OGOR" hidden="false" id="87dc-18a0-cca4-38a9" targetId="ddcb-3c91-472f-c35a" primary="false"/>
+        <categoryLink name="BEASTCLAW" hidden="false" id="cfe2-2a6a-803d-e88e" targetId="410d-6b15-3cf4-88d0" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry type="model" import="true" name="Huskard on Stonehorn" hidden="false" id="1b4b-8425-7c47-4b02">
+        <selectionEntry type="model" import="true" name="Huskard on Stonehorn" hidden="false" id="f4f2-133c-17ae-7671">
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="e78e-d13d-0b57-d052"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="a41f-6594-ba70-60c6"/>
+          </constraints>
           <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Stonehorn&apos;s Hooves" hidden="false" id="61bc-d7e8-8ef9-9f8e">
+            <selectionEntry type="upgrade" import="true" name="Chaintrap, Harpoon Launcher or Blood Vulture" hidden="false" id="6e57-927a-c854-3a9b">
               <profiles>
-                <profile name="Stonehorn&apos;s Hooves" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="2de4-d10b-f8f3-39a5">
+                <profile name="Chaintrap, Harpoon Launcher or Blood Vulture" typeId="1fd-a42f-41d3-fe05" typeName="Ranged Weapon" hidden="false" id="d855-0d3b-29b0-0d3c">
                   <characteristics>
-                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">D6</characteristic>
-                    <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">4+</characteristic>
-                    <characteristic name="Wnd" typeId="61c1-22cc-40af-2847">2+</characteristic>
-                    <characteristic name="Rnd" typeId="eccc-10fa-6958-fb73">1</characteristic>
-                    <characteristic name="Dmg" typeId="e948-9c71-12a6-6be4">D3</characteristic>
-                    <characteristic name="Ability" typeId="eda3-7332-5db1-4159">Companion</characteristic>
+                    <characteristic name="Rng" typeId="c6b5-908c-a604-1a98">15&quot;</characteristic>
+                    <characteristic name="Atk" typeId="aa17-4296-2887-e05d">1</characteristic>
+                    <characteristic name="Hit" typeId="194d-aeb6-5ba7-83b4">4+</characteristic>
+                    <characteristic name="Wnd" typeId="d3d5-9dc6-13de-8d1">3+</characteristic>
+                    <characteristic name="Rnd" typeId="d03f-a9ae-3eec-755">1</characteristic>
+                    <characteristic name="Dmg" typeId="96c2-d0a5-ea1e-653b">3</characteristic>
+                    <characteristic name="Ability" typeId="d793-3dd7-9c13-741e">-</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="b467-6088-89e9-714e"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="b67f-2ffa-1bce-7911"/>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="6d1b-d77d-4718-7c02"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="3fa5-f010-0b2b-448e"/>
               </constraints>
             </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Punches and Kicks" hidden="false" id="578e-3215-e2ca-88dc">
+            <selectionEntry type="upgrade" import="true" name="Huskard&apos;s Punches and Kicks" hidden="false" id="7182-8b82-647b-c381">
               <profiles>
-                <profile name="Punches and Kicks" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="406e-bd44-5503-8f91">
+                <profile name="Huskard&apos;s Punches and Kicks" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="c9a4-76d4-0e98-756a">
                   <characteristics>
-                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">3</characteristic>
+                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">4</characteristic>
                     <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">4+</characteristic>
                     <characteristic name="Wnd" typeId="61c1-22cc-40af-2847">2+</characteristic>
-                    <characteristic name="Rnd" typeId="eccc-10fa-6958-fb73">-</characteristic>
+                    <characteristic name="Rnd" typeId="eccc-10fa-6958-fb73">1</characteristic>
                     <characteristic name="Dmg" typeId="e948-9c71-12a6-6be4">1</characteristic>
                     <characteristic name="Ability" typeId="eda3-7332-5db1-4159">-</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="6ae4-171e-f4de-18bd"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8dba-e62b-be5b-9e80"/>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="8af6-1fb4-61f4-2e5c"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="99ca-c9f3-7384-a7f6"/>
               </constraints>
             </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Stonehorn&apos;s Rock-hard Horns" hidden="false" id="301e-9e6f-ec7d-9df">
+            <selectionEntry type="upgrade" import="true" name="Stonehorn&apos;s Rock-hard Horns and Hooves" hidden="false" id="d7b2-fbd4-7bb0-e5a1">
               <profiles>
-                <profile name="Stonehorn&apos;s Rock-hard Horns" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="34b5-e535-2b33-b4fa">
+                <profile name="Stonehorn&apos;s Rock-hard Horns and Hooves" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="7573-3efe-e595-a0ed">
                   <characteristics>
-                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">6</characteristic>
+                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">7</characteristic>
                     <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">4+</characteristic>
                     <characteristic name="Wnd" typeId="61c1-22cc-40af-2847">2+</characteristic>
                     <characteristic name="Rnd" typeId="eccc-10fa-6958-fb73">2</characteristic>
                     <characteristic name="Dmg" typeId="e948-9c71-12a6-6be4">3</characteristic>
-                    <characteristic name="Ability" typeId="eda3-7332-5db1-4159">Charge (+1 Damage), Companion</characteristic>
+                    <characteristic name="Ability" typeId="eda3-7332-5db1-4159">Charge (+1 Damage), Companion</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="cf76-448f-14e-fd1b"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="86c4-12c7-91aa-c27e"/>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="0537-0d1a-9be0-c660"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="949a-05fc-ea3b-e388"/>
               </constraints>
             </selectionEntry>
           </selectionEntries>
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="87d3-3ce8-bead-b475"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4db9-8967-be57-a29a"/>
-          </constraints>
-          <selectionEntryGroups>
-            <selectionEntryGroup name="Wargear Options" id="a08a-2432-fe0a-ceee" hidden="false" flatten="true">
-              <selectionEntries>
-                <selectionEntry type="upgrade" import="true" name="Chaintrap" hidden="false" id="af4b-c4de-265-429">
-                  <selectionEntries>
-                    <selectionEntry type="upgrade" import="true" name="Chaintrap" hidden="false" id="d11c-2afb-f5d4-71db">
-                      <profiles>
-                        <profile name="Chaintrap" typeId="1fd-a42f-41d3-fe05" typeName="Ranged Weapon" hidden="false" id="c005-e6b8-df40-4f20">
-                          <characteristics>
-                            <characteristic name="Rng" typeId="c6b5-908c-a604-1a98">12&quot;</characteristic>
-                            <characteristic name="Atk" typeId="aa17-4296-2887-e05d">1</characteristic>
-                            <characteristic name="Hit" typeId="194d-aeb6-5ba7-83b4">4+</characteristic>
-                            <characteristic name="Wnd" typeId="d3d5-9dc6-13de-8d1">3+</characteristic>
-                            <characteristic name="Rnd" typeId="d03f-a9ae-3eec-755">1</characteristic>
-                            <characteristic name="Dmg" typeId="96c2-d0a5-ea1e-653b">3</characteristic>
-                            <characteristic name="Ability" typeId="d793-3dd7-9c13-741e">Anti‑**^^Monster^^** (+1 Rend)</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                      <constraints>
-                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="1714-93a3-25-7740"/>
-                        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="de39-bd8e-f062-3471"/>
-                      </constraints>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <constraints>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="a2c1-9d91-7b29-d41"/>
-                  </constraints>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Blood Vulture" hidden="false" id="1463-b61b-a988-719a">
-                  <constraints>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ce6-b78f-ed8-5d21"/>
-                  </constraints>
-                  <selectionEntries>
-                    <selectionEntry type="upgrade" import="true" name="Blood Vulture" hidden="false" id="4905-62ce-641b-809a">
-                      <profiles>
-                        <profile name="Blood Vulture" typeId="1fd-a42f-41d3-fe05" typeName="Ranged Weapon" hidden="false" id="20b8-3d9a-1bf9-2447">
-                          <characteristics>
-                            <characteristic name="Rng" typeId="c6b5-908c-a604-1a98">24&quot;</characteristic>
-                            <characteristic name="Atk" typeId="aa17-4296-2887-e05d">1</characteristic>
-                            <characteristic name="Hit" typeId="194d-aeb6-5ba7-83b4">2+</characteristic>
-                            <characteristic name="Wnd" typeId="d3d5-9dc6-13de-8d1">3+</characteristic>
-                            <characteristic name="Rnd" typeId="d03f-a9ae-3eec-755">-</characteristic>
-                            <characteristic name="Dmg" typeId="96c2-d0a5-ea1e-653b">1</characteristic>
-                            <characteristic name="Ability" typeId="d793-3dd7-9c13-741e">-</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                      <constraints>
-                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="d02b-5dc8-aaee-1867"/>
-                        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="41a3-381a-121c-d947"/>
-                      </constraints>
-                    </selectionEntry>
-                  </selectionEntries>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Harpoon Launcher" hidden="false" id="7eea-e4e1-282b-f918">
-                  <constraints>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="05c1-06ce-58cb-b683"/>
-                  </constraints>
-                  <selectionEntries>
-                    <selectionEntry type="upgrade" import="true" name="Harpoon Launcher" hidden="false" id="2d7f-70c-78-ca20">
-                      <profiles>
-                        <profile name="Harpoon Launcher" typeId="1fd-a42f-41d3-fe05" typeName="Ranged Weapon" hidden="false" id="a2b1-2842-60ba-c691">
-                          <characteristics>
-                            <characteristic name="Rng" typeId="c6b5-908c-a604-1a98">18&quot;</characteristic>
-                            <characteristic name="Atk" typeId="aa17-4296-2887-e05d">1</characteristic>
-                            <characteristic name="Hit" typeId="194d-aeb6-5ba7-83b4">4+</characteristic>
-                            <characteristic name="Wnd" typeId="d3d5-9dc6-13de-8d1">3+</characteristic>
-                            <characteristic name="Rnd" typeId="d03f-a9ae-3eec-755">1</characteristic>
-                            <characteristic name="Dmg" typeId="96c2-d0a5-ea1e-653b">D3</characteristic>
-                            <characteristic name="Ability" typeId="d793-3dd7-9c13-741e">-</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                      <constraints>
-                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="1d33-c21-e6cb-31ab"/>
-                        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="6a3a-7539-4a47-f85c"/>
-                      </constraints>
-                    </selectionEntry>
-                  </selectionEntries>
-                </selectionEntry>
-              </selectionEntries>
-              <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="f5b9-d2d2-d734-b80c"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ed93-5586-1b5c-fa84"/>
-              </constraints>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
           <rules>
-            <rule name="Base Size" id="5484-da9e-87df-1239" hidden="true">
+            <rule name="Base Size" id="ac16-d9c5-02e1-0539" hidden="true">
               <description>120x92mm</description>
             </rule>
           </rules>
         </selectionEntry>
       </selectionEntries>
     </selectionEntry>
-    <selectionEntry type="unit" import="true" name="Huskard on Thundertusk" hidden="false" id="ebcd-aa92-94f1-c1be" publicationId="1ac6-e227-a186-12">
+    <selectionEntry type="unit" import="true" name="Huskard on Thundertusk" hidden="false" id="ebcd-aa92-94f1-c1be" publicationId="feba-6749-6df3-ea9e">
       <entryLinks>
-        <entryLink import="true" name="General" hidden="false" id="f2bf-6590-2580-2f34" type="selectionEntry" targetId="a56b-952e-ad15-7868"/>
+        <entryLink import="true" name="General" hidden="false" id="fc81-ccbf-c301-78fb" type="selectionEntry" targetId="a56b-952e-ad15-7868"/>
       </entryLinks>
       <profiles>
-        <profile name="Huskard on Thundertusk" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="22e5-5d30-602-d15">
+        <profile name="Huskard on Thundertusk" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="470b-118f-4b0a-3748">
           <characteristics>
             <characteristic name="Move" typeId="fed0-d1b3-1bb8-c501">10&quot;</characteristic>
             <characteristic name="Health" typeId="96be-54ae-ce7b-10b7">14</characteristic>
@@ -2339,47 +1671,84 @@
             <characteristic name="Control" typeId="6c6f-8510-9ce1-fc6e">10</characteristic>
           </characteristics>
         </profile>
-        <profile name="Battle Damaged" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="542-f32b-3d59-1f88">
+        <profile name="Battle Damaged" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="d449-a92a-160f-82f4">
           <characteristics>
             <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
-            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">While this unit has 10 or more damage points, the Attacks characteristic of its **Thundertusk's Colossal Tusks** is 2.</characteristic>
+            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">While this unit has 10 or more damage points, the Attacks characteristic of its **Thundertusk's Colossal Tusks** is 2.</characteristic>
           </characteristics>
           <attributes>
-            <attribute name="Color" typeId="50fe-4f29-6bc3-dcc6">Black</attribute>
-            <attribute name="Type" typeId="bf11-4e10-3ab1-06f4">Damage</attribute>
+            <attribute typeId="50fe-4f29-6bc3-dcc6" name="Color">Black</attribute>
+            <attribute typeId="bf11-4e10-3ab1-06f4" name="Type">Damage</attribute>
             <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
           </attributes>
         </profile>
-        <profile name="Freezing Aura" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="6947-613b-ba6f-66f0">
+        <profile name="Winter&apos;s Cruelty" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="87f1-d976-66b3-8d04">
+          <characteristics>
+            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Turn (Army), Any Shooting Phase</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick a visible enemy unit to be the target.</characteristic>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Roll a dice. If the roll is equal to or less than the number of damage points allocated to the target by attacks made with this unit's **Ice Blast** this phase, subtract 1 from the Damage characteristic of the target's weapons until the start of your next turn.</characteristic>
+            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+          </characteristics>
+          <attributes>
+            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Blue</attribute>
+            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Defensive</attribute>
+            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+          </attributes>
+        </profile>
+        <profile name="Freezing Aura" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="c5e1-bb1c-3cf5-4ded">
           <characteristics>
             <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Turn (Army), Any Combat Phase</characteristic>
-            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick an enemy **^^Infantry^^** unit in combat with this unit to be the target.</characteristic>
-            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Roll a dice. Add 1 to the roll if the target had **^^Strike-last^^** as a result of this ability in the previous turn. On a 4+, the target has **^^Strike-last^^** for the rest of the turn.</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">If this unit did not charge this turn, pick an enemy unit in combat with it to be the target.</characteristic>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Roll a dice. On a 3+, subtract 1 from the Attacks characteristic of the target's melee weapons for the rest of the turn.</characteristic>
             <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f">**^^Rampage^^**</characteristic>
             <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
           </characteristics>
           <attributes>
-            <attribute name="Color" typeId="5a11-eab3-180c-ddf5">Red</attribute>
-            <attribute name="Type" typeId="6d16-c86b-2698-85a4">Defensive</attribute>
+            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Red</attribute>
+            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Defensive</attribute>
             <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
           </attributes>
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink name="HERO" hidden="false" id="b7a5-2981-7576-b52f" targetId="6e72-1656-d554-528a" primary="true"/>
-        <categoryLink name="DESTRUCTION" hidden="false" id="5bee-2ff0-a5fb-2694" targetId="9057-5a29-dda5-3c28" primary="false"/>
-        <categoryLink name="OGOR MAWTRIBES" hidden="false" id="78fc-f835-4e16-6dda" targetId="743-1bd8-e3d-ced2" primary="false"/>
-        <categoryLink name="OGOR" hidden="false" id="c785-8076-5d7d-9621" targetId="ddcb-3c91-472f-c35a" primary="false"/>
-        <categoryLink name="MONSTER" hidden="false" id="225c-1b5f-e172-583a" targetId="6d54-625c-d063-13e2" primary="false"/>
-        <categoryLink name="BEASTCLAW RAIDERS" hidden="false" id="e791-1fd9-bb6d-424e" targetId="1a3d-33f9-c4cc-fe0" primary="false"/>
-        <categoryLink name="PRIEST (1)" hidden="false" id="8044-47b0-39c8-e97f" targetId="3fe-84f4-cec6-a1c1" primary="false"/>
+        <categoryLink name="HERO" hidden="false" id="1124-c1a2-8af5-e132" targetId="6e72-1656-d554-528a" primary="true"/>
+        <categoryLink name="MONSTER" hidden="false" id="db2e-413c-693b-5bbe" targetId="6d54-625c-d063-13e2" primary="false"/>
+        <categoryLink name="PRIEST (1)" hidden="false" id="ae37-b689-a4c4-d8e2" targetId="3fe-84f4-cec6-a1c1" primary="false"/>
+        <categoryLink name="DESTRUCTION" hidden="false" id="9eec-ae5b-3ae8-4568" targetId="9057-5a29-dda5-3c28" primary="false"/>
+        <categoryLink name="OGOR MAWTRIBES" hidden="false" id="07e3-f66d-15c6-29ee" targetId="743-1bd8-e3d-ced2" primary="false"/>
+        <categoryLink name="OGOR" hidden="false" id="33a2-2105-be75-51a1" targetId="ddcb-3c91-472f-c35a" primary="false"/>
+        <categoryLink name="BEASTCLAW" hidden="false" id="f9ee-40f2-6aed-c0c3" targetId="410d-6b15-3cf4-88d0" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry type="model" import="true" name="Huskard on Thundertusk" hidden="false" id="8f25-8e16-f80a-f172">
+        <selectionEntry type="model" import="true" name="Huskard on Thundertusk" hidden="false" id="6ace-e036-fdb7-35de">
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="e3ef-3e1e-6890-178d"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="607a-8665-8d5f-1ea1"/>
+          </constraints>
           <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Ice Blast" hidden="false" id="6fd7-8fbe-9558-7aa0">
+            <selectionEntry type="upgrade" import="true" name="Chaintrap, Harpoon Launcher or Blood Vulture" hidden="false" id="9047-9525-5f97-0f41">
               <profiles>
-                <profile name="Ice Blast" typeId="1fd-a42f-41d3-fe05" typeName="Ranged Weapon" hidden="false" id="1647-eed6-f73f-66e1">
+                <profile name="Chaintrap, Harpoon Launcher or Blood Vulture" typeId="1fd-a42f-41d3-fe05" typeName="Ranged Weapon" hidden="false" id="7699-e64f-e50b-1f12">
+                  <characteristics>
+                    <characteristic name="Rng" typeId="c6b5-908c-a604-1a98">15&quot;</characteristic>
+                    <characteristic name="Atk" typeId="aa17-4296-2887-e05d">1</characteristic>
+                    <characteristic name="Hit" typeId="194d-aeb6-5ba7-83b4">4+</characteristic>
+                    <characteristic name="Wnd" typeId="d3d5-9dc6-13de-8d1">3+</characteristic>
+                    <characteristic name="Rnd" typeId="d03f-a9ae-3eec-755">1</characteristic>
+                    <characteristic name="Dmg" typeId="96c2-d0a5-ea1e-653b">3</characteristic>
+                    <characteristic name="Ability" typeId="d793-3dd7-9c13-741e">-</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="b118-fe4b-224c-a9ed"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="a890-72d2-58fd-b88d"/>
+              </constraints>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Ice Blast" hidden="false" id="6341-0f99-b1ab-bd8f">
+              <profiles>
+                <profile name="Ice Blast" typeId="1fd-a42f-41d3-fe05" typeName="Ranged Weapon" hidden="false" id="38e7-8adb-225f-b454">
                   <characteristics>
                     <characteristic name="Rng" typeId="c6b5-908c-a604-1a98">12&quot;</characteristic>
                     <characteristic name="Atk" typeId="aa17-4296-2887-e05d">1</characteristic>
@@ -2392,141 +1761,49 @@
                 </profile>
               </profiles>
               <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="5b30-7836-9fd0-1e4d"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="effb-b03d-d10a-9e33"/>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="94d0-127b-928f-fb25"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="b11c-ba92-7cfb-a171"/>
               </constraints>
             </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Thundertusk&apos;s Colossal Tusks" hidden="false" id="77e1-6e39-d487-8e78">
+            <selectionEntry type="upgrade" import="true" name="Huskard&apos;s Punches and Kicks" hidden="false" id="0ed8-43a0-a919-1e97">
               <profiles>
-                <profile name="Thundertusk&apos;s Colossal Tusks" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="d130-72fb-f8c6-f217">
+                <profile name="Huskard&apos;s Punches and Kicks" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="da83-eba5-306b-9854">
                   <characteristics>
-                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">3</characteristic>
+                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">4</characteristic>
                     <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">4+</characteristic>
                     <characteristic name="Wnd" typeId="61c1-22cc-40af-2847">2+</characteristic>
                     <characteristic name="Rnd" typeId="eccc-10fa-6958-fb73">1</characteristic>
-                    <characteristic name="Dmg" typeId="e948-9c71-12a6-6be4">5</characteristic>
-                    <characteristic name="Ability" typeId="eda3-7332-5db1-4159">Anti-**^^Infantry^^** (+1 Rend), Companion</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="6839-144c-4bee-b2da"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="1d53-52ea-7965-e0f7"/>
-              </constraints>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Punches and Kicks" hidden="false" id="ca92-3c96-c233-2337">
-              <profiles>
-                <profile name="Punches and Kicks" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="bf78-79c9-6585-1a98">
-                  <characteristics>
-                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">3</characteristic>
-                    <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">4+</characteristic>
-                    <characteristic name="Wnd" typeId="61c1-22cc-40af-2847">2+</characteristic>
-                    <characteristic name="Rnd" typeId="eccc-10fa-6958-fb73">-</characteristic>
                     <characteristic name="Dmg" typeId="e948-9c71-12a6-6be4">1</characteristic>
                     <characteristic name="Ability" typeId="eda3-7332-5db1-4159">-</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
               <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="8a37-4da3-3bd7-584c"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4eb0-f616-5afe-1271"/>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="be97-20c9-9ed4-2f61"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="680d-f98e-cc0d-151a"/>
+              </constraints>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Thundertusk&apos;s Colossal Tusks" hidden="false" id="bd24-879e-1a7f-1ee3">
+              <profiles>
+                <profile name="Thundertusk&apos;s Colossal Tusks" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="3eeb-6bab-cd40-3c16">
+                  <characteristics>
+                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">3</characteristic>
+                    <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">4+</characteristic>
+                    <characteristic name="Wnd" typeId="61c1-22cc-40af-2847">2+</characteristic>
+                    <characteristic name="Rnd" typeId="eccc-10fa-6958-fb73">1</characteristic>
+                    <characteristic name="Dmg" typeId="e948-9c71-12a6-6be4">5</characteristic>
+                    <characteristic name="Ability" typeId="eda3-7332-5db1-4159">Anti-**^^Infantry^^** (+1 Rend), Companion</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="b19f-7e36-8c31-92c8"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="d4a9-1969-19e8-2816"/>
               </constraints>
             </selectionEntry>
           </selectionEntries>
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="a880-11c5-7078-1896"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="e1fc-40d3-6a05-62ca"/>
-          </constraints>
-          <selectionEntryGroups>
-            <selectionEntryGroup name="Wargear Options" id="3ad1-9a2a-de38-f4ee" hidden="false" flatten="true">
-              <selectionEntries>
-                <selectionEntry type="upgrade" import="true" name="Chaintrap" hidden="false" id="611c-781a-e27-e250">
-                  <selectionEntries>
-                    <selectionEntry type="upgrade" import="true" name="Chaintrap" hidden="false" id="ae29-5c26-c3d5-6ff4">
-                      <profiles>
-                        <profile name="Chaintrap" typeId="1fd-a42f-41d3-fe05" typeName="Ranged Weapon" hidden="false" id="4bf7-365a-9788-c0ed">
-                          <characteristics>
-                            <characteristic name="Rng" typeId="c6b5-908c-a604-1a98">12&quot;</characteristic>
-                            <characteristic name="Atk" typeId="aa17-4296-2887-e05d">1</characteristic>
-                            <characteristic name="Hit" typeId="194d-aeb6-5ba7-83b4">4+</characteristic>
-                            <characteristic name="Wnd" typeId="d3d5-9dc6-13de-8d1">3+</characteristic>
-                            <characteristic name="Rnd" typeId="d03f-a9ae-3eec-755">1</characteristic>
-                            <characteristic name="Dmg" typeId="96c2-d0a5-ea1e-653b">3</characteristic>
-                            <characteristic name="Ability" typeId="d793-3dd7-9c13-741e">Anti‑**^^Monster^^** (+1 Rend)</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                      <constraints>
-                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="a99a-6e37-1230-69"/>
-                        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="9598-4632-55fe-5d5b"/>
-                      </constraints>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <constraints>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6e35-947d-a8b2-87d2"/>
-                  </constraints>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Blood Vulture" hidden="false" id="ae7-157d-c18d-3f2a">
-                  <constraints>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="d613-417-ccb8-8570"/>
-                  </constraints>
-                  <selectionEntries>
-                    <selectionEntry type="upgrade" import="true" name="Blood Vulture" hidden="false" id="4201-7507-e59f-74d3">
-                      <profiles>
-                        <profile name="Blood Vulture" typeId="1fd-a42f-41d3-fe05" typeName="Ranged Weapon" hidden="false" id="3ebc-1a39-73b8-fa23">
-                          <characteristics>
-                            <characteristic name="Rng" typeId="c6b5-908c-a604-1a98">24&quot;</characteristic>
-                            <characteristic name="Atk" typeId="aa17-4296-2887-e05d">1</characteristic>
-                            <characteristic name="Hit" typeId="194d-aeb6-5ba7-83b4">2+</characteristic>
-                            <characteristic name="Wnd" typeId="d3d5-9dc6-13de-8d1">3+</characteristic>
-                            <characteristic name="Rnd" typeId="d03f-a9ae-3eec-755">-</characteristic>
-                            <characteristic name="Dmg" typeId="96c2-d0a5-ea1e-653b">1</characteristic>
-                            <characteristic name="Ability" typeId="d793-3dd7-9c13-741e">-</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                      <constraints>
-                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8b47-6ee8-48fc-e831"/>
-                        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="a788-fdd9-45d4-eaa7"/>
-                      </constraints>
-                    </selectionEntry>
-                  </selectionEntries>
-                </selectionEntry>
-                <selectionEntry type="upgrade" import="true" name="Harpoon Launcher" hidden="false" id="7df2-009d-8c08-8601">
-                  <constraints>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="dadb-50c5-7bfe-d94c"/>
-                  </constraints>
-                  <selectionEntries>
-                    <selectionEntry type="upgrade" import="true" name="Harpoon Launcher" hidden="false" id="e7ec-092d-23b0-ec4a">
-                      <profiles>
-                        <profile name="Harpoon Launcher" typeId="1fd-a42f-41d3-fe05" typeName="Ranged Weapon" hidden="false" id="f447-7ba6-cdfe-181e">
-                          <characteristics>
-                            <characteristic name="Rng" typeId="c6b5-908c-a604-1a98">18&quot;</characteristic>
-                            <characteristic name="Atk" typeId="aa17-4296-2887-e05d">1</characteristic>
-                            <characteristic name="Hit" typeId="194d-aeb6-5ba7-83b4">4+</characteristic>
-                            <characteristic name="Wnd" typeId="d3d5-9dc6-13de-8d1">3+</characteristic>
-                            <characteristic name="Rnd" typeId="d03f-a9ae-3eec-755">1</characteristic>
-                            <characteristic name="Dmg" typeId="96c2-d0a5-ea1e-653b">D3</characteristic>
-                            <characteristic name="Ability" typeId="d793-3dd7-9c13-741e">-</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                      <constraints>
-                        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4fde-dc67-f34f-d1d3"/>
-                        <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="4424-52fe-aba8-1eac"/>
-                      </constraints>
-                    </selectionEntry>
-                  </selectionEntries>
-                </selectionEntry>
-              </selectionEntries>
-              <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="6da1-896a-f8f9-c4bc"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="a68d-6157-5047-798b"/>
-              </constraints>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
           <rules>
-            <rule name="Base Size" id="a904-c819-739a-b6e2" hidden="true">
+            <rule name="Base Size" id="bbe6-61a5-be32-5422" hidden="true">
               <description>120x92mm</description>
             </rule>
           </rules>
@@ -2773,61 +2050,72 @@
         </modifier>
       </modifiers>
     </selectionEntry>
-    <selectionEntry type="unit" import="true" name="Tyrant" hidden="false" id="8af5-807c-4c2e-2ceb" publicationId="1ac6-e227-a186-12">
+    <selectionEntry type="unit" import="true" name="Tyrant" hidden="false" id="8af5-807c-4c2e-2ceb" publicationId="feba-6749-6df3-ea9e">
       <entryLinks>
-        <entryLink import="true" name="General" hidden="false" id="9780-74ee-4b98-b0b1" type="selectionEntry" targetId="a56b-952e-ad15-7868"/>
+        <entryLink import="true" name="General" hidden="false" id="f1c1-e568-0258-3be7" type="selectionEntry" targetId="a56b-952e-ad15-7868"/>
       </entryLinks>
       <profiles>
-        <profile name="Tyrant" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="2cd5-7576-2bd1-d92">
+        <profile name="Tyrant" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="01ff-bfa7-6483-3f28">
           <characteristics>
             <characteristic name="Move" typeId="fed0-d1b3-1bb8-c501">6&quot;</characteristic>
             <characteristic name="Health" typeId="96be-54ae-ce7b-10b7">8</characteristic>
             <characteristic name="Save" typeId="1981-ef09-96f6-7aa9">4+</characteristic>
-            <characteristic name="Control" typeId="6c6f-8510-9ce1-fc6e">5</characteristic>
+            <characteristic name="Control" typeId="6c6f-8510-9ce1-fc6e">3</characteristic>
           </characteristics>
         </profile>
-        <profile name="Brawlerguts" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="b30d-c1ee-7640-2864">
+        <profile name="Big Name" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="67ef-f6b2-a976-c2ce">
           <characteristics>
-            <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
-            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">Add 1 to the D3 roll made when this unit uses the 'Trampling Charge' ability.</characteristic>
-          </characteristics>
-          <attributes>
-            <attribute name="Color" typeId="50fe-4f29-6bc3-dcc6">Orange</attribute>
-            <attribute name="Type" typeId="bf11-4e10-3ab1-06f4">Special</attribute>
-            <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
-          </attributes>
-        </profile>
-        <profile name="Bully of the First Degree" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="9ea2-2b60-ec50-12aa">
-          <characteristics>
-            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Your Hero Phase</characteristic>
-            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick another friendly **^^Ogor Mawtribes^^** unit wholly within 12&quot; of this unit to be the target.</characteristic>
-            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Add 3 to the target's control score until the start of your next turn.</characteristic>
+            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Deployment Phase</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb"/>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Pick 1 of the following effects to apply for the rest of the battle. You cannot pick an effect that has already been picked for another friendly **Tyrant**.
+
+• ***Neck-wringer***: Enemy **^^Infantry^^** units that have a Health characteristic of 1 or 2 cannot contest objectives while they are in combat with this unit.
+• ***Steed-eater***: Enemy **^^Cavalry^^** units cannot use **^^Retreat^^** abilities while they are in combat with this unit.
+• ***Giant-wrestler***: Enemy **^^Monsters^^** cannot use **^^Rampage^^** abilities while they are in combat with this unit.</characteristic>
             <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
             <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
           </characteristics>
           <attributes>
-            <attribute name="Color" typeId="5a11-eab3-180c-ddf5">Yellow</attribute>
-            <attribute name="Type" typeId="6d16-c86b-2698-85a4">Control</attribute>
+            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Black</attribute>
+            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Special</attribute>
+            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+          </attributes>
+        </profile>
+        <profile name="Brawlerguts" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="26f2-641a-ecbf-c706">
+          <characteristics>
+            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Reaction: You declared a Fight ability for this unit</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb"/>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Pick a visible friendly non-**^^Hero Ogor Mawtribes Infantry^^** unit that has not used a **^^Fight^^** ability this turn and is within this unit's combat range to be the target. The target can be picked to use a **^^Fight^^** ability immediately after the **^^Fight^^** ability used by this unit has been resolved. If it is picked to do so, add 1 to hit rolls for the target's combat attacks for the rest of the turn.</characteristic>
+            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+          </characteristics>
+          <attributes>
+            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Red</attribute>
+            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Offensive</attribute>
             <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
           </attributes>
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink name="HERO" hidden="false" id="5a3-2d11-e447-d1b4" targetId="6e72-1656-d554-528a" primary="true"/>
-        <categoryLink name="DESTRUCTION" hidden="false" id="6028-2bf2-2d43-49a2" targetId="9057-5a29-dda5-3c28" primary="false"/>
-        <categoryLink name="OGOR MAWTRIBES" hidden="false" id="83b3-8cf6-4134-178e" targetId="743-1bd8-e3d-ced2" primary="false"/>
-        <categoryLink name="INFANTRY" hidden="false" id="1546-706f-481e-3e62" targetId="75d6-6995-dfcc-3898" primary="false"/>
-        <categoryLink name="OGOR" hidden="false" id="4b67-aeeb-96f1-9e0f" targetId="ddcb-3c91-472f-c35a" primary="false"/>
-        <categoryLink name="GUTBUSTERS" hidden="false" id="a3ea-1ae1-69eb-c48f" targetId="5c0d-5e93-d71f-f0da" primary="false"/>
+        <categoryLink name="HERO" hidden="false" id="5607-3925-f099-2acf" targetId="6e72-1656-d554-528a" primary="true"/>
+        <categoryLink name="INFANTRY" hidden="false" id="666c-14dd-0e2c-53db" targetId="75d6-6995-dfcc-3898" primary="false"/>
+        <categoryLink name="DESTRUCTION" hidden="false" id="60cc-fe67-9c26-af69" targetId="9057-5a29-dda5-3c28" primary="false"/>
+        <categoryLink name="OGOR MAWTRIBES" hidden="false" id="78e3-c178-b544-d2c8" targetId="743-1bd8-e3d-ced2" primary="false"/>
+        <categoryLink name="OGOR" hidden="false" id="9b78-6461-dd11-3d0e" targetId="ddcb-3c91-472f-c35a" primary="false"/>
+        <categoryLink name="GUTBUSTERS" hidden="false" id="46b8-adb7-e3a9-4dec" targetId="5c0d-5e93-d71f-f0da" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry type="model" import="true" name="Tyrant" hidden="false" id="8a3b-c384-deff-ce72">
+        <selectionEntry type="model" import="true" name="Tyrant" hidden="false" id="afbf-49ea-1a49-afe9">
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="a7aa-be15-cb09-5c81"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="91c5-83b1-090c-b020"/>
+          </constraints>
           <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Thundermace" hidden="false" id="2810-40b-bf84-eb30">
+            <selectionEntry type="upgrade" import="true" name="Tyrant&apos;s Meatcleavers" hidden="false" id="7601-89b3-c8e7-f6f5">
               <profiles>
-                <profile name="Thundermace" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="c343-66f5-985c-d003">
+                <profile name="Tyrant&apos;s Meatcleavers" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="f0eb-11ad-dfd5-b891">
                   <characteristics>
-                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">3</characteristic>
+                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">4</characteristic>
                     <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">4+</characteristic>
                     <characteristic name="Wnd" typeId="61c1-22cc-40af-2847">2+</characteristic>
                     <characteristic name="Rnd" typeId="eccc-10fa-6958-fb73">2</characteristic>
@@ -2837,136 +2125,18 @@
                 </profile>
               </profiles>
               <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="51c4-9b20-ac9e-7f9f"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="be9e-c96c-3845-50ab"/>
-              </constraints>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Beastskewer Glaive" hidden="false" id="db34-10c1-3095-a9a0">
-              <profiles>
-                <profile name="Beastskewer Glaive" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="6661-c23a-af46-a6e1">
-                  <characteristics>
-                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">2</characteristic>
-                    <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">4+</characteristic>
-                    <characteristic name="Wnd" typeId="61c1-22cc-40af-2847">2+</characteristic>
-                    <characteristic name="Rnd" typeId="eccc-10fa-6958-fb73">1</characteristic>
-                    <characteristic name="Dmg" typeId="e948-9c71-12a6-6be4">2</characteristic>
-                    <characteristic name="Ability" typeId="eda3-7332-5db1-4159">Anti-**^^Monster^^** (+1 Rend)</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="9609-eaa2-fc83-3c2b"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="667b-5862-23b1-8a0b"/>
-              </constraints>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Ogor Pistols" hidden="false" id="5189-3063-3708-873e">
-              <profiles>
-                <profile name="Ogor Pistols" typeId="1fd-a42f-41d3-fe05" typeName="Ranged Weapon" hidden="false" id="43b6-d4f5-e7a9-12f5">
-                  <characteristics>
-                    <characteristic name="Rng" typeId="c6b5-908c-a604-1a98">10&quot;</characteristic>
-                    <characteristic name="Atk" typeId="aa17-4296-2887-e05d">2</characteristic>
-                    <characteristic name="Hit" typeId="194d-aeb6-5ba7-83b4">4+</characteristic>
-                    <characteristic name="Wnd" typeId="d3d5-9dc6-13de-8d1">3+</characteristic>
-                    <characteristic name="Rnd" typeId="d03f-a9ae-3eec-755">1</characteristic>
-                    <characteristic name="Dmg" typeId="96c2-d0a5-ea1e-653b">D3</characteristic>
-                    <characteristic name="Ability" typeId="d793-3dd7-9c13-741e">Shoot in Combat</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="90f8-b69a-c167-3826"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="f4d5-fe36-97e-3e6a"/>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="87d6-3bdd-bda1-14c1"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="28b1-0839-f2c4-ee6f"/>
               </constraints>
             </selectionEntry>
           </selectionEntries>
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="209c-bd56-3b9b-17a2"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="1a90-1810-1fca-325d"/>
-          </constraints>
           <rules>
-            <rule name="Base Size" id="495b-40e8-1b31-a016" hidden="true">
+            <rule name="Base Size" id="e753-239f-04ee-e4cc" hidden="true">
               <description>50mm</description>
             </rule>
           </rules>
         </selectionEntry>
       </selectionEntries>
-    </selectionEntry>
-    <selectionEntry type="unit" import="true" name="Frost Sabres" hidden="false" id="bdf9-1644-707-f0df" publicationId="1ac6-e227-a186-12">
-      <profiles>
-        <profile name="Frost Sabres" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="343a-5c3b-d57c-8e3f">
-          <characteristics>
-            <characteristic name="Move" typeId="fed0-d1b3-1bb8-c501">9&quot;</characteristic>
-            <characteristic name="Health" typeId="96be-54ae-ce7b-10b7">3</characteristic>
-            <characteristic name="Save" typeId="1981-ef09-96f6-7aa9">6+</characteristic>
-            <characteristic name="Control" typeId="6c6f-8510-9ce1-fc6e">1</characteristic>
-          </characteristics>
-        </profile>
-        <profile name="Hunters of the Frozen Wilds" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="4659-aaed-5769-40f3">
-          <characteristics>
-            <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
-            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">This unit is not visible to enemy units while it is within 3&quot; of a terrain feature and more than 9&quot; from all enemy units.</characteristic>
-          </characteristics>
-          <attributes>
-            <attribute name="Color" typeId="50fe-4f29-6bc3-dcc6">Green</attribute>
-            <attribute name="Type" typeId="bf11-4e10-3ab1-06f4">Defensive</attribute>
-            <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
-          </attributes>
-        </profile>
-      </profiles>
-      <categoryLinks>
-        <categoryLink name="OGOR MAWTRIBES" hidden="false" id="5d52-99e5-9fc8-3a93" targetId="743-1bd8-e3d-ced2" primary="false"/>
-        <categoryLink name="DESTRUCTION" hidden="false" id="cf-ff21-afdd-1cd3" targetId="9057-5a29-dda5-3c28" primary="false"/>
-        <categoryLink name="BEAST" hidden="false" id="f874-6ee0-f64b-761c" targetId="b224-8c8e-ca93-9860" primary="true"/>
-        <categoryLink name="BEASTCLAW RAIDERS" hidden="false" id="70b9-4dcc-cf8b-ce89" targetId="1a3d-33f9-c4cc-fe0" primary="false"/>
-      </categoryLinks>
-      <selectionEntries>
-        <selectionEntry type="model" import="true" name="Frost Sabre" hidden="false" id="ff22-edda-bf1c-6de1" defaultAmount="2">
-          <constraints>
-            <constraint type="min" value="2" field="selections" scope="parent" shared="false" id="48d1-272a-3da2-de"/>
-            <constraint type="max" value="2" field="selections" scope="parent" shared="false" id="9cff-ff53-3dbc-5b40"/>
-          </constraints>
-          <modifiers>
-            <modifier type="increment" value="2" field="48d1-272a-3da2-de">
-              <repeats>
-                <repeat value="1" repeats="1" field="selections" scope="bdf9-1644-707-f0df" childId="1b37-82b8-c062-eb82" shared="true" roundUp="false"/>
-              </repeats>
-            </modifier>
-            <modifier type="increment" value="2" field="9cff-ff53-3dbc-5b40">
-              <repeats>
-                <repeat value="1" repeats="1" field="selections" scope="bdf9-1644-707-f0df" childId="1b37-82b8-c062-eb82" shared="true" roundUp="false"/>
-              </repeats>
-            </modifier>
-          </modifiers>
-          <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Tusks and Claws" hidden="false" id="9fe7-4ca7-2b5d-b6da">
-              <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="6de8-fd16-d86-113a"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="afca-d218-c049-dab4"/>
-              </constraints>
-              <profiles>
-                <profile name="Tusks and Claws" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="cee1-6bd7-fcc1-d28c">
-                  <characteristics>
-                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">3</characteristic>
-                    <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">4+</characteristic>
-                    <characteristic name="Wnd" typeId="61c1-22cc-40af-2847">3+</characteristic>
-                    <characteristic name="Rnd" typeId="eccc-10fa-6958-fb73">1</characteristic>
-                    <characteristic name="Dmg" typeId="e948-9c71-12a6-6be4">1</characteristic>
-                    <characteristic name="Ability" typeId="eda3-7332-5db1-4159">-</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-          </selectionEntries>
-          <rules>
-            <rule name="Base Size" id="8211-b56a-3619-4357" hidden="true">
-              <description>60x35mm</description>
-            </rule>
-          </rules>
-        </selectionEntry>
-      </selectionEntries>
-      <infoLinks>
-        <infoLink name="Beast" id="ccc9-33e2-bd41-5361" hidden="false" type="profile" targetId="8e01-c681-8a44-8f44"/>
-      </infoLinks>
     </selectionEntry>
     <selectionEntry type="unit" import="true" name="Leadbelchers" hidden="false" id="15cd-469c-4ed6-afef" publicationId="1ac6-e227-a186-12">
       <profiles>
@@ -3091,537 +2261,160 @@
         </selectionEntry>
       </selectionEntries>
     </selectionEntry>
-    <selectionEntry type="unit" import="true" name="Icebrow Hunter" hidden="false" id="8ea1-2719-4da0-2b1f" publicationId="1ac6-e227-a186-12">
-      <entryLinks>
-        <entryLink import="true" name="General" hidden="false" id="d23b-ec94-dd1d-159a" type="selectionEntry" targetId="a56b-952e-ad15-7868"/>
-      </entryLinks>
+    <selectionEntry type="unit" import="true" name="Mawpit" hidden="false" id="8e60-2852-1bfc-272" publicationId="feba-6749-6df3-ea9e">
       <profiles>
-        <profile name="Icebrow Hunter" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="1865-2c41-af66-d56e">
+        <profile name="Mawpit" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="36b0-fda4-b17a-9a4a">
           <characteristics>
-            <characteristic name="Move" typeId="fed0-d1b3-1bb8-c501">6&quot;</characteristic>
-            <characteristic name="Health" typeId="96be-54ae-ce7b-10b7">7</characteristic>
-            <characteristic name="Save" typeId="1981-ef09-96f6-7aa9">5+</characteristic>
-            <characteristic name="Control" typeId="6c6f-8510-9ce1-fc6e">5</characteristic>
+            <characteristic name="Move" typeId="fed0-d1b3-1bb8-c501">-</characteristic>
+            <characteristic name="Health" typeId="96be-54ae-ce7b-10b7">12</characteristic>
+            <characteristic name="Save" typeId="1981-ef09-96f6-7aa9">4+</characteristic>
+            <characteristic name="Control" typeId="6c6f-8510-9ce1-fc6e">-</characteristic>
           </characteristics>
         </profile>
-        <profile name="Masters of Ambush" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="b4f2-dae1-5bcb-a57a">
+        <profile name="Hungry Sinkhole" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="4afc-abf2-4777-fa14">
           <characteristics>
-            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Deployment Phase</characteristic>
-            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick this unit and up to 2 friendly **Frost Sabres** units if those units have not been deployed.</characteristic>
-            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Set up those units in reserve **outflanking the prey**. They have now been deployed.</characteristic>
-            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f">**^^Deploy^^**</characteristic>
-            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
-          </characteristics>
-          <attributes>
-            <attribute name="Color" typeId="5a11-eab3-180c-ddf5">Black</attribute>
-            <attribute name="Type" typeId="6d16-c86b-2698-85a4">Special</attribute>
-            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
-          </attributes>
-        </profile>
-        <profile name="The Hunt Is On" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="166-c7f0-b1cf-33e8">
-          <characteristics>
-            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Your Movement Phase</characteristic>
-            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick this unit if it is **outflanking the prey**.</characteristic>
-            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Set up this unit wholly within 9&quot; of a battlefield edge and more than 9&quot; from all enemy units. Then, set up each **Frost Sabres** unit that was set up **outflanking the prey** with this unit wholly within 12&quot; of it and more than 9&quot; from all enemy units.</characteristic>
+            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Turn (Army), End of Any Turn</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick this **Mawpit** to be a **sinkhole**. Then, you can pick another terrain feature within 12&quot; of this **Mawpit** and that you have already picked to be a **sinkhole** this battle to be a **sinkhole** for the rest of the turn. Then, pick every enemy unit within 3&quot; of the **sinkhole(s)** to be targets.</characteristic>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Roll a D3 for each target. On a 2+, inflict an amount of mortal damage on the target equal to the roll. From the second battle round onwards, increase the range at which another terrain feature can be picked to be a **sinkhole** by 3&quot; each battle round. If this terrain feature has a **Head Butcher**, increase the range at which another terrain feature can be picked to be a **sinkhole** by 6&quot; that turn instead of 3&quot;. This effect is cumulative.</characteristic>
             <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
             <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
           </characteristics>
           <attributes>
-            <attribute name="Color" typeId="5a11-eab3-180c-ddf5">Gray</attribute>
-            <attribute name="Type" typeId="6d16-c86b-2698-85a4">Movement</attribute>
+            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Purple</attribute>
+            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Offensive</attribute>
+            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+          </attributes>
+        </profile>
+        <profile name="Feed the Maw" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="0856-aeb1-2830-2553">
+          <characteristics>
+            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Your Hero Phase</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">If this terrain feature does not have a **Head Butcher**, pick a friendly **Butcher** within 3&quot; of it and not in combat to be the target.</characteristic>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Place the target on this terrain feature. The target is now a **Head Butcher** (see 'Hungry Sinkhole').</characteristic>
+            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+          </characteristics>
+          <attributes>
+            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Yellow</attribute>
+            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Movement</attribute>
+            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+          </attributes>
+        </profile>
+        <profile name="Step Away from the Maw" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="35cf-4d00-b749-7096">
+          <characteristics>
+            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Your Movement Phase</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb"/>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">If this terrain feature has a **Head Butcher** that was not placed on it this turn, set up the **Head Butcher** on the battlefield wholly within 3&quot; of this terrain feature and not in combat. That unit is no longer a **Head Butcher**.</characteristic>
+            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+          </characteristics>
+          <attributes>
+            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Gray</attribute>
+            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Movement</attribute>
             <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
           </attributes>
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink name="HERO" hidden="false" id="dfd7-5488-ce47-a3d7" targetId="6e72-1656-d554-528a" primary="true"/>
-        <categoryLink name="DESTRUCTION" hidden="false" id="9087-af28-325c-589c" targetId="9057-5a29-dda5-3c28" primary="false"/>
-        <categoryLink name="OGOR MAWTRIBES" hidden="false" id="136c-eb6a-4143-2f86" targetId="743-1bd8-e3d-ced2" primary="false"/>
-        <categoryLink name="INFANTRY" hidden="false" id="86ff-142e-51c-48bc" targetId="75d6-6995-dfcc-3898" primary="false"/>
-        <categoryLink name="OGOR" hidden="false" id="11cf-a129-32f2-133b" targetId="ddcb-3c91-472f-c35a" primary="false"/>
-        <categoryLink name="BEASTCLAW RAIDERS" hidden="false" id="db40-8cfe-e17b-3d98" targetId="1a3d-33f9-c4cc-fe0" primary="false"/>
+        <categoryLink name="FACTION TERRAIN" hidden="false" id="242c-0eb8-96d8-0115" targetId="cdd6-ffa1-9b32-4cb8" primary="true"/>
+        <categoryLink name="DESTRUCTION" hidden="false" id="0817-0379-0409-25b1" targetId="9057-5a29-dda5-3c28" primary="false"/>
+        <categoryLink name="OGOR MAWTRIBES" hidden="false" id="24ee-d3e8-67c4-3036" targetId="743-1bd8-e3d-ced2" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry type="model" import="true" name="Icebrow Hunter" hidden="false" id="3a2c-8e6-4439-9c84">
-          <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Culling Club" hidden="false" id="3f64-7243-e90d-ab5d">
-              <profiles>
-                <profile name="Culling Club" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="8e54-8457-3296-f432">
-                  <characteristics>
-                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">4</characteristic>
-                    <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">4+</characteristic>
-                    <characteristic name="Wnd" typeId="61c1-22cc-40af-2847">2+</characteristic>
-                    <characteristic name="Rnd" typeId="eccc-10fa-6958-fb73">-</characteristic>
-                    <characteristic name="Dmg" typeId="e948-9c71-12a6-6be4">1</characteristic>
-                    <characteristic name="Ability" typeId="eda3-7332-5db1-4159">Anti-**^^Monster^^** (+1 Rend)</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="5cbf-dd27-d0da-6791"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="84ba-f5d7-44d9-f903"/>
-              </constraints>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Hunter&apos;s Crossbow" hidden="false" id="2efb-4abb-d000-8b93">
-              <profiles>
-                <profile name="Hunter&apos;s Crossbow" typeId="1fd-a42f-41d3-fe05" typeName="Ranged Weapon" hidden="false" id="13ea-3879-837c-235e">
-                  <characteristics>
-                    <characteristic name="Rng" typeId="c6b5-908c-a604-1a98">12&quot;</characteristic>
-                    <characteristic name="Atk" typeId="aa17-4296-2887-e05d">1</characteristic>
-                    <characteristic name="Hit" typeId="194d-aeb6-5ba7-83b4">4+</characteristic>
-                    <characteristic name="Wnd" typeId="d3d5-9dc6-13de-8d1">2+</characteristic>
-                    <characteristic name="Rnd" typeId="d03f-a9ae-3eec-755">-</characteristic>
-                    <characteristic name="Dmg" typeId="96c2-d0a5-ea1e-653b">D3</characteristic>
-                    <characteristic name="Ability" typeId="d793-3dd7-9c13-741e">Anti-**^^Monster^^** (+1 Rend)</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="e070-44a1-ab8c-b44"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ab0f-4d3a-43a6-f85f"/>
-              </constraints>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Great Throwing Spear" hidden="false" id="9483-f961-5fc5-f52d">
-              <profiles>
-                <profile name="Great Throwing Spear" typeId="1fd-a42f-41d3-fe05" typeName="Ranged Weapon" hidden="false" id="1ec1-3c5f-b756-9ba0">
-                  <characteristics>
-                    <characteristic name="Rng" typeId="c6b5-908c-a604-1a98">10&quot;</characteristic>
-                    <characteristic name="Atk" typeId="aa17-4296-2887-e05d">1</characteristic>
-                    <characteristic name="Hit" typeId="194d-aeb6-5ba7-83b4">4+</characteristic>
-                    <characteristic name="Wnd" typeId="d3d5-9dc6-13de-8d1">3+</characteristic>
-                    <characteristic name="Rnd" typeId="d03f-a9ae-3eec-755">1</characteristic>
-                    <characteristic name="Dmg" typeId="96c2-d0a5-ea1e-653b">D3</characteristic>
-                    <characteristic name="Ability" typeId="d793-3dd7-9c13-741e">Anti-**^^Monster^^** (+1 Rend)</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="353-f3ce-5618-7f82"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="166a-22ac-4e34-c696"/>
-              </constraints>
-            </selectionEntry>
-          </selectionEntries>
+        <selectionEntry type="upgrade" import="true" name="Ever-hungry Pit" hidden="false" id="8376-e2ae-b242-b4fd">
+          <profiles>
+            <profile name="Ever-hungry Pit" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="d257-5672-ac21-2316">
+              <characteristics>
+                <characteristic name="Atk" typeId="60e-35aa-31ed-e488">2D6</characteristic>
+                <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">4+</characteristic>
+                <characteristic name="Wnd" typeId="61c1-22cc-40af-2847">2+</characteristic>
+                <characteristic name="Rnd" typeId="eccc-10fa-6958-fb73">1</characteristic>
+                <characteristic name="Dmg" typeId="e948-9c71-12a6-6be4">1</characteristic>
+                <characteristic name="Ability" typeId="eda3-7332-5db1-4159">Crit (Mortal)</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
           <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="280-b9a8-7efd-afc5"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="7af1-19c4-b276-2082"/>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="436f-2682-901d-8190"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="9a36-524c-e5dc-7135"/>
           </constraints>
-          <rules>
-            <rule name="Base Size" id="554d-c614-1cef-a582" hidden="true">
-              <description>50mm</description>
-            </rule>
-          </rules>
         </selectionEntry>
       </selectionEntries>
+      <rules>
+        <rule name="Mawpit" id="e7f2-f3ce-0124-25c9" hidden="false">
+          <description>**The following universal terrain abilities apply to this terrain feature (Terrain, 1.2):
+Cover, Impassable**</description>
+        </rule>
+        <rule name="Base Size" id="fb60-b76b-2d11-a98b" hidden="true">
+          <description>Use model</description>
+        </rule>
+      </rules>
     </selectionEntry>
-    <selectionEntry type="unit" import="true" name="Mournfang Pack" hidden="false" id="b91b-cba6-89af-7225" publicationId="1ac6-e227-a186-12">
+    <selectionEntry type="unit" import="true" name="Ironguts" hidden="false" id="7ea4-f81b-b7cc-b16e" publicationId="feba-6749-6df3-ea9e">
       <profiles>
-        <profile name="Mournfang Pack" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="9fe6-b824-610c-cc8a">
+        <profile name="Ironguts" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="b434-ddda-69d0-aa7b">
           <characteristics>
-            <characteristic name="Move" typeId="fed0-d1b3-1bb8-c501">9&quot;</characteristic>
-            <characteristic name="Health" typeId="96be-54ae-ce7b-10b7">6</characteristic>
+            <characteristic name="Move" typeId="fed0-d1b3-1bb8-c501">6&quot;</characteristic>
+            <characteristic name="Health" typeId="96be-54ae-ce7b-10b7">4</characteristic>
             <characteristic name="Save" typeId="1981-ef09-96f6-7aa9">4+</characteristic>
             <characteristic name="Control" typeId="6c6f-8510-9ce1-fc6e">2</characteristic>
           </characteristics>
         </profile>
-        <profile name="Alpha Cavalry" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="aedb-3fcf-b1c9-b703">
+        <profile name="Personal Enforcers" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="5cd8-db3f-7f9a-d865">
           <characteristics>
             <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
-            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">The **Charge (+1 Damage)** weapon ability has no effect on attacks that target this unit.</characteristic>
+            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">While this unit is within the combat ranges of any friendly **^^Ogor Mawtribes Infantry Heroes^^**, both this unit and those **^^Heroes^^** have **^^Ward (5+)^^**.</characteristic>
           </characteristics>
           <attributes>
-            <attribute name="Color" typeId="50fe-4f29-6bc3-dcc6">Black</attribute>
-            <attribute name="Type" typeId="bf11-4e10-3ab1-06f4">Special</attribute>
+            <attribute typeId="50fe-4f29-6bc3-dcc6" name="Color">Green</attribute>
+            <attribute typeId="bf11-4e10-3ab1-06f4" name="Type">Defensive</attribute>
             <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
           </attributes>
         </profile>
-        <profile name="Lumpen Wall of Flesh" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="3c2-be9b-e291-75a1">
+        <profile name="Displays of Might" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="c910-44a2-7095-5a2b">
           <characteristics>
-            <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
-            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">Subtract 1 from wound rolls for shooting attacks that target friendly **^^Beastclaw Raiders^^** units while they are within this unit's combat range.</characteristic>
+            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Turn (Army), Any Charge Phase</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb"/>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">This unit can use the 'Bull Charge' ability even if another friendly unit has used it this turn.</characteristic>
+            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
           </characteristics>
           <attributes>
-            <attribute name="Color" typeId="50fe-4f29-6bc3-dcc6">Green</attribute>
-            <attribute name="Type" typeId="bf11-4e10-3ab1-06f4">Defensive</attribute>
-            <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
+            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Orange</attribute>
+            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Offensive</attribute>
+            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
           </attributes>
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink name="CHAMPION" hidden="false" id="769f-1572-2cf3-8c5b" targetId="f679-3bcb-d664-9ac3" primary="false"/>
-        <categoryLink name="OGOR MAWTRIBES" hidden="false" id="bf8f-f93a-4caf-d724" targetId="743-1bd8-e3d-ced2" primary="false"/>
-        <categoryLink name="DESTRUCTION" hidden="false" id="d7d4-b41e-47a5-ab04" targetId="9057-5a29-dda5-3c28" primary="false"/>
-        <categoryLink name="OGOR" hidden="false" id="8789-5af5-e267-80f0" targetId="ddcb-3c91-472f-c35a" primary="false"/>
-        <categoryLink name="MUSICIAN (1/4)" hidden="false" id="5817-52fa-639f-52f4" targetId="fe9c-1d27-a698-5f31" primary="false"/>
-        <categoryLink name="STANDARD BEARER (1/4)" hidden="false" id="5336-4224-b811-a441" targetId="7528-e097-91b0-f4f9" primary="false"/>
-        <categoryLink name="CAVALRY" hidden="false" id="a85e-1ee5-4e0f-ed07" targetId="926c-df8c-6841-d49e" primary="true"/>
-        <categoryLink name="BEASTCLAW RAIDERS" hidden="false" id="f0dc-2790-18cc-d999" targetId="1a3d-33f9-c4cc-fe0" primary="false"/>
+        <categoryLink name="INFANTRY" hidden="false" id="6227-bc3a-88b6-762e" targetId="75d6-6995-dfcc-3898" primary="true"/>
+        <categoryLink name="CHAMPION" hidden="false" id="f34e-245f-a43f-7e2b" targetId="f679-3bcb-d664-9ac3" primary="false"/>
+        <categoryLink name="DESTRUCTION" hidden="false" id="3333-9efd-7313-92c4" targetId="9057-5a29-dda5-3c28" primary="false"/>
+        <categoryLink name="OGOR MAWTRIBES" hidden="false" id="0c99-4f3d-97cb-d246" targetId="743-1bd8-e3d-ced2" primary="false"/>
+        <categoryLink name="OGOR" hidden="false" id="883f-84c8-bc60-6304" targetId="ddcb-3c91-472f-c35a" primary="false"/>
+        <categoryLink name="GUTBUSTERS" hidden="false" id="9e0a-1f48-1e6b-d87f" targetId="5c0d-5e93-d71f-f0da" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry type="model" import="true" name="Mournfang" hidden="false" id="8bf5-b52e-76a-a6ce" defaultAmount="1,1">
+        <selectionEntry type="model" import="true" name="Irongut" hidden="false" id="3587-5bf8-4647-5932" defaultAmount="1,2">
           <constraints>
-            <constraint type="min" value="2" field="selections" scope="parent" shared="false" id="1111-cd61-e080-95b8"/>
-            <constraint type="max" value="2" field="selections" scope="parent" shared="false" id="9ea2-7f14-d4f9-e78c"/>
+            <constraint type="min" value="3" field="selections" scope="parent" shared="false" id="d77a-cd43-838a-f37a"/>
+            <constraint type="max" value="3" field="selections" scope="parent" shared="false" id="4965-f1ec-0120-5763"/>
           </constraints>
           <modifiers>
-            <modifier type="increment" value="2" field="1111-cd61-e080-95b8">
-              <repeats>
-                <repeat value="1" repeats="1" field="selections" scope="b91b-cba6-89af-7225" childId="1b37-82b8-c062-eb82" shared="true" roundUp="false"/>
-              </repeats>
-            </modifier>
-            <modifier type="increment" value="2" field="9ea2-7f14-d4f9-e78c">
-              <repeats>
-                <repeat value="1" repeats="1" field="selections" scope="b91b-cba6-89af-7225" childId="1b37-82b8-c062-eb82" shared="true" roundUp="false"/>
-              </repeats>
-            </modifier>
-          </modifiers>
-          <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Mournfang Rider Weapon" hidden="false" id="43c-cfb6-e4b5-d9cf">
-              <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="bfa9-21e3-2241-9b"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="65d0-31f0-73e9-f261"/>
-              </constraints>
-              <profiles>
-                <profile name="Mournfang Rider Weapon" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="e994-67d8-c77e-4ae5">
-                  <characteristics>
-                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">3</characteristic>
-                    <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">4+</characteristic>
-                    <characteristic name="Wnd" typeId="61c1-22cc-40af-2847">2+</characteristic>
-                    <characteristic name="Rnd" typeId="eccc-10fa-6958-fb73">1</characteristic>
-                    <characteristic name="Dmg" typeId="e948-9c71-12a6-6be4">2</characteristic>
-                    <characteristic name="Ability" typeId="eda3-7332-5db1-4159">Anti-**^^Cavalry^^** (+1 Rend)</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Mournfang&apos;s Tusks" hidden="false" id="9fc3-9e71-5da-c7da">
-              <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="7a50-4840-338e-95ea"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="a5b4-124a-9b89-cbc0"/>
-              </constraints>
-              <profiles>
-                <profile name="Mournfang&apos;s Tusks" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="70cf-ed25-c637-e60e">
-                  <characteristics>
-                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">4</characteristic>
-                    <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">4+</characteristic>
-                    <characteristic name="Wnd" typeId="61c1-22cc-40af-2847">2+</characteristic>
-                    <characteristic name="Rnd" typeId="eccc-10fa-6958-fb73">1</characteristic>
-                    <characteristic name="Dmg" typeId="e948-9c71-12a6-6be4">2</characteristic>
-                    <characteristic name="Ability" typeId="eda3-7332-5db1-4159">Companion</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Ironlock Pistol" hidden="false" id="262e-28e0-3f84-5967">
-              <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="86a8-34ce-c79a-acf3" automatic="true"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="5285-c12f-ecce-bb05" automatic="true"/>
-              </constraints>
-              <profiles>
-                <profile name="Ironlock Pistol" typeId="1fd-a42f-41d3-fe05" typeName="Ranged Weapon" hidden="false" id="7386-d945-36a3-ac92">
-                  <characteristics>
-                    <characteristic name="Rng" typeId="c6b5-908c-a604-1a98">10&quot;</characteristic>
-                    <characteristic name="Atk" typeId="aa17-4296-2887-e05d">1</characteristic>
-                    <characteristic name="Hit" typeId="194d-aeb6-5ba7-83b4">4+</characteristic>
-                    <characteristic name="Wnd" typeId="d3d5-9dc6-13de-8d1">3+</characteristic>
-                    <characteristic name="Rnd" typeId="d03f-a9ae-3eec-755">1</characteristic>
-                    <characteristic name="Dmg" typeId="96c2-d0a5-ea1e-653b">D3</characteristic>
-                    <characteristic name="Ability" typeId="d793-3dd7-9c13-741e">Shoot in Combat</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <modifiers>
-                <modifier type="set" value="0" field="5285-c12f-ecce-bb05">
-                  <conditions>
-                    <condition type="lessThan" value="1" field="selections" scope="parent" childId="31e7-5cb6-3efe-99c3" shared="true"/>
-                  </conditions>
-                </modifier>
-                <modifier type="set" value="0" field="86a8-34ce-c79a-acf3">
-                  <conditions>
-                    <condition type="lessThan" value="1" field="selections" scope="parent" childId="31e7-5cb6-3efe-99c3" shared="true"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups>
-            <selectionEntryGroup name="Command Models" id="ac09-9b3e-8a4a-d40f" hidden="false">
-              <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="53fb-64f0-505f-fc39"/>
-              </constraints>
-              <entryLinks>
-                <entryLink import="true" name="Champion" hidden="false" id="31e7-5cb6-3efe-99c3" type="selectionEntry" targetId="9c21-1746-9873-a5b5" defaultAmount="1,0">
-                  <constraints>
-                    <constraint type="max" value="1" field="selections" scope="b91b-cba6-89af-7225" shared="true" id="39b7-f889-a2ee-f0ba" includeChildSelections="true"/>
-                  </constraints>
-                </entryLink>
-                <entryLink import="true" name="Standard Bearer" hidden="false" id="5ad5-5d3b-a307-fcac" type="selectionEntry" targetId="7f34-77c9-597-62c3" defaultAmount="0">
-                  <constraints>
-                    <constraint type="max" value="0" field="selections" scope="b91b-cba6-89af-7225" shared="true" id="11fb-bc3b-b32-7aa7" includeChildSelections="true"/>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="226f-38fb-3432-fa76"/>
-                  </constraints>
-                  <modifiers>
-                    <modifier type="increment" value="1" field="11fb-bc3b-b32-7aa7">
-                      <repeats>
-                        <repeat value="1" repeats="1" field="selections" scope="root-entry" childId="1b37-82b8-c062-eb82" shared="true" roundUp="false" includeChildSelections="true"/>
-                      </repeats>
-                    </modifier>
-                  </modifiers>
-                </entryLink>
-                <entryLink import="true" name="Musician" hidden="false" id="62e5-5365-2d6b-b95c" type="selectionEntry" targetId="2475-183b-3802-4431" defaultAmount="0">
-                  <constraints>
-                    <constraint type="max" value="0" field="selections" scope="b91b-cba6-89af-7225" shared="true" id="2838-a10e-f05f-71df" includeChildSelections="true"/>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="77ee-a6f8-8dc3-6b9d"/>
-                  </constraints>
-                  <modifiers>
-                    <modifier type="increment" value="1" field="2838-a10e-f05f-71df">
-                      <repeats>
-                        <repeat value="1" repeats="1" field="selections" scope="root-entry" childId="1b37-82b8-c062-eb82" shared="true" roundUp="false" includeChildSelections="true"/>
-                      </repeats>
-                    </modifier>
-                  </modifiers>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <rules>
-            <rule name="Base Size" id="472e-0ead-edef-95b4" hidden="true">
-              <description>90x52mm</description>
-            </rule>
-          </rules>
-        </selectionEntry>
-      </selectionEntries>
-    </selectionEntry>
-    <selectionEntry type="unit" import="true" name="Mawpit" hidden="false" id="8e60-2852-1bfc-272" publicationId="1ac6-e227-a186-12">
-      <categoryLinks>
-        <categoryLink name="FACTION TERRAIN" hidden="false" id="cd2a-b01b-6e14-7ee6" targetId="cdd6-ffa1-9b32-4cb8" primary="true"/>
-        <categoryLink name="DESTRUCTION" hidden="false" id="4ef8-e7bf-bf9-5b11" targetId="9057-5a29-dda5-3c28" primary="false"/>
-        <categoryLink name="OGOR MAWTRIBES" hidden="false" id="dce7-f257-2189-c560" targetId="743-1bd8-e3d-ced2" primary="false"/>
-      </categoryLinks>
-      <profiles>
-        <profile name="Altar of the Gulping God" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="c82e-b7f6-85d4-2b78">
-          <characteristics>
-            <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
-            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">While this terrain feature has a Head Butcher:
-• The Head Butcher cannot use **^^Move^^** abilities.
-• Instead of measuring range or visibility to the Head Butcher, measure to this terrain feature instead.
-• All attacks that would target the Head Butcher target this terrain feature instead.
-• If this terrain feature is destroyed, before removing it from the battlefield, inflict D3 mortal damage on the Head Butcher. Then, set up the Head Butcher on the battlefield wholly within 3&quot; of this terrain feature and not in combat. That unit is no longer a Head Butcher. If it is not possible to set up the Head Butcher, it is slain.</characteristic>
-          </characteristics>
-          <attributes>
-            <attribute name="Color" typeId="50fe-4f29-6bc3-dcc6">Black</attribute>
-            <attribute name="Type" typeId="bf11-4e10-3ab1-06f4">Special</attribute>
-            <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
-          </attributes>
-        </profile>
-        <profile name="Mawpit" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="3644-72a5-3bb-76a6">
-          <characteristics>
-            <characteristic name="Move" typeId="fed0-d1b3-1bb8-c501">-</characteristic>
-            <characteristic name="Health" typeId="96be-54ae-ce7b-10b7">10</characteristic>
-            <characteristic name="Save" typeId="1981-ef09-96f6-7aa9">5+</characteristic>
-            <characteristic name="Control" typeId="6c6f-8510-9ce1-fc6e">-</characteristic>
-          </characteristics>
-        </profile>
-        <profile name="Feed the Maw" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="9e65-513c-51a2-2350">
-          <characteristics>
-            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Your Hero Phase</characteristic>
-            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">If this terrain feature does not have a Head Butcher, pick a friendly **Butcher** or **Slaughtermaster** within 3&quot; of it and not in combat to be the target.</characteristic>
-            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Place the target on this terrain feature. The target is now a Head Butcher (see 'Altar of the Gulping God').</characteristic>
-            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
-            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
-          </characteristics>
-          <attributes>
-            <attribute name="Color" typeId="5a11-eab3-180c-ddf5">Yellow</attribute>
-            <attribute name="Type" typeId="6d16-c86b-2698-85a4">Movement</attribute>
-            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
-          </attributes>
-        </profile>
-        <profile name="Throat of Ghur" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="2b9e-ae8-6d0c-c670">
-          <characteristics>
-            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Any Hero Phase</characteristic>
-            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick up to 3 enemy units within 12&quot; of this terrain feature, or within 18&quot; if it has a Head Butcher, to be the targets.</characteristic>
-            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Roll a D3 for each target. Add 1 to the roll if the target is more than 3&quot; from all other enemy units. On a 2+, inflict an amount of mortal damage on that unit equal to the roll.</characteristic>
-            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
-            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
-          </characteristics>
-          <attributes>
-            <attribute name="Color" typeId="5a11-eab3-180c-ddf5">Yellow</attribute>
-            <attribute name="Type" typeId="6d16-c86b-2698-85a4">Offensive</attribute>
-            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
-          </attributes>
-        </profile>
-        <profile name="Step Away From the Maw" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="49df-ebb1-b61a-291">
-          <characteristics>
-            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Your Movement Phase</characteristic>
-            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb"/>
-            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">If this terrain feature has a Head Butcher that was not placed on it this turn, set up the Head Butcher on the battlefield wholly within 3&quot; of this terrain feature and not in combat. That unit is no longer a Head Butcher.</characteristic>
-            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
-            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
-          </characteristics>
-          <attributes>
-            <attribute name="Color" typeId="5a11-eab3-180c-ddf5">Gray</attribute>
-            <attribute name="Type" typeId="6d16-c86b-2698-85a4">Movement</attribute>
-            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
-          </attributes>
-        </profile>
-      </profiles>
-      <rules>
-        <rule name="Mawpit" id="475-a3ac-8b9d-b3fc" hidden="false">
-          <description>**The following universal terrain abilities apply to this terrain feature (Terrain, 1.2):
-Cover, Impassable**</description>
-        </rule>
-        <rule name="Base Size" id="3f04-2149-5b4b-8956" hidden="true">
-          <description>Use model</description>
-        </rule>
-      </rules>
-    </selectionEntry>
-    <selectionEntry type="unit" import="true" name="Great Mawpot" hidden="false" id="2586-d28e-7404-b64e" publicationId="1ac6-e227-a186-12">
-      <categoryLinks>
-        <categoryLink name="FACTION TERRAIN" hidden="false" id="5881-79e3-fd84-7d8e" targetId="cdd6-ffa1-9b32-4cb8" primary="true"/>
-        <categoryLink name="DESTRUCTION" hidden="false" id="94fa-be80-135c-2694" targetId="9057-5a29-dda5-3c28" primary="false"/>
-        <categoryLink name="OGOR MAWTRIBES" hidden="false" id="ce04-3850-8fd0-d050" targetId="743-1bd8-e3d-ced2" primary="false"/>
-      </categoryLinks>
-      <profiles>
-        <profile name="Great Mawpot" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="a716-182b-d7ec-1794">
-          <characteristics>
-            <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
-            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">The **Great Mawpot** is either **full** or **empty**. It starts the battle **full**.</characteristic>
-          </characteristics>
-          <attributes>
-            <attribute name="Color" typeId="50fe-4f29-6bc3-dcc6">Black</attribute>
-            <attribute name="Type" typeId="bf11-4e10-3ab1-06f4">Special</attribute>
-            <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
-          </attributes>
-        </profile>
-        <profile name="Great Mawpot" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="b94f-154c-51e9-8dc8">
-          <characteristics>
-            <characteristic name="Move" typeId="fed0-d1b3-1bb8-c501">-</characteristic>
-            <characteristic name="Health" typeId="96be-54ae-ce7b-10b7">6</characteristic>
-            <characteristic name="Save" typeId="1981-ef09-96f6-7aa9">5+</characteristic>
-            <characteristic name="Control" typeId="6c6f-8510-9ce1-fc6e">-</characteristic>
-          </characteristics>
-        </profile>
-        <profile name="Battlebroth" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="5d44-3637-a984-d185">
-          <characteristics>
-            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Your Hero Phase</characteristic>
-            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb"/>
-            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">If the **Great Mawpot** is full, **Heal (D3)** each friendly unit wholly within 18&quot; of it. After you have done so, the **Great Mawpot** is empty.</characteristic>
-            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
-            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
-          </characteristics>
-          <attributes>
-            <attribute name="Color" typeId="5a11-eab3-180c-ddf5">Yellow</attribute>
-            <attribute name="Type" typeId="6d16-c86b-2698-85a4">Defensive</attribute>
-            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
-          </attributes>
-        </profile>
-        <profile name="Vessel of the Gulping God" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="21dc-31c8-ec8a-48aa">
-          <characteristics>
-            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Your Hero Phase</characteristic>
-            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">If the **Great Mawpot** is full, pick a friendly **^^Ogor Wizard^^** within 3&quot; of it to be the target.</characteristic>
-            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Add 1 to the power level of the target for the rest of the turn.</characteristic>
-            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
-            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
-          </characteristics>
-          <attributes>
-            <attribute name="Color" typeId="5a11-eab3-180c-ddf5">Yellow</attribute>
-            <attribute name="Type" typeId="6d16-c86b-2698-85a4">Special</attribute>
-            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
-          </attributes>
-        </profile>
-        <profile name="Throw &apos;Em In" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="b0aa-620-8f45-ade0">
-          <characteristics>
-            <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
-            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">If an enemy model is slain within 6&quot; of the **Great Mawpot** when it is **empty**, it becomes **full**.</characteristic>
-          </characteristics>
-          <attributes>
-            <attribute name="Color" typeId="50fe-4f29-6bc3-dcc6">Black</attribute>
-            <attribute name="Type" typeId="bf11-4e10-3ab1-06f4">Special</attribute>
-            <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
-          </attributes>
-        </profile>
-      </profiles>
-      <rules>
-        <rule name="Great Mawpot" id="f456-7b92-79b3-c496" hidden="false">
-          <description>**The following universal terrain abilities apply to this terrain feature (Terrain, 1.2):
-Cover, Impassable**</description>
-        </rule>
-        <rule name="Base Size" id="9ef7-034c-f4d6-8429" hidden="true">
-          <description>Use model</description>
-        </rule>
-      </rules>
-    </selectionEntry>
-    <selectionEntry type="unit" import="true" name="Ironguts" hidden="false" id="7ea4-f81b-b7cc-b16e" publicationId="1ac6-e227-a186-12">
-      <profiles>
-        <profile name="Ironguts" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="52f4-69e-67c2-c56f">
-          <characteristics>
-            <characteristic name="Move" typeId="fed0-d1b3-1bb8-c501">6&quot;</characteristic>
-            <characteristic name="Health" typeId="96be-54ae-ce7b-10b7">4</characteristic>
-            <characteristic name="Save" typeId="1981-ef09-96f6-7aa9">5+</characteristic>
-            <characteristic name="Control" typeId="6c6f-8510-9ce1-fc6e">2</characteristic>
-          </characteristics>
-        </profile>
-        <profile name="Down to the Ironguts" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="3d7c-6719-e553-3ad5">
-          <characteristics>
-            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Battle, Any Combat Phase</characteristic>
-            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb"/>
-            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">This unit can use 2 **^^Fight^^** abilities this phase. After the first is used, however, this unit has Strike-last for the rest of the turn.</characteristic>
-            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
-            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
-          </characteristics>
-          <attributes>
-            <attribute name="Color" typeId="5a11-eab3-180c-ddf5">Red</attribute>
-            <attribute name="Type" typeId="6d16-c86b-2698-85a4">Offensive</attribute>
-            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
-          </attributes>
-        </profile>
-        <profile name="Protect the Tyrant" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="1949-91ca-3796-3da7">
-          <characteristics>
-            <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
-            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">While this unit is within the combat ranges of any friendly Tyrants, both this unit and those Tyrants have Ward (6+).</characteristic>
-          </characteristics>
-          <attributes>
-            <attribute name="Color" typeId="50fe-4f29-6bc3-dcc6">Green</attribute>
-            <attribute name="Type" typeId="bf11-4e10-3ab1-06f4">Defensive</attribute>
-            <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
-          </attributes>
-        </profile>
-      </profiles>
-      <categoryLinks>
-        <categoryLink name="INFANTRY" hidden="false" id="e004-93fa-ab2e-7da6" targetId="75d6-6995-dfcc-3898" primary="true"/>
-        <categoryLink name="CHAMPION" hidden="false" id="a9e-a0bd-777a-8a90" targetId="f679-3bcb-d664-9ac3" primary="false"/>
-        <categoryLink name="OGOR MAWTRIBES" hidden="false" id="3fbc-997a-972d-adc8" targetId="743-1bd8-e3d-ced2" primary="false"/>
-        <categoryLink name="DESTRUCTION" hidden="false" id="6853-e725-48fb-284f" targetId="9057-5a29-dda5-3c28" primary="false"/>
-        <categoryLink name="OGOR" hidden="false" id="695-9f35-6a46-b82c" targetId="ddcb-3c91-472f-c35a" primary="false"/>
-        <categoryLink name="GUTBUSTERS" hidden="false" id="e19d-325c-2198-d619" targetId="5c0d-5e93-d71f-f0da" primary="false"/>
-        <categoryLink name="MUSICIAN (1/4)" hidden="false" id="b5f-b41a-9ee1-8d91" targetId="fe9c-1d27-a698-5f31" primary="false"/>
-        <categoryLink name="STANDARD BEARER (1/4)" hidden="false" id="26f0-b2c9-8824-9558" targetId="7528-e097-91b0-f4f9" primary="false"/>
-      </categoryLinks>
-      <selectionEntries>
-        <selectionEntry type="model" import="true" name="Irongut" hidden="false" id="5f5a-635f-ec38-84df" defaultAmount="1,1,1,1">
-          <constraints>
-            <constraint type="min" value="4" field="selections" scope="parent" shared="false" id="8d4f-67d9-2674-b9d6"/>
-            <constraint type="max" value="4" field="selections" scope="parent" shared="false" id="8c01-9aa1-a7d3-906c"/>
-          </constraints>
-          <modifiers>
-            <modifier type="increment" value="4" field="8d4f-67d9-2674-b9d6">
+            <modifier type="increment" value="3" field="d77a-cd43-838a-f37a">
               <repeats>
                 <repeat value="1" repeats="1" field="selections" scope="7ea4-f81b-b7cc-b16e" childId="1b37-82b8-c062-eb82" shared="true" roundUp="false"/>
               </repeats>
             </modifier>
-            <modifier type="increment" value="4" field="8c01-9aa1-a7d3-906c">
+            <modifier type="increment" value="3" field="4965-f1ec-0120-5763">
               <repeats>
                 <repeat value="1" repeats="1" field="selections" scope="7ea4-f81b-b7cc-b16e" childId="1b37-82b8-c062-eb82" shared="true" roundUp="false"/>
               </repeats>
             </modifier>
           </modifiers>
           <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Irongut Weapon" hidden="false" id="3b9c-25a7-5794-fa18">
-              <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="bac1-8f5c-8463-7644"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="a49f-e2a5-731b-ec5a"/>
-              </constraints>
+            <selectionEntry type="upgrade" import="true" name="Irongut Weapon" hidden="false" id="e87c-6891-1851-410a">
               <profiles>
-                <profile name="Irongut Weapon" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="6163-a98b-17b6-2d4e">
+                <profile name="Irongut Weapon" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="0602-114e-52d5-f543">
                   <characteristics>
                     <characteristic name="Atk" typeId="60e-35aa-31ed-e488">3</characteristic>
                     <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">4+</characteristic>
@@ -3632,50 +2425,28 @@ Cover, Impassable**</description>
                   </characteristics>
                 </profile>
               </profiles>
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="5a86-a26c-95b4-8141"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="beb3-0307-0d1c-a73a"/>
+              </constraints>
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups>
-            <selectionEntryGroup name="Command Models" id="2e4d-7e82-a29f-b86d" hidden="false">
+            <selectionEntryGroup name="Command Models" id="fceb-446b-e336-8fbf" hidden="false">
               <constraints>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ae67-36a9-cddc-2aa"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="80f1-9377-e1c7-6c11"/>
               </constraints>
               <entryLinks>
-                <entryLink import="true" name="Champion" hidden="false" id="834-91be-cef5-804b" type="selectionEntry" targetId="9c21-1746-9873-a5b5" defaultAmount="1,0,0,0">
+                <entryLink import="true" name="Champion" hidden="false" id="0d0d-85b4-7bae-5003" type="selectionEntry" targetId="9c21-1746-9873-a5b5" defaultAmount="1,0">
                   <constraints>
-                    <constraint type="max" value="1" field="selections" scope="7ea4-f81b-b7cc-b16e" shared="true" id="da14-45b7-3f66-dfee" includeChildSelections="true"/>
+                    <constraint type="max" value="1" field="selections" scope="7ea4-f81b-b7cc-b16e" shared="true" id="71e6-4225-e174-7a3b" includeChildSelections="true"/>
                   </constraints>
-                </entryLink>
-                <entryLink import="true" name="Standard Bearer" hidden="false" id="1fa8-82ff-1334-385d" type="selectionEntry" targetId="7f34-77c9-597-62c3" defaultAmount="0,0,1,0">
-                  <constraints>
-                    <constraint type="max" value="1" field="selections" scope="7ea4-f81b-b7cc-b16e" shared="true" id="aec4-9fb1-138e-d25" includeChildSelections="true"/>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="b16-6281-d4af-2f87"/>
-                  </constraints>
-                  <modifiers>
-                    <modifier type="increment" value="1" field="aec4-9fb1-138e-d25">
-                      <repeats>
-                        <repeat value="1" repeats="1" field="selections" scope="root-entry" childId="1b37-82b8-c062-eb82" shared="true" roundUp="false"/>
-                      </repeats>
-                    </modifier>
-                  </modifiers>
-                </entryLink>
-                <entryLink import="true" name="Musician" hidden="false" id="9ef0-72e7-94f0-46d5" type="selectionEntry" targetId="2475-183b-3802-4431" defaultAmount="0,1,0,0">
-                  <constraints>
-                    <constraint type="max" value="1" field="selections" scope="7ea4-f81b-b7cc-b16e" shared="true" id="3f61-16c9-5fb3-6616" includeChildSelections="true"/>
-                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="d94f-d3c6-519f-76eb"/>
-                  </constraints>
-                  <modifiers>
-                    <modifier type="increment" value="1" field="3f61-16c9-5fb3-6616">
-                      <repeats>
-                        <repeat value="1" repeats="1" field="selections" scope="root-entry" childId="1b37-82b8-c062-eb82" shared="true" roundUp="false"/>
-                      </repeats>
-                    </modifier>
-                  </modifiers>
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <rules>
-            <rule name="Base Size" id="f3a3-9b55-8b22-2b62" hidden="true">
+            <rule name="Base Size" id="0d73-4589-e8d3-cadd" hidden="true">
               <description>40mm</description>
             </rule>
           </rules>
@@ -4154,12 +2925,12 @@ Cover, Impassable**</description>
         </modifier>
       </modifiers>
     </selectionEntry>
-    <selectionEntry type="unit" import="true" name="Mantrapper" hidden="false" id="9167-b1ce-996d-5d19" publicationId="fb5f-170a-00d0-4cf5">
+    <selectionEntry type="unit" import="true" name="Mantrapper" hidden="false" id="9167-b1ce-996d-5d19" publicationId="feba-6749-6df3-ea9e">
       <entryLinks>
-        <entryLink import="true" name="General" hidden="false" id="f908-c33b-fabc-67a4" type="selectionEntry" targetId="a56b-952e-ad15-7868"/>
+        <entryLink import="true" name="General" hidden="false" id="efc8-ba11-7ada-bdef" type="selectionEntry" targetId="a56b-952e-ad15-7868"/>
       </entryLinks>
       <profiles>
-        <profile name="Mantrapper" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="aebf-8b12-599c-3c90">
+        <profile name="Mantrapper" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="df84-d69f-b667-5863">
           <characteristics>
             <characteristic name="Move" typeId="fed0-d1b3-1bb8-c501">6&quot;</characteristic>
             <characteristic name="Health" typeId="96be-54ae-ce7b-10b7">8</characteristic>
@@ -4167,67 +2938,71 @@ Cover, Impassable**</description>
             <characteristic name="Control" typeId="6c6f-8510-9ce1-fc6e">3</characteristic>
           </characteristics>
         </profile>
-        <profile name="Trapped!" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="f504-00e9-5359-6685">
+        <profile name="Mantrapper&apos;s Accomplices" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="0ea7-78e3-8719-5a26">
+          <characteristics>
+            <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
+            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">This unit's **Sabrefang**, **Gnoblars** and **Trap** are **Mantrapper accomplice** tokens. After setting up this unit on the battlefield for the first time, place all its tokens next to it.
+
+If an enemy unit is destroyed or removed from the battlefield while any of this unit's **Mantrapper accomplices** are next to it (see the 'Just a Little Closer...' ability), remove that **Mantrapper accomplice** from the battlefield.</characteristic>
+          </characteristics>
+          <attributes>
+            <attribute typeId="50fe-4f29-6bc3-dcc6" name="Color">Black</attribute>
+            <attribute typeId="bf11-4e10-3ab1-06f4" name="Type">Special</attribute>
+            <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
+          </attributes>
+        </profile>
+        <profile name="Just a Little Closer..." typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="9700-5486-35bc-f5c9">
+          <characteristics>
+            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Turn (Army), Start of Battle Round</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb"/>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">If this unit has any **Mantrapper accomplices**, remove 1 **Mantrapper accomplice** from this unit and place it next to a visible enemy unit.</characteristic>
+            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+          </characteristics>
+          <attributes>
+            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Black</attribute>
+            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Special</attribute>
+            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+          </attributes>
+        </profile>
+        <profile name="Trapped!" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="39fe-f779-c3bb-b055">
           <characteristics>
             <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Turn (Army), Any Shooting Phase</characteristic>
-            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick an enemy unit that had any damage points allocated to it this turn by this unit's shooting attacks to be the target.</characteristic>
-            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Make a trapped roll of D6. Subtract 1 from the roll for each friendly **Mantrapper accomplice** next to the target. If the roll is less than the target's Save characteristic, until the start of your next turn:
-• Subtract 1 from the number of dice rolled when making charge rolls for the target, to a minimum of 1.
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick an enemy unit that had any damage points allocated to it this turn by this unit's shooting attacks to be the target.</characteristic>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Make a **trapped roll** of D6. Subtract 1 from the roll for each **Mantrapper accomplice** next to the target.
+
+If the roll is less than the target's Save characteristic, until the start of your next turn:
+
+• Subtract 1 from the number of dice rolled when making charge rolls for the target, to a minimum of 1.
 • The target does not have **^^Fly^^**.</characteristic>
             <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
             <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
           </characteristics>
           <attributes>
-            <attribute name="Color" typeId="5a11-eab3-180c-ddf5">Blue</attribute>
-            <attribute name="Type" typeId="6d16-c86b-2698-85a4">Special</attribute>
+            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Blue</attribute>
+            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Special</attribute>
             <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
-          </attributes>
-        </profile>
-        <profile name="Just a Little Closer..." typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="d13a-e879-2525-ec8c">
-          <characteristics>
-            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Turn (Army), Start of Battle Round</characteristic>
-            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">If any of this unit's **Mantrapper accomplices** are next to this unit, pick a visible enemy unit to be the target.</characteristic>
-            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Place 1 of this unit's **Mantrapper accomplices** next to the target.</characteristic>
-            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
-            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
-          </characteristics>
-          <attributes>
-            <attribute name="Color" typeId="5a11-eab3-180c-ddf5">Black</attribute>
-            <attribute name="Type" typeId="6d16-c86b-2698-85a4">Special</attribute>
-            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
-          </attributes>
-        </profile>
-        <profile name="Mantrapper&apos;s Accomplices" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="51e8-9f59-fb5d-50f3">
-          <characteristics>
-            <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
-            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">This unit's **Sabrefang**, **Gnoblars** and **Trap** are **Mantrapper accomplice** tokens. After setting up this unit on the battlefield for the first time, place all its tokens next to it.
-If an enemy unit is destroyed or removed from the battlefield while any of this unit's **Mantrapper accomplices** are next to it, remove those **Mantrapper accomplices** from the battlefield.</characteristic>
-          </characteristics>
-          <attributes>
-            <attribute name="Color" typeId="50fe-4f29-6bc3-dcc6">Black</attribute>
-            <attribute name="Type" typeId="bf11-4e10-3ab1-06f4">Special</attribute>
-            <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
           </attributes>
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink name="HERO" hidden="false" id="d0f3-8817-ad09-5585" targetId="6e72-1656-d554-528a" primary="true"/>
-        <categoryLink name="INFANTRY" hidden="false" id="c134-dbe1-830a-29f8" targetId="75d6-6995-dfcc-3898" primary="false"/>
-        <categoryLink name="DESTRUCTION" hidden="false" id="2961-b3aa-f17e-0d09" targetId="9057-5a29-dda5-3c28" primary="false"/>
-        <categoryLink name="OGOR" hidden="false" id="d666-75b3-e916-ff95" targetId="ddcb-3c91-472f-c35a" primary="false"/>
-        <categoryLink name="OGOR MAWTRIBES" hidden="false" id="db8f-db9f-cdc6-631a" targetId="743-1bd8-e3d-ced2" primary="false"/>
-        <categoryLink name="BEASTCLAW RAIDERS" hidden="false" id="f945-e8c1-208f-803a" targetId="1a3d-33f9-c4cc-fe0" primary="false"/>
+        <categoryLink name="HERO" hidden="false" id="a7aa-e2cf-0e6a-e4dd" targetId="6e72-1656-d554-528a" primary="true"/>
+        <categoryLink name="INFANTRY" hidden="false" id="643b-d89b-37de-5451" targetId="75d6-6995-dfcc-3898" primary="false"/>
+        <categoryLink name="DESTRUCTION" hidden="false" id="70ac-4e52-2cfe-c4c0" targetId="9057-5a29-dda5-3c28" primary="false"/>
+        <categoryLink name="OGOR MAWTRIBES" hidden="false" id="6eee-27dc-b077-3475" targetId="743-1bd8-e3d-ced2" primary="false"/>
+        <categoryLink name="OGOR" hidden="false" id="e36e-cce4-7d59-e9cf" targetId="ddcb-3c91-472f-c35a" primary="false"/>
+        <categoryLink name="BEASTCLAW" hidden="false" id="4359-734a-6f5d-1912" targetId="410d-6b15-3cf4-88d0" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry type="model" import="true" name="Mantrapper" hidden="false" id="19c9-cd09-39fa-0f09">
+        <selectionEntry type="model" import="true" name="Mantrapper" hidden="false" id="19e4-dc13-ff87-a046">
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="b0cc-b811-1938-6387"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="c5b7-db1f-1e8d-2b80"/>
+          </constraints>
           <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Mantrap Launcher" hidden="false" id="2252-3f34-dcc4-29f0">
-              <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="01fc-484a-bcdf-d785"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="7f13-2890-3820-c92c"/>
-              </constraints>
+            <selectionEntry type="upgrade" import="true" name="Mantrap Launcher" hidden="false" id="1764-1ad4-73f2-8952">
               <profiles>
-                <profile name="Mantrap Launcher" typeId="1fd-a42f-41d3-fe05" typeName="Ranged Weapon" hidden="false" id="ed73-cdfa-adb5-84c6">
+                <profile name="Mantrap Launcher" typeId="1fd-a42f-41d3-fe05" typeName="Ranged Weapon" hidden="false" id="7e9b-bd71-065f-3386">
                   <characteristics>
                     <characteristic name="Rng" typeId="c6b5-908c-a604-1a98">15&quot;</characteristic>
                     <characteristic name="Atk" typeId="aa17-4296-2887-e05d">4</characteristic>
@@ -4239,14 +3014,14 @@ If an enemy unit is destroyed or removed from the battlefield while any of this
                   </characteristics>
                 </profile>
               </profiles>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Mantrapper&apos;s Hunting Knife" hidden="false" id="200b-6dc6-5039-44d6">
               <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="1c9d-1694-05c2-be7a"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="316c-3706-7a17-1a8b"/>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="07e7-b382-0ca3-ca92"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="d2af-0145-e598-1df2"/>
               </constraints>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Mantrapper&apos;s Hunting Knife" hidden="false" id="9f38-a477-9625-de62">
               <profiles>
-                <profile name="Mantrapper&apos;s Hunting Knife" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="a5c3-e659-2308-144f">
+                <profile name="Mantrapper&apos;s Hunting Knife" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="863b-46c5-0f5d-36dc">
                   <characteristics>
                     <characteristic name="Atk" typeId="60e-35aa-31ed-e488">4</characteristic>
                     <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">4+</characteristic>
@@ -4257,22 +3032,1161 @@ If an enemy unit is destroyed or removed from the battlefield while any of this
                   </characteristics>
                 </profile>
               </profiles>
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="3b82-4a0c-bb1f-6fe8"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="9e9f-0084-0343-1a64"/>
+              </constraints>
             </selectionEntry>
           </selectionEntries>
-          <constraints>
-            <constraint type="min" value="1" field="selections" scope="parent" shared="false" id="f377-5687-9c9b-d3b2"/>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="false" id="0214-09dc-dc1a-6afe"/>
-          </constraints>
           <rules>
-            <rule name="Base Size" id="7efe-eb98-885a-5b80" hidden="true">
+            <rule name="Base Size" id="c5eb-5289-8fa3-1e1f" hidden="true">
               <description>40mm</description>
             </rule>
           </rules>
         </selectionEntry>
       </selectionEntries>
+    </selectionEntry>
+    <selectionEntry type="unit" import="true" name="Morga the Mighty, Overtyrant" hidden="false" id="bbbf-3088-d9ef-ab3e" publicationId="feba-6749-6df3-ea9e">
+      <entryLinks>
+        <entryLink import="true" name="General" hidden="false" id="44df-ecdf-c4ea-001a" type="selectionEntry" targetId="a56b-952e-ad15-7868"/>
+      </entryLinks>
+      <profiles>
+        <profile name="Morga the Mighty, Overtyrant" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="26c7-cfc2-e078-da20">
+          <characteristics>
+            <characteristic name="Move" typeId="fed0-d1b3-1bb8-c501">10&quot;</characteristic>
+            <characteristic name="Health" typeId="96be-54ae-ce7b-10b7">16</characteristic>
+            <characteristic name="Save" typeId="1981-ef09-96f6-7aa9">3+</characteristic>
+            <characteristic name="Control" typeId="6c6f-8510-9ce1-fc6e">10</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="An Ogor&apos;s Ogor" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="9336-7ae1-1aee-6b00">
+          <characteristics>
+            <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
+            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">More than 1 effect of the 'Eat 'Em Alive' ability can apply to this unit at the same time; however, each effect can only be applied to this unit once.</characteristic>
+          </characteristics>
+          <attributes>
+            <attribute typeId="50fe-4f29-6bc3-dcc6" name="Color">Gray</attribute>
+            <attribute typeId="bf11-4e10-3ab1-06f4" name="Type">Special</attribute>
+            <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
+          </attributes>
+        </profile>
+        <profile name="Battle Damaged" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="d1bc-32e6-3520-cf68">
+          <characteristics>
+            <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
+            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">While this unit has 10 or more damage points, the Attacks characteristic of **Grutta's Horn and Hooves** is 5.</characteristic>
+          </characteristics>
+          <attributes>
+            <attribute typeId="50fe-4f29-6bc3-dcc6" name="Color">Black</attribute>
+            <attribute typeId="bf11-4e10-3ab1-06f4" name="Type">Damage</attribute>
+            <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
+          </attributes>
+        </profile>
+        <profile name="A Light Snack" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="c777-41c0-4c51-013f">
+          <characteristics>
+            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Turn (Army), Any Combat Phase</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick an enemy unit in combat with this unit to be the target.</characteristic>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Roll a dice. If the roll exceeds the target's Health characteristic, 1 model in the target unit is automatically slain.</characteristic>
+            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f">**^^Rampage^^**</characteristic>
+            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+          </characteristics>
+          <attributes>
+            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Red</attribute>
+            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Offensive</attribute>
+            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+          </attributes>
+        </profile>
+        <profile name="Been There, Ate That" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="b8bf-beab-38f4-5eac">
+          <characteristics>
+            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">End of Any Turn</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb"/>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Pick 1 of the following effects:
+• If any enemy non-**^^Monster^^** models were slain by this unit's combat attacks this turn, **Heal (D3)** this unit.
+• If any damage points were allocated to an enemy **^^Monster^^** unit by this unit's combat attacks this turn and that enemy **^^Monster^^** has been destroyed, **Heal (D3+3)** this unit.</characteristic>
+            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+          </characteristics>
+          <attributes>
+            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Purple</attribute>
+            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Rallying</attribute>
+            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+          </attributes>
+        </profile>
+        <profile name="The Right Motivation" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="c1c1-c7f4-8968-5372">
+          <characteristics>
+            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Any Combat Phase</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick a visible friendly **^^Ogor Mawtribes Infantry^^** unit wholly within 12&quot; of this unit to be the target.</characteristic>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">For the rest of the turn, the following effects apply:
+• While the target has not had any damage points allocated to it this phase, each time the unmodified hit roll for a combat attack that targets it is 1, inflict 1 mortal damage on the attacking unit after the **^^Fight^^** ability has been resolved.
+• If the target has had any damage points allocated to it this phase, add 1 to the Attacks characteristic of the target's melee weapons.</characteristic>
+            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+          </characteristics>
+          <attributes>
+            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Red</attribute>
+            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Special</attribute>
+            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+          </attributes>
+        </profile>
+      </profiles>
+      <categoryLinks>
+        <categoryLink name="HERO" hidden="false" id="0076-3478-b00e-0b1c" targetId="6e72-1656-d554-528a" primary="true"/>
+        <categoryLink name="WARMASTER" hidden="false" id="9005-01f3-fb18-dd59" targetId="c203-51a0-3d44-6b07" primary="false"/>
+        <categoryLink name="UNIQUE" hidden="false" id="5ec2-291b-32a9-0e1f" targetId="72ce-2188-70bf-2dbd" primary="false"/>
+        <categoryLink name="MONSTER" hidden="false" id="6448-fb6a-6258-c1d5" targetId="6d54-625c-d063-13e2" primary="false"/>
+        <categoryLink name="DESTRUCTION" hidden="false" id="908a-8118-e399-ba32" targetId="9057-5a29-dda5-3c28" primary="false"/>
+        <categoryLink name="OGOR MAWTRIBES" hidden="false" id="5500-bf3d-2a75-b166" targetId="743-1bd8-e3d-ced2" primary="false"/>
+        <categoryLink name="OGOR" hidden="false" id="db3a-bf13-2d4e-cc92" targetId="ddcb-3c91-472f-c35a" primary="false"/>
+        <categoryLink name="GUTBUSTERS" hidden="false" id="3b8e-027d-ebb2-a043" targetId="5c0d-5e93-d71f-f0da" primary="false"/>
+      </categoryLinks>
       <constraints>
-        <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="582e-4291-4512-892f"/>
+        <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="46ad-5e63-7ed7-290b" includeChildSelections="true"/>
       </constraints>
+      <selectionEntries>
+        <selectionEntry type="model" import="true" name="Morga the Mighty, Overtyrant" hidden="false" id="1160-fa62-0bec-ec86">
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="dd81-2e3f-8227-bbcb"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="093e-dffd-a2f2-53fa"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="The Meatfist Masher" hidden="false" id="cd67-bea5-1411-9a05">
+              <profiles>
+                <profile name="The Meatfist Masher" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="931e-d940-44eb-0db0">
+                  <characteristics>
+                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">4</characteristic>
+                    <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">3+</characteristic>
+                    <characteristic name="Wnd" typeId="61c1-22cc-40af-2847">2+</characteristic>
+                    <characteristic name="Rnd" typeId="eccc-10fa-6958-fb73">2</characteristic>
+                    <characteristic name="Dmg" typeId="e948-9c71-12a6-6be4">3</characteristic>
+                    <characteristic name="Ability" typeId="eda3-7332-5db1-4159">Crit (Mortal)</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="18b7-6ac1-3109-f3ef"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="66fe-255b-d598-4e9c"/>
+              </constraints>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Grutta&apos;s Horn and Hooves" hidden="false" id="9962-6b6a-a5e5-6f8c">
+              <profiles>
+                <profile name="Grutta&apos;s Horn and Hooves" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="027f-7b0a-a555-1254">
+                  <characteristics>
+                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">8</characteristic>
+                    <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">4+</characteristic>
+                    <characteristic name="Wnd" typeId="61c1-22cc-40af-2847">2+</characteristic>
+                    <characteristic name="Rnd" typeId="eccc-10fa-6958-fb73">2</characteristic>
+                    <characteristic name="Dmg" typeId="e948-9c71-12a6-6be4">3</characteristic>
+                    <characteristic name="Ability" typeId="eda3-7332-5db1-4159">Charge (+1 Damage), Companion</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="b695-6bf3-38f7-50ef"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="b606-8d21-0268-e0ed"/>
+              </constraints>
+            </selectionEntry>
+          </selectionEntries>
+          <rules>
+            <rule name="Base Size" id="14cf-4f2f-517b-969e" hidden="true">
+              <description>120x92mm</description>
+            </rule>
+          </rules>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntry>
+    <selectionEntry type="unit" import="true" name="Grell Firefist" hidden="false" id="3fb5-d2d7-81b4-6a19" publicationId="feba-6749-6df3-ea9e">
+      <entryLinks>
+        <entryLink import="true" name="General" hidden="false" id="2f28-1c57-7fed-9e09" type="selectionEntry" targetId="a56b-952e-ad15-7868"/>
+      </entryLinks>
+      <profiles>
+        <profile name="Grell Firefist" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="da28-07b4-e630-f688">
+          <characteristics>
+            <characteristic name="Move" typeId="fed0-d1b3-1bb8-c501">6&quot;</characteristic>
+            <characteristic name="Health" typeId="96be-54ae-ce7b-10b7">8</characteristic>
+            <characteristic name="Save" typeId="1981-ef09-96f6-7aa9">4+</characteristic>
+            <characteristic name="Control" typeId="6c6f-8510-9ce1-fc6e">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Ogor-Made Ammunition" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="b721-73b9-89b1-a6ff">
+          <characteristics>
+            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Any Shooting Phase</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick a visible enemy unit within 6&quot; of this unit to be the target.</characteristic>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">For the rest of the phase:
+• All of this unit's shooting attacks must target that enemy unit.
+• The Attacks characteristic of this unit's **Blastbelch** is D6+2 instead of D3+2.</characteristic>
+            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+          </characteristics>
+          <attributes>
+            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Blue</attribute>
+            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Shooting</attribute>
+            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+          </attributes>
+        </profile>
+        <profile name="Thunderous Diversion" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="c3fc-3d83-0a08-6078">
+          <characteristics>
+            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Your Shooting Phase</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick a friendly **^^Ogor Mawtribes^^** unit that is in combat with an enemy unit that had any damage inflicted on it this turn by this unit's shooting attacks to be the target.</characteristic>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">The target can immediately use a **^^Retreat^^** ability as if it were your movement phase and can still use **^^Charge^^** abilities later in the turn. No mortal damage is inflicted on the target by that **^^Retreat^^** ability.</characteristic>
+            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+          </characteristics>
+          <attributes>
+            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Blue</attribute>
+            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Movement</attribute>
+            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+          </attributes>
+        </profile>
+        <profile name="Oi! Pay Attention, Slobs!" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="2dae-8e36-552a-c380">
+          <characteristics>
+            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Turn (Army), Reaction: Opponent declared a command for a visible enemy unit within 6&quot; of this unit</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb"/>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">You must allocate D3 damage points to another visible friendly **^^Ogor Mawtribes^^** unit within 3&quot; of this unit (ward rolls cannot be made for those damage points). Then, that command has no effect and still counts as having been used, but the command points spent to use it are regained by your opponent.</characteristic>
+            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+          </characteristics>
+          <attributes>
+            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Black</attribute>
+            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Special</attribute>
+            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+          </attributes>
+        </profile>
+      </profiles>
+      <categoryLinks>
+        <categoryLink name="HERO" hidden="false" id="ff78-2145-a475-f899" targetId="6e72-1656-d554-528a" primary="true"/>
+        <categoryLink name="UNIQUE" hidden="false" id="6af3-1975-9967-3055" targetId="72ce-2188-70bf-2dbd" primary="false"/>
+        <categoryLink name="INFANTRY" hidden="false" id="8299-3f4d-6838-9083" targetId="75d6-6995-dfcc-3898" primary="false"/>
+        <categoryLink name="DESTRUCTION" hidden="false" id="2510-4cc1-9935-97ab" targetId="9057-5a29-dda5-3c28" primary="false"/>
+        <categoryLink name="OGOR MAWTRIBES" hidden="false" id="ae3a-1a96-d94e-734a" targetId="743-1bd8-e3d-ced2" primary="false"/>
+        <categoryLink name="OGOR" hidden="false" id="532e-3fac-f435-3943" targetId="ddcb-3c91-472f-c35a" primary="false"/>
+        <categoryLink name="GUTBUSTERS" hidden="false" id="7c72-a667-a35a-6abc" targetId="5c0d-5e93-d71f-f0da" primary="false"/>
+      </categoryLinks>
+      <constraints>
+        <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="3889-48e5-131b-a32e" includeChildSelections="true"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry type="model" import="true" name="Grell Firefist" hidden="false" id="9727-21e5-d9a8-e93f">
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="5532-9a25-c12d-5351"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="393d-3b49-0fde-481a"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Blastbelch" hidden="false" id="7cdd-9c68-535e-73ca">
+              <profiles>
+                <profile name="Blastbelch" typeId="1fd-a42f-41d3-fe05" typeName="Ranged Weapon" hidden="false" id="5bf9-6742-9f53-5f2d">
+                  <characteristics>
+                    <characteristic name="Rng" typeId="c6b5-908c-a604-1a98">12&quot;</characteristic>
+                    <characteristic name="Atk" typeId="aa17-4296-2887-e05d">D3+2</characteristic>
+                    <characteristic name="Hit" typeId="194d-aeb6-5ba7-83b4">4+</characteristic>
+                    <characteristic name="Wnd" typeId="d3d5-9dc6-13de-8d1">2+</characteristic>
+                    <characteristic name="Rnd" typeId="d03f-a9ae-3eec-755">2</characteristic>
+                    <characteristic name="Dmg" typeId="96c2-d0a5-ea1e-653b">2</characteristic>
+                    <characteristic name="Ability" typeId="d793-3dd7-9c13-741e">-</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="23b6-ccf1-a582-7b49"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="9f21-e7e5-fa16-e18a"/>
+              </constraints>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Maneater Cleaver" hidden="false" id="78c8-5068-707f-1310">
+              <profiles>
+                <profile name="Maneater Cleaver" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="636d-7e46-5664-b25f">
+                  <characteristics>
+                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">4</characteristic>
+                    <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">4+</characteristic>
+                    <characteristic name="Wnd" typeId="61c1-22cc-40af-2847">2+</characteristic>
+                    <characteristic name="Rnd" typeId="eccc-10fa-6958-fb73">2</characteristic>
+                    <characteristic name="Dmg" typeId="e948-9c71-12a6-6be4">2</characteristic>
+                    <characteristic name="Ability" typeId="eda3-7332-5db1-4159">Crit (Mortal)</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="b678-3f31-294c-8ed2"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4b81-b639-b569-150b"/>
+              </constraints>
+            </selectionEntry>
+          </selectionEntries>
+          <rules>
+            <rule name="Base Size" id="401c-44ea-977e-c915" hidden="true">
+              <description>50mm</description>
+            </rule>
+          </rules>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntry>
+    <selectionEntry type="unit" import="true" name="Tyrant on Glutthorn" hidden="false" id="9e4e-efb1-3f18-b23d" publicationId="feba-6749-6df3-ea9e">
+      <entryLinks>
+        <entryLink import="true" name="General" hidden="false" id="c7e3-4d64-52be-56b5" type="selectionEntry" targetId="a56b-952e-ad15-7868"/>
+      </entryLinks>
+      <profiles>
+        <profile name="Tyrant on Glutthorn" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="8303-17ed-a6d4-a106">
+          <characteristics>
+            <characteristic name="Move" typeId="fed0-d1b3-1bb8-c501">10&quot;</characteristic>
+            <characteristic name="Health" typeId="96be-54ae-ce7b-10b7">16</characteristic>
+            <characteristic name="Save" typeId="1981-ef09-96f6-7aa9">3+</characteristic>
+            <characteristic name="Control" typeId="6c6f-8510-9ce1-fc6e">10</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Battle Damaged" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="8502-c265-41c9-1aa4">
+          <characteristics>
+            <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
+            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">While this unit has 10 or more damage points, the Attacks characteristic of its **Glutthorn's Horn and Hooves** is 5.</characteristic>
+          </characteristics>
+          <attributes>
+            <attribute typeId="50fe-4f29-6bc3-dcc6" name="Color">Black</attribute>
+            <attribute typeId="bf11-4e10-3ab1-06f4" name="Type">Damage</attribute>
+            <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
+          </attributes>
+        </profile>
+        <profile name="Pitiless Warlord" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="0292-9118-39da-278d">
+          <characteristics>
+            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Turn (Army), Reaction: You declared a **^^Charge^^** ability for an **^^Ogor Mawtribes^^** unit wholly within 12&quot; of this unit</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb"/>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Re-roll 1 dice in that charge roll.</characteristic>
+            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+          </characteristics>
+          <attributes>
+            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Orange</attribute>
+            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Movement</attribute>
+            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+          </attributes>
+        </profile>
+        <profile name="Glutthorn Stampede" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="5c15-8eab-cce0-78cb">
+          <characteristics>
+            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Turn (Army), Any Combat Phase</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">If this unit charged this turn, pick an enemy unit in combat with it to be the target.</characteristic>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Roll a dice. Add 1 to the roll if the target is **^^Infantry^^**. On a 4+, the target has **^^Strike-last^^** for the rest of the turn.</characteristic>
+            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f">**^^Rampage^^**</characteristic>
+            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+          </characteristics>
+          <attributes>
+            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Red</attribute>
+            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Defensive</attribute>
+            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+          </attributes>
+        </profile>
+      </profiles>
+      <categoryLinks>
+        <categoryLink name="HERO" hidden="false" id="c4f3-92f0-2407-aa18" targetId="6e72-1656-d554-528a" primary="true"/>
+        <categoryLink name="MONSTER" hidden="false" id="c122-d00f-fbb3-a92e" targetId="6d54-625c-d063-13e2" primary="false"/>
+        <categoryLink name="DESTRUCTION" hidden="false" id="6e9a-2af2-a015-e486" targetId="9057-5a29-dda5-3c28" primary="false"/>
+        <categoryLink name="OGOR MAWTRIBES" hidden="false" id="2a90-5346-d01f-f8ca" targetId="743-1bd8-e3d-ced2" primary="false"/>
+        <categoryLink name="OGOR" hidden="false" id="d201-5cdb-8614-6ede" targetId="ddcb-3c91-472f-c35a" primary="false"/>
+        <categoryLink name="GUTBUSTERS" hidden="false" id="9847-4008-1250-aa4c" targetId="5c0d-5e93-d71f-f0da" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry type="model" import="true" name="Tyrant on Glutthorn" hidden="false" id="9c09-56a7-b307-78ff">
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="c098-c6ac-e2a0-ad17"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8573-4116-5396-276a"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Tyrant&apos;s Meatcleavers" hidden="false" id="e9da-0736-b2d4-f9d2">
+              <profiles>
+                <profile name="Tyrant&apos;s Meatcleavers" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="5299-f43e-8c51-4360">
+                  <characteristics>
+                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">4</characteristic>
+                    <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">4+</characteristic>
+                    <characteristic name="Wnd" typeId="61c1-22cc-40af-2847">2+</characteristic>
+                    <characteristic name="Rnd" typeId="eccc-10fa-6958-fb73">2</characteristic>
+                    <characteristic name="Dmg" typeId="e948-9c71-12a6-6be4">3</characteristic>
+                    <characteristic name="Ability" typeId="eda3-7332-5db1-4159">Crit (Mortal)</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="8a3a-e5a0-c8d0-576c"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="fb5a-8986-2beb-8b58"/>
+              </constraints>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Glutthorn&apos;s Horn and Hooves" hidden="false" id="ea83-3839-4953-2c33">
+              <profiles>
+                <profile name="Glutthorn&apos;s Horn and Hooves" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="1b9f-99e7-8353-18ba">
+                  <characteristics>
+                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">7</characteristic>
+                    <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">4+</characteristic>
+                    <characteristic name="Wnd" typeId="61c1-22cc-40af-2847">2+</characteristic>
+                    <characteristic name="Rnd" typeId="eccc-10fa-6958-fb73">2</characteristic>
+                    <characteristic name="Dmg" typeId="e948-9c71-12a6-6be4">3</characteristic>
+                    <characteristic name="Ability" typeId="eda3-7332-5db1-4159">Charge (+1 Damage), Companion</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="c3c8-32ee-2a90-f762"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8b02-d015-80f1-6f24"/>
+              </constraints>
+            </selectionEntry>
+          </selectionEntries>
+          <rules>
+            <rule name="Base Size" id="2e1d-216e-27cf-3d8b" hidden="true">
+              <description>120x92mm</description>
+            </rule>
+          </rules>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntry>
+    <selectionEntry type="unit" import="true" name="Maulbeast Cavalry" hidden="false" id="4781-28ae-2385-ff02" publicationId="feba-6749-6df3-ea9e">
+      <profiles>
+        <profile name="Maulbeast Cavalry" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="7ffc-92ad-d4b0-fee4">
+          <characteristics>
+            <characteristic name="Move" typeId="fed0-d1b3-1bb8-c501">10&quot;</characteristic>
+            <characteristic name="Health" typeId="96be-54ae-ce7b-10b7">7</characteristic>
+            <characteristic name="Save" typeId="1981-ef09-96f6-7aa9">3+</characteristic>
+            <characteristic name="Control" typeId="6c6f-8510-9ce1-fc6e">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Ravenous Counter-Attack" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="9b43-27a2-c7c4-56cb">
+          <characteristics>
+            <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
+            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">Enemy units do not count as having charged while they are in combat with this unit.</characteristic>
+          </characteristics>
+          <attributes>
+            <attribute typeId="50fe-4f29-6bc3-dcc6" name="Color">Green</attribute>
+            <attribute typeId="bf11-4e10-3ab1-06f4" name="Type">Defensive</attribute>
+            <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
+          </attributes>
+        </profile>
+        <profile name="Shock and Gore" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="cde5-e306-dca0-60f2">
+          <characteristics>
+            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Turn (Army), Any Combat Phase</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">If this unit charged this turn, pick an enemy unit in combat with it to be the target.</characteristic>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Roll a dice. On a 3+, for the rest of the turn, subtract 1 from wound rolls for the target's attacks.</characteristic>
+            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+          </characteristics>
+          <attributes>
+            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Red</attribute>
+            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Defensive</attribute>
+            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+          </attributes>
+        </profile>
+      </profiles>
+      <categoryLinks>
+        <categoryLink name="CAVALRY" hidden="false" id="03f0-6f18-189d-bd05" targetId="926c-df8c-6841-d49e" primary="true"/>
+        <categoryLink name="CHAMPION" hidden="false" id="744a-65b5-1655-a098" targetId="f679-3bcb-d664-9ac3" primary="false"/>
+        <categoryLink name="DESTRUCTION" hidden="false" id="b59c-71dd-54fa-8f96" targetId="9057-5a29-dda5-3c28" primary="false"/>
+        <categoryLink name="OGOR MAWTRIBES" hidden="false" id="7afc-ddc2-92f0-bfe1" targetId="743-1bd8-e3d-ced2" primary="false"/>
+        <categoryLink name="OGOR" hidden="false" id="7254-c832-9fd1-cb23" targetId="ddcb-3c91-472f-c35a" primary="false"/>
+        <categoryLink name="GUTBUSTERS" hidden="false" id="cbe8-ccfd-4bb2-cebb" targetId="5c0d-5e93-d71f-f0da" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry type="model" import="true" name="Maulbeast" hidden="false" id="55cb-3bf9-5c4f-9f72" defaultAmount="1,1">
+          <constraints>
+            <constraint type="min" value="2" field="selections" scope="parent" shared="false" id="c261-e18d-a472-c3f3"/>
+            <constraint type="max" value="2" field="selections" scope="parent" shared="false" id="ffdf-1d9a-e230-3c6d"/>
+          </constraints>
+          <modifiers>
+            <modifier type="increment" value="2" field="c261-e18d-a472-c3f3">
+              <repeats>
+                <repeat value="1" repeats="1" field="selections" scope="4781-28ae-2385-ff02" childId="1b37-82b8-c062-eb82" shared="true" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="increment" value="2" field="ffdf-1d9a-e230-3c6d">
+              <repeats>
+                <repeat value="1" repeats="1" field="selections" scope="4781-28ae-2385-ff02" childId="1b37-82b8-c062-eb82" shared="true" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Gutbiter Weapons" hidden="false" id="fb0a-a80b-e5cc-9085">
+              <profiles>
+                <profile name="Gutbiter Weapons" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="788c-0b2d-0889-d204">
+                  <characteristics>
+                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">3</characteristic>
+                    <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">4+</characteristic>
+                    <characteristic name="Wnd" typeId="61c1-22cc-40af-2847">2+</characteristic>
+                    <characteristic name="Rnd" typeId="eccc-10fa-6958-fb73">2</characteristic>
+                    <characteristic name="Dmg" typeId="e948-9c71-12a6-6be4">3</characteristic>
+                    <characteristic name="Ability" typeId="eda3-7332-5db1-4159">-</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="79c8-b994-7002-5585"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="d3db-f135-04c6-a0dc"/>
+              </constraints>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Maulbeast&apos;s Horns and Fangs" hidden="false" id="33b2-9684-3d10-921b">
+              <profiles>
+                <profile name="Maulbeast&apos;s Horns and Fangs" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="ac06-0439-7ce4-f761">
+                  <characteristics>
+                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">4</characteristic>
+                    <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">4+</characteristic>
+                    <characteristic name="Wnd" typeId="61c1-22cc-40af-2847">2+</characteristic>
+                    <characteristic name="Rnd" typeId="eccc-10fa-6958-fb73">1</characteristic>
+                    <characteristic name="Dmg" typeId="e948-9c71-12a6-6be4">2</characteristic>
+                    <characteristic name="Ability" typeId="eda3-7332-5db1-4159">Charge (+1 Damage), Companion</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="098e-3749-ddf4-6b41"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="e153-2511-102d-164a"/>
+              </constraints>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups>
+            <selectionEntryGroup name="Command Models" id="2f30-dfc0-8932-7124" hidden="false">
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="7493-d7ec-4dc5-5892"/>
+              </constraints>
+              <entryLinks>
+                <entryLink import="true" name="Champion" hidden="false" id="05d2-31e4-72ed-57e5" type="selectionEntry" targetId="9c21-1746-9873-a5b5" defaultAmount="1,0">
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="4781-28ae-2385-ff02" shared="true" id="f6cd-9dbb-e410-2658" includeChildSelections="true"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <rules>
+            <rule name="Base Size" id="50ba-ebfc-2047-2edd" hidden="true">
+              <description>90x52mm</description>
+            </rule>
+          </rules>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntry>
+    <selectionEntry type="unit" import="true" name="Maulbeast Raiders" hidden="false" id="a30d-9041-ffdb-5a33" publicationId="feba-6749-6df3-ea9e">
+      <profiles>
+        <profile name="Maulbeast Raiders" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="163a-4535-1cc1-776e">
+          <characteristics>
+            <characteristic name="Move" typeId="fed0-d1b3-1bb8-c501">10&quot;</characteristic>
+            <characteristic name="Health" typeId="96be-54ae-ce7b-10b7">7</characteristic>
+            <characteristic name="Save" typeId="1981-ef09-96f6-7aa9">4+</characteristic>
+            <characteristic name="Control" typeId="6c6f-8510-9ce1-fc6e">3</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Relentless Predators" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="b585-77e2-65aa-e2f2">
+          <characteristics>
+            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Turn (Army), Enemy Movement Phase</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb"/>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">If this unit is more than 9&quot; from all enemy units, it can move up to D6&quot;. It cannot move into combat during any part of that move.</characteristic>
+            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+          </characteristics>
+          <attributes>
+            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Gray</attribute>
+            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Movement</attribute>
+            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+          </attributes>
+        </profile>
+      </profiles>
+      <categoryLinks>
+        <categoryLink name="CAVALRY" hidden="false" id="bf04-d82a-c516-8731" targetId="926c-df8c-6841-d49e" primary="true"/>
+        <categoryLink name="CHAMPION" hidden="false" id="702c-9ca7-fc6d-6615" targetId="f679-3bcb-d664-9ac3" primary="false"/>
+        <categoryLink name="DESTRUCTION" hidden="false" id="0f5b-4265-4a90-c68a" targetId="9057-5a29-dda5-3c28" primary="false"/>
+        <categoryLink name="OGOR MAWTRIBES" hidden="false" id="46b1-65b3-5497-b81b" targetId="743-1bd8-e3d-ced2" primary="false"/>
+        <categoryLink name="OGOR" hidden="false" id="d44b-bf42-2b4b-8989" targetId="ddcb-3c91-472f-c35a" primary="false"/>
+        <categoryLink name="BEASTCLAW" hidden="false" id="c47b-9867-2d69-0c7a" targetId="410d-6b15-3cf4-88d0" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry type="model" import="true" name="Maulbeast" hidden="false" id="2119-d13c-4859-e0b3" defaultAmount="1,1">
+          <constraints>
+            <constraint type="min" value="2" field="selections" scope="parent" shared="false" id="75c1-eaa7-5ba3-cd42"/>
+            <constraint type="max" value="2" field="selections" scope="parent" shared="false" id="b4e9-f067-cd00-b95a"/>
+          </constraints>
+          <modifiers>
+            <modifier type="increment" value="2" field="75c1-eaa7-5ba3-cd42">
+              <repeats>
+                <repeat value="1" repeats="1" field="selections" scope="a30d-9041-ffdb-5a33" childId="1b37-82b8-c062-eb82" shared="true" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="increment" value="2" field="b4e9-f067-cd00-b95a">
+              <repeats>
+                <repeat value="1" repeats="1" field="selections" scope="a30d-9041-ffdb-5a33" childId="1b37-82b8-c062-eb82" shared="true" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Hunter Crossbow and Blood Vulture" hidden="false" id="9234-7c49-74e6-7fc1">
+              <profiles>
+                <profile name="Hunter Crossbow and Blood Vulture" typeId="1fd-a42f-41d3-fe05" typeName="Ranged Weapon" hidden="false" id="1cbb-2933-c981-e4d6">
+                  <characteristics>
+                    <characteristic name="Rng" typeId="c6b5-908c-a604-1a98">15&quot;</characteristic>
+                    <characteristic name="Atk" typeId="aa17-4296-2887-e05d">3</characteristic>
+                    <characteristic name="Hit" typeId="194d-aeb6-5ba7-83b4">4+</characteristic>
+                    <characteristic name="Wnd" typeId="d3d5-9dc6-13de-8d1">3+</characteristic>
+                    <characteristic name="Rnd" typeId="d03f-a9ae-3eec-755">1</characteristic>
+                    <characteristic name="Dmg" typeId="96c2-d0a5-ea1e-653b">2</characteristic>
+                    <characteristic name="Ability" typeId="d793-3dd7-9c13-741e">Shoot in Combat</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="9dfc-f78a-44a9-22a9"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="d791-864d-b1f2-9352"/>
+              </constraints>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Punches and Kicks" hidden="false" id="91b6-cb97-95aa-7a6b">
+              <profiles>
+                <profile name="Punches and Kicks" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="f5db-4e94-f7f0-35de">
+                  <characteristics>
+                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">4</characteristic>
+                    <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">4+</characteristic>
+                    <characteristic name="Wnd" typeId="61c1-22cc-40af-2847">2+</characteristic>
+                    <characteristic name="Rnd" typeId="eccc-10fa-6958-fb73">1</characteristic>
+                    <characteristic name="Dmg" typeId="e948-9c71-12a6-6be4">1</characteristic>
+                    <characteristic name="Ability" typeId="eda3-7332-5db1-4159">-</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="bf91-40d9-b445-a524"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="92a1-c748-5b87-2393"/>
+              </constraints>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Maulbeast&apos;s Horns and Fangs" hidden="false" id="002e-3d04-dff8-2a5c">
+              <profiles>
+                <profile name="Maulbeast&apos;s Horns and Fangs" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="c758-5180-7b1f-94dd">
+                  <characteristics>
+                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">4</characteristic>
+                    <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">4+</characteristic>
+                    <characteristic name="Wnd" typeId="61c1-22cc-40af-2847">2+</characteristic>
+                    <characteristic name="Rnd" typeId="eccc-10fa-6958-fb73">1</characteristic>
+                    <characteristic name="Dmg" typeId="e948-9c71-12a6-6be4">2</characteristic>
+                    <characteristic name="Ability" typeId="eda3-7332-5db1-4159">Charge (+1 Damage), Companion</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="8e4c-69cf-78ed-9fb2"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="7595-4426-dc10-ca0f"/>
+              </constraints>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups>
+            <selectionEntryGroup name="Command Models" id="e06c-8b0f-3a70-f0a6" hidden="false">
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="21ff-6f76-d49c-3f6d"/>
+              </constraints>
+              <entryLinks>
+                <entryLink import="true" name="Champion" hidden="false" id="0781-9842-663c-d5d1" type="selectionEntry" targetId="9c21-1746-9873-a5b5" defaultAmount="1,0">
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="a30d-9041-ffdb-5a33" shared="true" id="f46e-693f-a920-555a" includeChildSelections="true"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <rules>
+            <rule name="Base Size" id="2cfa-f25b-294d-1052" hidden="true">
+              <description>90x52mm</description>
+            </rule>
+          </rules>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntry>
+    <selectionEntry type="unit" import="true" name="Hunters with Sabrefangs" hidden="false" id="cdfc-5bdb-a479-48fa" publicationId="feba-6749-6df3-ea9e">
+      <profiles>
+        <profile name="Hunters with Sabrefangs" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="2192-ae8a-3b2f-ba1d">
+          <characteristics>
+            <characteristic name="Move" typeId="fed0-d1b3-1bb8-c501">6&quot;</characteristic>
+            <characteristic name="Health" typeId="96be-54ae-ce7b-10b7">4</characteristic>
+            <characteristic name="Save" typeId="1981-ef09-96f6-7aa9">5+</characteristic>
+            <characteristic name="Control" typeId="6c6f-8510-9ce1-fc6e">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Through the Frosts" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="d498-c36b-110c-d63b">
+          <characteristics>
+            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Battle (Army), Deployment Phase</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb"/>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Remove this unit from the battlefield and set it up again wholly within 3&quot; of a terrain feature and more than 9&quot; from all enemy units. This unit cannot use **^^Move^^** abilities in the first turn of the first battle round.</characteristic>
+            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+          </characteristics>
+          <attributes>
+            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Black</attribute>
+            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Movement</attribute>
+            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+          </attributes>
+        </profile>
+        <profile name="Ferocious Sabrefangs" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="96a7-2a08-f153-ec25">
+          <characteristics>
+            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Turn (Army), Any Combat Phase</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick an enemy unit in combat with this unit and that charged this turn to be the target.</characteristic>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Roll 2 dice for each **Sabrefang** in this unit. For each 3+, inflict 1 mortal damage on the target.</characteristic>
+            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+          </characteristics>
+          <attributes>
+            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Red</attribute>
+            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Offensive</attribute>
+            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+          </attributes>
+        </profile>
+      </profiles>
+      <categoryLinks>
+        <categoryLink name="INFANTRY" hidden="false" id="b228-1bde-364a-31ad" targetId="75d6-6995-dfcc-3898" primary="true"/>
+        <categoryLink name="CHAMPION" hidden="false" id="5115-d3e0-a14c-267a" targetId="f679-3bcb-d664-9ac3" primary="false"/>
+        <categoryLink name="DESTRUCTION" hidden="false" id="7ef6-032e-6841-6669" targetId="9057-5a29-dda5-3c28" primary="false"/>
+        <categoryLink name="OGOR MAWTRIBES" hidden="false" id="8b61-cbca-6eab-df74" targetId="743-1bd8-e3d-ced2" primary="false"/>
+        <categoryLink name="OGOR" hidden="false" id="8bc6-a057-9848-c295" targetId="ddcb-3c91-472f-c35a" primary="false"/>
+        <categoryLink name="BEASTCLAW" hidden="false" id="c035-f457-125d-6929" targetId="410d-6b15-3cf4-88d0" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry type="model" import="true" name="Hunter" hidden="false" id="562b-efe1-ae55-87e4" defaultAmount="1,2">
+          <constraints>
+            <constraint type="min" value="3" field="selections" scope="parent" shared="false" id="6c99-fc85-28be-e08d"/>
+            <constraint type="max" value="3" field="selections" scope="parent" shared="false" id="e225-cc4c-e864-0a9e"/>
+          </constraints>
+          <modifiers>
+            <modifier type="increment" value="3" field="6c99-fc85-28be-e08d">
+              <repeats>
+                <repeat value="1" repeats="1" field="selections" scope="cdfc-5bdb-a479-48fa" childId="1b37-82b8-c062-eb82" shared="true" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="increment" value="3" field="e225-cc4c-e864-0a9e">
+              <repeats>
+                <repeat value="1" repeats="1" field="selections" scope="cdfc-5bdb-a479-48fa" childId="1b37-82b8-c062-eb82" shared="true" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Hunter&apos;s Crossbow" hidden="false" id="ff2e-6e82-5041-02de">
+              <profiles>
+                <profile name="Hunter&apos;s Crossbow" typeId="1fd-a42f-41d3-fe05" typeName="Ranged Weapon" hidden="false" id="284d-df5a-333c-44fe">
+                  <characteristics>
+                    <characteristic name="Rng" typeId="c6b5-908c-a604-1a98">15&quot;</characteristic>
+                    <characteristic name="Atk" typeId="aa17-4296-2887-e05d">3</characteristic>
+                    <characteristic name="Hit" typeId="194d-aeb6-5ba7-83b4">4+</characteristic>
+                    <characteristic name="Wnd" typeId="d3d5-9dc6-13de-8d1">3+</characteristic>
+                    <characteristic name="Rnd" typeId="d03f-a9ae-3eec-755">1</characteristic>
+                    <characteristic name="Dmg" typeId="96c2-d0a5-ea1e-653b">2</characteristic>
+                    <characteristic name="Ability" typeId="d793-3dd7-9c13-741e">Anti-**^^Monster^^** (+1 Rend)</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="c945-9940-d7c0-d73d"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6a06-7c76-63da-36e5"/>
+              </constraints>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Skinning Blades" hidden="false" id="e75e-f5aa-f990-dd27">
+              <profiles>
+                <profile name="Skinning Blades" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="da17-a7ef-f488-9605">
+                  <characteristics>
+                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">2</characteristic>
+                    <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">4+</characteristic>
+                    <characteristic name="Wnd" typeId="61c1-22cc-40af-2847">2+</characteristic>
+                    <characteristic name="Rnd" typeId="eccc-10fa-6958-fb73">1</characteristic>
+                    <characteristic name="Dmg" typeId="e948-9c71-12a6-6be4">1</characteristic>
+                    <characteristic name="Ability" typeId="eda3-7332-5db1-4159">Anti-**^^Cavalry^^** (+1 Rend), Anti-**^^Monster^^** (+1 Rend)</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="ecdd-3bf3-9085-1563"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="e049-0de1-88b0-ac14"/>
+              </constraints>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups>
+            <selectionEntryGroup name="Command Models" id="5836-16e5-a000-375b" hidden="false">
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="807c-b4bd-66ad-0829"/>
+              </constraints>
+              <entryLinks>
+                <entryLink import="true" name="Champion" hidden="false" id="546f-dc45-671b-fbea" type="selectionEntry" targetId="9c21-1746-9873-a5b5" defaultAmount="1,0">
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="cdfc-5bdb-a479-48fa" shared="true" id="5b0b-f92a-8d8a-afc2" includeChildSelections="true"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <rules>
+            <rule name="Base Size" id="0e5a-6cd9-392c-b258" hidden="true">
+              <description>40mm</description>
+            </rule>
+          </rules>
+        </selectionEntry>
+        <selectionEntry type="model" import="true" name="Sabrefang" hidden="false" id="bede-3227-9913-865a">
+          <constraints>
+            <constraint type="min" value="2" field="selections" scope="parent" shared="false" id="cb04-816d-e590-6407"/>
+            <constraint type="max" value="2" field="selections" scope="parent" shared="false" id="7fa9-750b-ab4b-84ed"/>
+          </constraints>
+          <modifiers>
+            <modifier type="increment" value="2" field="cb04-816d-e590-6407">
+              <repeats>
+                <repeat value="1" repeats="1" field="selections" scope="cdfc-5bdb-a479-48fa" childId="1b37-82b8-c062-eb82" shared="true" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="increment" value="2" field="7fa9-750b-ab4b-84ed">
+              <repeats>
+                <repeat value="1" repeats="1" field="selections" scope="cdfc-5bdb-a479-48fa" childId="1b37-82b8-c062-eb82" shared="true" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Sabrefang&apos;s Tusks and Claws" hidden="false" id="5600-f328-6272-daeb">
+              <profiles>
+                <profile name="Sabrefang&apos;s Tusks and Claws" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="d2b7-0da4-2eaf-9416">
+                  <characteristics>
+                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">4</characteristic>
+                    <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">4+</characteristic>
+                    <characteristic name="Wnd" typeId="61c1-22cc-40af-2847">3+</characteristic>
+                    <characteristic name="Rnd" typeId="eccc-10fa-6958-fb73">1</characteristic>
+                    <characteristic name="Dmg" typeId="e948-9c71-12a6-6be4">1</characteristic>
+                    <characteristic name="Ability" typeId="eda3-7332-5db1-4159">Companion</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="05b5-0105-74be-8596"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="d90f-378e-add7-5361"/>
+              </constraints>
+            </selectionEntry>
+          </selectionEntries>
+          <rules>
+            <rule name="Base Size" id="6b81-8cf1-3d00-79c1" hidden="true">
+              <description>60x35mm</description>
+            </rule>
+          </rules>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntry>
+    <selectionEntry type="unit" import="true" name="Redd the Maw, High Slaughtermaster" hidden="false" id="63b1-7b0e-39da-a18f" publicationId="feba-6749-6df3-ea9e">
+      <entryLinks>
+        <entryLink import="true" name="General" hidden="false" id="2685-1ad0-15a7-a385" type="selectionEntry" targetId="a56b-952e-ad15-7868"/>
+      </entryLinks>
+      <profiles>
+        <profile name="Redd the Maw, High Slaughtermaster" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="81de-9a8b-5e7d-8e0c">
+          <characteristics>
+            <characteristic name="Move" typeId="fed0-d1b3-1bb8-c501">6&quot;</characteristic>
+            <characteristic name="Health" typeId="96be-54ae-ce7b-10b7">18</characteristic>
+            <characteristic name="Save" typeId="1981-ef09-96f6-7aa9">4+</characteristic>
+            <characteristic name="Control" typeId="6c6f-8510-9ce1-fc6e">10</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Battle Damaged" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="2dc6-a7fb-47ce-0ae7">
+          <characteristics>
+            <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
+            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">While this unit has 10 or more damage points, the Attacks characteristic of its **Mawseeker Acolytes' Blades and Gorger's Claws** is 5.</characteristic>
+          </characteristics>
+          <attributes>
+            <attribute typeId="50fe-4f29-6bc3-dcc6" name="Color">Black</attribute>
+            <attribute typeId="bf11-4e10-3ab1-06f4" name="Type">Damage</attribute>
+            <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
+          </attributes>
+        </profile>
+        <profile name="Son of the Hungering One" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="8cd5-b947-674b-cb98">
+          <characteristics>
+            <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
+            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">While they are wholly within 12&quot; of this unit:
+• Friendly non-**^^Mawseekers Ogor Mawtribes Infantry^^** units have **^^Ward (6+)^^**.
+• Friendly **^^Mawseekers^^** units have **^^Ward (5+)^^**.</characteristic>
+          </characteristics>
+          <attributes>
+            <attribute typeId="50fe-4f29-6bc3-dcc6" name="Color">Green</attribute>
+            <attribute typeId="bf11-4e10-3ab1-06f4" name="Type">Defensive</attribute>
+            <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
+          </attributes>
+        </profile>
+        <profile name="From the Depths of the Cauldron" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="16c4-b037-5dfa-bfd1">
+          <characteristics>
+            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Your Hero Phase</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick a visible friendly non-**^^Hero Ogor Mawtribes^^** unit wholly within 12&quot; of this unit to be the target.</characteristic>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">The target can immediately use the 'Eat 'Em Alive' ability as if it were the end of the turn and it were eligible to do so.</characteristic>
+            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+          </characteristics>
+          <attributes>
+            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Yellow</attribute>
+            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Special</attribute>
+            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+          </attributes>
+        </profile>
+        <profile name="The Maw Opens" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="fe8a-8a18-cf2a-b806">
+          <characteristics>
+            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Your Hero Phase</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick a visible friendly **^^Ogor Mawtribes^^** unit wholly within 12&quot; of this unit to be the target, then make a casting roll of 2D6.</characteristic>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">If the target is not in combat, it can move up to D3+3&quot; but must end that move no further from the nearest enemy unit that is visible to it. It cannot move into combat during any part of that move.
+
+If the target is in combat, inflict D3 mortal damage on each enemy unit in combat with the target, then **Heal (D3)** the target. If the target is a **^^Mawseekers^^** unit, instead inflict 3 mortal damage on each enemy unit in combat with the target, then **Heal (3)** the target.</characteristic>
+            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f">**^^Spell^^**</characteristic>
+            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+          </characteristics>
+          <attributes>
+            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Yellow</attribute>
+            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Special</attribute>
+            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+          </attributes>
+        </profile>
+      </profiles>
+      <categoryLinks>
+        <categoryLink name="HERO" hidden="false" id="26e4-acee-a175-8dbb" targetId="6e72-1656-d554-528a" primary="true"/>
+        <categoryLink name="WARMASTER" hidden="false" id="3431-14c3-fb3e-89bc" targetId="c203-51a0-3d44-6b07" primary="false"/>
+        <categoryLink name="UNIQUE" hidden="false" id="5672-43ff-b0f1-1ec0" targetId="72ce-2188-70bf-2dbd" primary="false"/>
+        <categoryLink name="WAR MACHINE" hidden="false" id="dc71-e83b-7994-aa38" targetId="f7bc-b618-4b5d-2bae" primary="false"/>
+        <categoryLink name="WIZARD (2)" hidden="false" id="602a-dc83-bb85-8849" targetId="8179-697a-9f4c-91d4" primary="false"/>
+        <categoryLink name="DESTRUCTION" hidden="false" id="3bb7-2271-c143-5be1" targetId="9057-5a29-dda5-3c28" primary="false"/>
+        <categoryLink name="OGOR MAWTRIBES" hidden="false" id="18ea-0ef5-a08c-e570" targetId="743-1bd8-e3d-ced2" primary="false"/>
+        <categoryLink name="OGOR" hidden="false" id="d3e4-fe58-ddd8-53c4" targetId="ddcb-3c91-472f-c35a" primary="false"/>
+        <categoryLink name="MAWSEEKERS" hidden="false" id="73ab-4320-d3be-8e37" targetId="b50b-6a98-f92a-c99c" primary="false"/>
+        <categoryLink name="WARD (5+)" hidden="false" id="b7ba-9a6c-0ffb-b11a" targetId="52cc-95fd-6cd3-8f72" primary="false"/>
+      </categoryLinks>
+      <constraints>
+        <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="e308-94b2-6b0d-a373" includeChildSelections="true"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry type="model" import="true" name="Redd the Maw, High Slaughtermaster" hidden="false" id="1a07-0cfd-9b78-b9f5">
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="1bb9-22cd-e225-efbf"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="0b81-b1d0-991f-c1dd"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Redd&apos;s Ladle" hidden="false" id="8b63-fa20-0ab5-3b9f">
+              <profiles>
+                <profile name="Redd&apos;s Ladle" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="a897-6f0b-f304-90e8">
+                  <characteristics>
+                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">5</characteristic>
+                    <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">4+</characteristic>
+                    <characteristic name="Wnd" typeId="61c1-22cc-40af-2847">2+</characteristic>
+                    <characteristic name="Rnd" typeId="eccc-10fa-6958-fb73">2</characteristic>
+                    <characteristic name="Dmg" typeId="e948-9c71-12a6-6be4">3</characteristic>
+                    <characteristic name="Ability" typeId="eda3-7332-5db1-4159">-</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="cdc6-8906-db59-2d0c"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="170a-939f-cb0f-42d7"/>
+              </constraints>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Mawseeker Acolytes&apos; Blades and Gorger&apos;s Claws" hidden="false" id="a56c-ef3d-2a06-95f5">
+              <profiles>
+                <profile name="Mawseeker Acolytes&apos; Blades and Gorger&apos;s Claws" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="598d-eeaf-1b67-3882">
+                  <characteristics>
+                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">8</characteristic>
+                    <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">4+</characteristic>
+                    <characteristic name="Wnd" typeId="61c1-22cc-40af-2847">2+</characteristic>
+                    <characteristic name="Rnd" typeId="eccc-10fa-6958-fb73">2</characteristic>
+                    <characteristic name="Dmg" typeId="e948-9c71-12a6-6be4">2</characteristic>
+                    <characteristic name="Ability" typeId="eda3-7332-5db1-4159">-</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="44bf-3800-be0e-083e"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8d70-77df-fdc4-f66d"/>
+              </constraints>
+            </selectionEntry>
+          </selectionEntries>
+          <rules>
+            <rule name="Base Size" id="681c-b4f4-21a4-d166" hidden="true">
+              <description>160mm</description>
+            </rule>
+          </rules>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntry>
+    <selectionEntry type="unit" import="true" name="Cleavers" hidden="false" id="7ad4-12cf-f68d-953f" publicationId="feba-6749-6df3-ea9e">
+      <profiles>
+        <profile name="Cleavers" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="357d-6751-7aee-38fc">
+          <characteristics>
+            <characteristic name="Move" typeId="fed0-d1b3-1bb8-c501">6&quot;</characteristic>
+            <characteristic name="Health" typeId="96be-54ae-ce7b-10b7">4</characteristic>
+            <characteristic name="Save" typeId="1981-ef09-96f6-7aa9">5+</characteristic>
+            <characteristic name="Control" typeId="6c6f-8510-9ce1-fc6e">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Arcane Appetite" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="ed72-694d-b288-8152">
+          <characteristics>
+            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Any Combat Phase</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb"/>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">If a friendly or enemy **^^Wizard^^** or **^^Priest^^** is within 6&quot; of this unit, roll a dice. On a 3+, pick 1 of the following effects to apply for the rest of the turn:
+• This unit's melee weapons have **Crit (2 Hits)**.
+• If this unit's melee weapons already have **Crit (2 Hits)**, they have **Crit (Mortal)**.</characteristic>
+            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+          </characteristics>
+          <attributes>
+            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Red</attribute>
+            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Offensive</attribute>
+            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+          </attributes>
+        </profile>
+      </profiles>
+      <categoryLinks>
+        <categoryLink name="INFANTRY" hidden="false" id="428c-9aaa-6555-2176" targetId="75d6-6995-dfcc-3898" primary="true"/>
+        <categoryLink name="CHAMPION" hidden="false" id="e37c-70af-c688-8138" targetId="f679-3bcb-d664-9ac3" primary="false"/>
+        <categoryLink name="DESTRUCTION" hidden="false" id="c623-0aae-264e-dd94" targetId="9057-5a29-dda5-3c28" primary="false"/>
+        <categoryLink name="OGOR MAWTRIBES" hidden="false" id="8f82-41ac-8bd7-4cfe" targetId="743-1bd8-e3d-ced2" primary="false"/>
+        <categoryLink name="OGOR" hidden="false" id="2442-5fba-8d16-0fa7" targetId="ddcb-3c91-472f-c35a" primary="false"/>
+        <categoryLink name="MAWSEEKERS" hidden="false" id="df66-f97a-42d4-5fab" targetId="b50b-6a98-f92a-c99c" primary="false"/>
+        <categoryLink name="WARD (6+)" hidden="false" id="3c8c-416b-e061-4a54" targetId="70a4-383f-421f-52cd" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry type="model" import="true" name="Cleaver" hidden="false" id="fe67-3a4b-3757-e278" defaultAmount="1,2">
+          <constraints>
+            <constraint type="min" value="3" field="selections" scope="parent" shared="false" id="6447-185e-f6ce-4618"/>
+            <constraint type="max" value="3" field="selections" scope="parent" shared="false" id="8616-aaa3-5dcd-0fa0"/>
+          </constraints>
+          <modifiers>
+            <modifier type="increment" value="3" field="6447-185e-f6ce-4618">
+              <repeats>
+                <repeat value="1" repeats="1" field="selections" scope="7ad4-12cf-f68d-953f" childId="1b37-82b8-c062-eb82" shared="true" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="increment" value="3" field="8616-aaa3-5dcd-0fa0">
+              <repeats>
+                <repeat value="1" repeats="1" field="selections" scope="7ad4-12cf-f68d-953f" childId="1b37-82b8-c062-eb82" shared="true" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Cleaver&apos;s Tools" hidden="false" id="3fc4-0655-f56b-9d15">
+              <profiles>
+                <profile name="Cleaver&apos;s Tools" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="e7b8-4988-cc0e-35a2">
+                  <characteristics>
+                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">4</characteristic>
+                    <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">4+</characteristic>
+                    <characteristic name="Wnd" typeId="61c1-22cc-40af-2847">2+</characteristic>
+                    <characteristic name="Rnd" typeId="eccc-10fa-6958-fb73">2</characteristic>
+                    <characteristic name="Dmg" typeId="e948-9c71-12a6-6be4">3</characteristic>
+                    <characteristic name="Ability" typeId="eda3-7332-5db1-4159">-</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="1eb6-1c7c-7303-86db"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="241e-86e5-4644-7417"/>
+              </constraints>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups>
+            <selectionEntryGroup name="Command Models" id="c9f5-5544-16b6-19bb" hidden="false">
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="c44e-a35a-8362-226f"/>
+              </constraints>
+              <entryLinks>
+                <entryLink import="true" name="Champion" hidden="false" id="bfa6-668f-12f5-4d5f" type="selectionEntry" targetId="9c21-1746-9873-a5b5" defaultAmount="1,0">
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="7ad4-12cf-f68d-953f" shared="true" id="eb91-14f3-fe99-23cd" includeChildSelections="true"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <rules>
+            <rule name="Base Size" id="2749-2219-7ba0-fcc2" hidden="true">
+              <description>40mm</description>
+            </rule>
+          </rules>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntry>
+    <selectionEntry type="unit" import="true" name="Gutseers" hidden="false" id="5b64-1820-427e-0379" publicationId="feba-6749-6df3-ea9e">
+      <profiles>
+        <profile name="Gutseers" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="23f5-6393-dd1a-7c50">
+          <characteristics>
+            <characteristic name="Move" typeId="fed0-d1b3-1bb8-c501">6&quot;</characteristic>
+            <characteristic name="Health" typeId="96be-54ae-ce7b-10b7">4</characteristic>
+            <characteristic name="Save" typeId="1981-ef09-96f6-7aa9">5+</characteristic>
+            <characteristic name="Control" typeId="6c6f-8510-9ce1-fc6e">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Arcane Contortions" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="e3e6-35db-faaf-bc6c">
+          <characteristics>
+            <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
+            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">Subtract 1 from casting rolls and chanting rolls for visible enemy units while they are within 12&quot; of this unit.
+
+Add 1 to casting rolls for visible friendly **^^Mawseekers Wizards^^** while they are wholly within 12&quot; of this unit.</characteristic>
+          </characteristics>
+          <attributes>
+            <attribute typeId="50fe-4f29-6bc3-dcc6" name="Color">Black</attribute>
+            <attribute typeId="bf11-4e10-3ab1-06f4" name="Type">Special</attribute>
+            <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
+          </attributes>
+        </profile>
+        <profile name="Conduits of Gut Magic" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="1d0c-e5a8-4cf6-ff46">
+          <characteristics>
+            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Turn (Army), Any Hero Phase</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb"/>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Measure the range and visibility of the next **^^Spell^^** ability used by a friendly **^^Ogor Mawtribes Wizard^^** that is wholly within 12&quot; of and visible to this unit from this unit instead of that **^^Wizard^^**. This unit is treated as the caster for the purpose of other abilities or spell effects, such as 'Unbind'.</characteristic>
+            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+          </characteristics>
+          <attributes>
+            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Yellow</attribute>
+            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Special</attribute>
+            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+          </attributes>
+        </profile>
+      </profiles>
+      <categoryLinks>
+        <categoryLink name="INFANTRY" hidden="false" id="ac73-d878-bb65-75e8" targetId="75d6-6995-dfcc-3898" primary="true"/>
+        <categoryLink name="CHAMPION" hidden="false" id="aabb-ab65-cd95-98d5" targetId="f679-3bcb-d664-9ac3" primary="false"/>
+        <categoryLink name="DESTRUCTION" hidden="false" id="9eba-c00e-3005-90a3" targetId="9057-5a29-dda5-3c28" primary="false"/>
+        <categoryLink name="OGOR MAWTRIBES" hidden="false" id="a502-2a0a-bf46-9c46" targetId="743-1bd8-e3d-ced2" primary="false"/>
+        <categoryLink name="OGOR" hidden="false" id="fcb4-027b-cfea-0f5f" targetId="ddcb-3c91-472f-c35a" primary="false"/>
+        <categoryLink name="MAWSEEKERS" hidden="false" id="a55c-62a6-6239-378a" targetId="b50b-6a98-f92a-c99c" primary="false"/>
+        <categoryLink name="WARD (6+)" hidden="false" id="b0e3-a703-111e-bf74" targetId="70a4-383f-421f-52cd" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry type="model" import="true" name="Gutseer" hidden="false" id="f794-fe09-4a23-4fdc" defaultAmount="1,2">
+          <constraints>
+            <constraint type="min" value="3" field="selections" scope="parent" shared="false" id="1b58-a1d1-5d4e-aa3c"/>
+            <constraint type="max" value="3" field="selections" scope="parent" shared="false" id="5823-2ae2-51a5-e24b"/>
+          </constraints>
+          <modifiers>
+            <modifier type="increment" value="3" field="1b58-a1d1-5d4e-aa3c">
+              <repeats>
+                <repeat value="1" repeats="1" field="selections" scope="5b64-1820-427e-0379" childId="1b37-82b8-c062-eb82" shared="true" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="increment" value="3" field="5823-2ae2-51a5-e24b">
+              <repeats>
+                <repeat value="1" repeats="1" field="selections" scope="5b64-1820-427e-0379" childId="1b37-82b8-c062-eb82" shared="true" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Gutseer&apos;s Tools" hidden="false" id="4b72-47e5-70e8-41b7">
+              <profiles>
+                <profile name="Gutseer&apos;s Tools" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="68ca-5d84-f82a-24eb">
+                  <characteristics>
+                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">3</characteristic>
+                    <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">4+</characteristic>
+                    <characteristic name="Wnd" typeId="61c1-22cc-40af-2847">2+</characteristic>
+                    <characteristic name="Rnd" typeId="eccc-10fa-6958-fb73">2</characteristic>
+                    <characteristic name="Dmg" typeId="e948-9c71-12a6-6be4">3</characteristic>
+                    <characteristic name="Ability" typeId="eda3-7332-5db1-4159">-</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="2696-a792-adda-83ab"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="dfb3-7105-6a87-b878"/>
+              </constraints>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups>
+            <selectionEntryGroup name="Command Models" id="ab07-57a3-719c-18e7" hidden="false">
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="04e5-6331-c089-ff43"/>
+              </constraints>
+              <entryLinks>
+                <entryLink import="true" name="Champion" hidden="false" id="c8c2-32a5-9fcf-1e71" type="selectionEntry" targetId="9c21-1746-9873-a5b5" defaultAmount="1,0">
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="5b64-1820-427e-0379" shared="true" id="a5ba-3703-a63d-184c" includeChildSelections="true"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <rules>
+            <rule name="Base Size" id="84d5-75a8-db6d-ca66" hidden="true">
+              <description>40mm</description>
+            </rule>
+          </rules>
+        </selectionEntry>
+      </selectionEntries>
     </selectionEntry>
   </sharedSelectionEntries>
 </catalogue>

--- a/Ogor Mawtribes - Library.cat
+++ b/Ogor Mawtribes - Library.cat
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <catalogue library="true" id="9a90-83e7-7a45-6aed" name="Ogor Mawtribes - Library" gameSystemId="e51d-b1a3-75fc-dc3g" gameSystemRevision="2" revision="19" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <sharedSelectionEntries>
-    <selectionEntry type="unit" import="true" name="Bloodpelt Hunter" hidden="false" id="a800-1a5b-4097-8f11" publicationId="feba-6749-6df3-ea9e">
+    <selectionEntry type="unit" import="true" name="Bloodpelt Hunter" hidden="false" id="a800-1a5b-4097-8f11" publicationId="1ac6-e227-a186-12">
       <entryLinks>
         <entryLink import="true" name="General" hidden="false" id="894b-5272-2fbc-598b" type="selectionEntry" targetId="a56b-952e-ad15-7868"/>
       </entryLinks>
@@ -101,7 +101,7 @@
         </selectionEntry>
       </selectionEntries>
     </selectionEntry>
-    <selectionEntry type="unit" import="true" name="Kragnos, the End of Empires" hidden="false" id="7231-fb13-c283-ff9d" publicationId="feba-6749-6df3-ea9e">
+    <selectionEntry type="unit" import="true" name="Kragnos, the End of Empires" hidden="false" id="7231-fb13-c283-ff9d" publicationId="1ac6-e227-a186-12">
       <entryLinks>
         <entryLink import="true" name="General" hidden="false" id="8020-5dcb-dbbd-cac1" type="selectionEntry" targetId="a56b-952e-ad15-7868"/>
       </entryLinks>
@@ -263,7 +263,7 @@
         </selectionEntry>
       </selectionEntries>
     </selectionEntry>
-    <selectionEntry type="unit" import="true" name="Gnoblar Scraplauncher" hidden="false" id="206-8e8e-f77d-e786" publicationId="feba-6749-6df3-ea9e">
+    <selectionEntry type="unit" import="true" name="Gnoblar Scraplauncher" hidden="false" id="206-8e8e-f77d-e786" publicationId="1ac6-e227-a186-12">
       <profiles>
         <profile name="Gnoblar Scraplauncher" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="63e7-8098-8c73-a99a">
           <characteristics>
@@ -348,7 +348,7 @@ Then, roll a dice. On a 3+, until the start of your next turn, the target cannot
         </selectionEntry>
       </selectionEntries>
     </selectionEntry>
-    <selectionEntry type="unit" import="true" name="Slaughtermaster" hidden="false" id="3d51-af3a-455e-2373" publicationId="1ac6-e227-a186-12">
+    <selectionEntry type="unit" import="true" name="Slaughtermaster (Scourge of Ghyran)" hidden="false" id="3d51-af3a-455e-2373" publicationId="f894-7929-f79a-a269">
       <entryLinks>
         <entryLink import="true" name="General" hidden="false" id="14f4-e9ed-ba86-f601" type="selectionEntry" targetId="a56b-952e-ad15-7868"/>
       </entryLinks>
@@ -450,7 +450,7 @@ Then, roll a dice. On a 3+, until the start of your next turn, the target cannot
         </selectionEntry>
       </selectionEntries>
     </selectionEntry>
-    <selectionEntry type="unit" import="true" name="Butcher" hidden="false" id="1688-fcbe-1470-a4ee" publicationId="feba-6749-6df3-ea9e">
+    <selectionEntry type="unit" import="true" name="Butcher" hidden="false" id="1688-fcbe-1470-a4ee" publicationId="1ac6-e227-a186-12">
       <entryLinks>
         <entryLink import="true" name="General" hidden="false" id="5bfb-95b8-ddb3-fbae" type="selectionEntry" targetId="a56b-952e-ad15-7868"/>
       </entryLinks>
@@ -536,7 +536,7 @@ Then, roll a dice. On a 3+, until the start of your next turn, the target cannot
         </selectionEntry>
       </selectionEntries>
     </selectionEntry>
-    <selectionEntry type="unit" import="true" name="Gluttons" hidden="false" id="e93b-4897-f014-9b88" publicationId="feba-6749-6df3-ea9e">
+    <selectionEntry type="unit" import="true" name="Gluttons" hidden="false" id="e93b-4897-f014-9b88" publicationId="1ac6-e227-a186-12">
       <profiles>
         <profile name="Gluttons" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="f211-7407-ca30-300c">
           <characteristics>
@@ -640,7 +640,7 @@ Then, roll a dice. On a 3+, until the start of your next turn, the target cannot
         </selectionEntry>
       </selectionEntries>
     </selectionEntry>
-    <selectionEntry type="unit" import="true" name="Gorger Mawpack" hidden="false" id="8d6b-1912-d60a-5163" publicationId="feba-6749-6df3-ea9e">
+    <selectionEntry type="unit" import="true" name="Gorger Mawpack" hidden="false" id="8d6b-1912-d60a-5163" publicationId="1ac6-e227-a186-12">
       <profiles>
         <profile name="Gorger Mawpack" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="a689-6987-e8c5-d4e5">
           <characteristics>
@@ -743,7 +743,7 @@ Then, roll a dice. On a 3+, until the start of your next turn, the target cannot
         </selectionEntry>
       </selectionEntries>
     </selectionEntry>
-    <selectionEntry type="unit" import="true" name="Thundertusk Beastriders" hidden="false" id="e5a2-5b7c-b7af-8da6" publicationId="feba-6749-6df3-ea9e">
+    <selectionEntry type="unit" import="true" name="Thundertusk Beastriders" hidden="false" id="e5a2-5b7c-b7af-8da6" publicationId="1ac6-e227-a186-12">
       <profiles>
         <profile name="Thundertusk Beastriders" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="87e1-a314-cc4b-119b">
           <characteristics>
@@ -890,7 +890,7 @@ Then, roll a dice. On a 3+, until the start of your next turn, the target cannot
         </selectionEntry>
       </selectionEntries>
     </selectionEntry>
-    <selectionEntry type="unit" import="true" name="Ironblaster" hidden="false" id="7f12-bfdf-bff5-c0fd" publicationId="feba-6749-6df3-ea9e">
+    <selectionEntry type="unit" import="true" name="Ironblaster" hidden="false" id="7f12-bfdf-bff5-c0fd" publicationId="1ac6-e227-a186-12">
       <profiles>
         <profile name="Ironblaster" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="fed4-c208-1a91-df97">
           <characteristics>
@@ -995,7 +995,7 @@ Then, roll a dice. On a 3+, until the start of your next turn, the target cannot
         </selectionEntry>
       </selectionEntries>
     </selectionEntry>
-    <selectionEntry type="unit" import="true" name="Stonehorn Beastriders" hidden="false" id="8b95-893a-4c1a-9224" publicationId="feba-6749-6df3-ea9e">
+    <selectionEntry type="unit" import="true" name="Stonehorn Beastriders" hidden="false" id="8b95-893a-4c1a-9224" publicationId="1ac6-e227-a186-12">
       <profiles>
         <profile name="Stonehorn Beastriders" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="900b-0955-4ed5-9fb1">
           <characteristics>
@@ -1122,7 +1122,7 @@ Then, roll a dice. On a 3+, until the start of your next turn, the target cannot
         </selectionEntry>
       </selectionEntries>
     </selectionEntry>
-    <selectionEntry type="unit" import="true" name="Frostlord on Stonehorn" hidden="false" id="e445-5f3b-4228-8bd3" publicationId="feba-6749-6df3-ea9e">
+    <selectionEntry type="unit" import="true" name="Frostlord on Stonehorn" hidden="false" id="e445-5f3b-4228-8bd3" publicationId="1ac6-e227-a186-12">
       <entryLinks>
         <entryLink import="true" name="General" hidden="false" id="c0e1-d9dd-a19e-752c" type="selectionEntry" targetId="a56b-952e-ad15-7868"/>
       </entryLinks>
@@ -1243,7 +1243,7 @@ Then, roll a dice. On a 3+, until the start of your next turn, the target cannot
         </selectionEntry>
       </selectionEntries>
     </selectionEntry>
-    <selectionEntry type="unit" import="true" name="Frostlord on Thundertusk" hidden="false" id="e1b4-2fef-26cc-81c4" publicationId="feba-6749-6df3-ea9e">
+    <selectionEntry type="unit" import="true" name="Frostlord on Thundertusk" hidden="false" id="e1b4-2fef-26cc-81c4" publicationId="1ac6-e227-a186-12">
       <entryLinks>
         <entryLink import="true" name="General" hidden="false" id="1ed5-717e-0c70-f65d" type="selectionEntry" targetId="a56b-952e-ad15-7868"/>
       </entryLinks>
@@ -1526,7 +1526,7 @@ Then, roll a dice. On a 3+, until the start of your next turn, the target cannot
         </modifier>
       </modifiers>
     </selectionEntry>
-    <selectionEntry type="unit" import="true" name="Huskard on Stonehorn" hidden="false" id="8bfb-791d-158b-35a2" publicationId="feba-6749-6df3-ea9e">
+    <selectionEntry type="unit" import="true" name="Huskard on Stonehorn" hidden="false" id="8bfb-791d-158b-35a2" publicationId="1ac6-e227-a186-12">
       <entryLinks>
         <entryLink import="true" name="General" hidden="false" id="f0ab-332e-fd2c-8e5a" type="selectionEntry" targetId="a56b-952e-ad15-7868"/>
       </entryLinks>
@@ -1658,7 +1658,7 @@ Then, roll a dice. On a 3+, until the start of your next turn, the target cannot
         </selectionEntry>
       </selectionEntries>
     </selectionEntry>
-    <selectionEntry type="unit" import="true" name="Huskard on Thundertusk" hidden="false" id="ebcd-aa92-94f1-c1be" publicationId="feba-6749-6df3-ea9e">
+    <selectionEntry type="unit" import="true" name="Huskard on Thundertusk" hidden="false" id="ebcd-aa92-94f1-c1be" publicationId="1ac6-e227-a186-12">
       <entryLinks>
         <entryLink import="true" name="General" hidden="false" id="fc81-ccbf-c301-78fb" type="selectionEntry" targetId="a56b-952e-ad15-7868"/>
       </entryLinks>
@@ -2050,7 +2050,7 @@ Then, roll a dice. On a 3+, until the start of your next turn, the target cannot
         </modifier>
       </modifiers>
     </selectionEntry>
-    <selectionEntry type="unit" import="true" name="Tyrant" hidden="false" id="8af5-807c-4c2e-2ceb" publicationId="feba-6749-6df3-ea9e">
+    <selectionEntry type="unit" import="true" name="Tyrant" hidden="false" id="8af5-807c-4c2e-2ceb" publicationId="1ac6-e227-a186-12">
       <entryLinks>
         <entryLink import="true" name="General" hidden="false" id="f1c1-e568-0258-3be7" type="selectionEntry" targetId="a56b-952e-ad15-7868"/>
       </entryLinks>
@@ -2138,7 +2138,7 @@ Then, roll a dice. On a 3+, until the start of your next turn, the target cannot
         </selectionEntry>
       </selectionEntries>
     </selectionEntry>
-    <selectionEntry type="unit" import="true" name="Leadbelchers" hidden="false" id="15cd-469c-4ed6-afef" publicationId="1ac6-e227-a186-12">
+    <selectionEntry type="unit" import="true" name="Leadbelchers (Scourge of Ghyran)" hidden="false" id="15cd-469c-4ed6-afef" publicationId="f894-7929-f79a-a269">
       <profiles>
         <profile name="Leadbelchers" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="7623-a53d-8c13-ace">
           <characteristics>
@@ -2261,7 +2261,7 @@ Then, roll a dice. On a 3+, until the start of your next turn, the target cannot
         </selectionEntry>
       </selectionEntries>
     </selectionEntry>
-    <selectionEntry type="unit" import="true" name="Mawpit" hidden="false" id="8e60-2852-1bfc-272" publicationId="feba-6749-6df3-ea9e">
+    <selectionEntry type="unit" import="true" name="Mawpit" hidden="false" id="8e60-2852-1bfc-272" publicationId="1ac6-e227-a186-12">
       <profiles>
         <profile name="Mawpit" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="36b0-fda4-b17a-9a4a">
           <characteristics>
@@ -2349,7 +2349,7 @@ Cover, Impassable**</description>
         </rule>
       </rules>
     </selectionEntry>
-    <selectionEntry type="unit" import="true" name="Ironguts" hidden="false" id="7ea4-f81b-b7cc-b16e" publicationId="feba-6749-6df3-ea9e">
+    <selectionEntry type="unit" import="true" name="Ironguts" hidden="false" id="7ea4-f81b-b7cc-b16e" publicationId="1ac6-e227-a186-12">
       <profiles>
         <profile name="Ironguts" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="b434-ddda-69d0-aa7b">
           <characteristics>
@@ -2925,7 +2925,7 @@ Cover, Impassable**</description>
         </modifier>
       </modifiers>
     </selectionEntry>
-    <selectionEntry type="unit" import="true" name="Mantrapper" hidden="false" id="9167-b1ce-996d-5d19" publicationId="feba-6749-6df3-ea9e">
+    <selectionEntry type="unit" import="true" name="Mantrapper" hidden="false" id="9167-b1ce-996d-5d19" publicationId="1ac6-e227-a186-12">
       <entryLinks>
         <entryLink import="true" name="General" hidden="false" id="efc8-ba11-7ada-bdef" type="selectionEntry" targetId="a56b-952e-ad15-7868"/>
       </entryLinks>
@@ -3046,7 +3046,7 @@ If the roll is less than the target's Save characteristic, until the start of yo
         </selectionEntry>
       </selectionEntries>
     </selectionEntry>
-    <selectionEntry type="unit" import="true" name="Morga the Mighty, Overtyrant" hidden="false" id="bbbf-3088-d9ef-ab3e" publicationId="feba-6749-6df3-ea9e">
+    <selectionEntry type="unit" import="true" name="Morga the Mighty, Overtyrant" hidden="false" id="bbbf-3088-d9ef-ab3e" publicationId="1ac6-e227-a186-12">
       <entryLinks>
         <entryLink import="true" name="General" hidden="false" id="44df-ecdf-c4ea-001a" type="selectionEntry" targetId="a56b-952e-ad15-7868"/>
       </entryLinks>
@@ -3193,7 +3193,7 @@ If the roll is less than the target's Save characteristic, until the start of yo
         </selectionEntry>
       </selectionEntries>
     </selectionEntry>
-    <selectionEntry type="unit" import="true" name="Grell Firefist" hidden="false" id="3fb5-d2d7-81b4-6a19" publicationId="feba-6749-6df3-ea9e">
+    <selectionEntry type="unit" import="true" name="Grell Firefist" hidden="false" id="3fb5-d2d7-81b4-6a19" publicationId="1ac6-e227-a186-12">
       <entryLinks>
         <entryLink import="true" name="General" hidden="false" id="2f28-1c57-7fed-9e09" type="selectionEntry" targetId="a56b-952e-ad15-7868"/>
       </entryLinks>
@@ -3316,7 +3316,7 @@ If the roll is less than the target's Save characteristic, until the start of yo
         </selectionEntry>
       </selectionEntries>
     </selectionEntry>
-    <selectionEntry type="unit" import="true" name="Tyrant on Glutthorn" hidden="false" id="9e4e-efb1-3f18-b23d" publicationId="feba-6749-6df3-ea9e">
+    <selectionEntry type="unit" import="true" name="Tyrant on Glutthorn" hidden="false" id="9e4e-efb1-3f18-b23d" publicationId="1ac6-e227-a186-12">
       <entryLinks>
         <entryLink import="true" name="General" hidden="false" id="c7e3-4d64-52be-56b5" type="selectionEntry" targetId="a56b-952e-ad15-7868"/>
       </entryLinks>
@@ -3429,7 +3429,7 @@ If the roll is less than the target's Save characteristic, until the start of yo
         </selectionEntry>
       </selectionEntries>
     </selectionEntry>
-    <selectionEntry type="unit" import="true" name="Maulbeast Cavalry" hidden="false" id="4781-28ae-2385-ff02" publicationId="feba-6749-6df3-ea9e">
+    <selectionEntry type="unit" import="true" name="Maulbeast Cavalry" hidden="false" id="4781-28ae-2385-ff02" publicationId="1ac6-e227-a186-12">
       <profiles>
         <profile name="Maulbeast Cavalry" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="7ffc-92ad-d4b0-fee4">
           <characteristics>
@@ -3551,7 +3551,7 @@ If the roll is less than the target's Save characteristic, until the start of yo
         </selectionEntry>
       </selectionEntries>
     </selectionEntry>
-    <selectionEntry type="unit" import="true" name="Maulbeast Raiders" hidden="false" id="a30d-9041-ffdb-5a33" publicationId="feba-6749-6df3-ea9e">
+    <selectionEntry type="unit" import="true" name="Maulbeast Raiders" hidden="false" id="a30d-9041-ffdb-5a33" publicationId="1ac6-e227-a186-12">
       <profiles>
         <profile name="Maulbeast Raiders" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="163a-4535-1cc1-776e">
           <characteristics>
@@ -3681,7 +3681,7 @@ If the roll is less than the target's Save characteristic, until the start of yo
         </selectionEntry>
       </selectionEntries>
     </selectionEntry>
-    <selectionEntry type="unit" import="true" name="Hunters with Sabrefangs" hidden="false" id="cdfc-5bdb-a479-48fa" publicationId="feba-6749-6df3-ea9e">
+    <selectionEntry type="unit" import="true" name="Hunters with Sabrefangs" hidden="false" id="cdfc-5bdb-a479-48fa" publicationId="1ac6-e227-a186-12">
       <profiles>
         <profile name="Hunters with Sabrefangs" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="2192-ae8a-3b2f-ba1d">
           <characteristics>
@@ -3850,7 +3850,7 @@ If the roll is less than the target's Save characteristic, until the start of yo
         </selectionEntry>
       </selectionEntries>
     </selectionEntry>
-    <selectionEntry type="unit" import="true" name="Redd the Maw, High Slaughtermaster" hidden="false" id="63b1-7b0e-39da-a18f" publicationId="feba-6749-6df3-ea9e">
+    <selectionEntry type="unit" import="true" name="Redd the Maw, High Slaughtermaster" hidden="false" id="63b1-7b0e-39da-a18f" publicationId="1ac6-e227-a186-12">
       <entryLinks>
         <entryLink import="true" name="General" hidden="false" id="2685-1ad0-15a7-a385" type="selectionEntry" targetId="a56b-952e-ad15-7868"/>
       </entryLinks>
@@ -3985,7 +3985,7 @@ If the target is in combat, inflict D3 mortal damage on each enemy unit in comba
         </selectionEntry>
       </selectionEntries>
     </selectionEntry>
-    <selectionEntry type="unit" import="true" name="Cleavers" hidden="false" id="7ad4-12cf-f68d-953f" publicationId="feba-6749-6df3-ea9e">
+    <selectionEntry type="unit" import="true" name="Cleavers" hidden="false" id="7ad4-12cf-f68d-953f" publicationId="1ac6-e227-a186-12">
       <profiles>
         <profile name="Cleavers" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="357d-6751-7aee-38fc">
           <characteristics>
@@ -4081,7 +4081,7 @@ If the target is in combat, inflict D3 mortal damage on each enemy unit in comba
         </selectionEntry>
       </selectionEntries>
     </selectionEntry>
-    <selectionEntry type="unit" import="true" name="Gutseers" hidden="false" id="5b64-1820-427e-0379" publicationId="feba-6749-6df3-ea9e">
+    <selectionEntry type="unit" import="true" name="Gutseers" hidden="false" id="5b64-1820-427e-0379" publicationId="1ac6-e227-a186-12">
       <profiles>
         <profile name="Gutseers" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="23f5-6393-dd1a-7c50">
           <characteristics>

--- a/Ogor Mawtribes - Library.cat
+++ b/Ogor Mawtribes - Library.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="true" id="9a90-83e7-7a45-6aed" name="Ogor Mawtribes - Library" gameSystemId="e51d-b1a3-75fc-dc3g" gameSystemRevision="2" revision="19" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="true" id="9a90-83e7-7a45-6aed" name="Ogor Mawtribes - Library" gameSystemId="e51d-b1a3-75fc-dc3g" gameSystemRevision="2" revision="20" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <sharedSelectionEntries>
     <selectionEntry type="unit" import="true" name="Bloodpelt Hunter" hidden="false" id="a800-1a5b-4097-8f11" publicationId="1ac6-e227-a186-12">
       <entryLinks>

--- a/Ogor Mawtribes - Library.cat
+++ b/Ogor Mawtribes - Library.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="true" id="9a90-83e7-7a45-6aed" name="Ogor Mawtribes - Library" gameSystemId="e51d-b1a3-75fc-dc3g" gameSystemRevision="2" revision="20" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="true" id="9a90-83e7-7a45-6aed" name="Ogor Mawtribes - Library" gameSystemId="e51d-b1a3-75fc-dc3g" gameSystemRevision="2" revision="21" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <sharedSelectionEntries>
     <selectionEntry type="unit" import="true" name="Bloodpelt Hunter" hidden="false" id="a800-1a5b-4097-8f11" publicationId="1ac6-e227-a186-12">
       <entryLinks>
@@ -2318,6 +2318,7 @@ Then, roll a dice. On a 3+, until the start of your next turn, the target cannot
         <categoryLink name="FACTION TERRAIN" hidden="false" id="242c-0eb8-96d8-0115" targetId="cdd6-ffa1-9b32-4cb8" primary="true"/>
         <categoryLink name="DESTRUCTION" hidden="false" id="0817-0379-0409-25b1" targetId="9057-5a29-dda5-3c28" primary="false"/>
         <categoryLink name="OGOR MAWTRIBES" hidden="false" id="24ee-d3e8-67c4-3036" targetId="743-1bd8-e3d-ced2" primary="false"/>
+        <categoryLink name="WARD (6+)" hidden="false" id="0aa7-1bd5-3ce9-4f62" targetId="70a4-383f-421f-52cd" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry type="upgrade" import="true" name="Ever-hungry Pit" hidden="false" id="8376-e2ae-b242-b4fd">

--- a/Ogor Mawtribes - Library.cat
+++ b/Ogor Mawtribes - Library.cat
@@ -3111,20 +3111,20 @@ If the roll is less than the target's Save characteristic, until the start of yo
             <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
           </attributes>
         </profile>
-        <profile name="The Right Motivation" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="c1c1-c7f4-8968-5372">
+                <profile name="The Right Motivation" typeId="55ac-f837-dded-5872" typeName="Ability (Command)" hidden="false" id="c1c1-c7f4-8968-5372">
           <characteristics>
-            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Any Combat Phase</characteristic>
-            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick a visible friendly **^^Ogor Mawtribes Infantry^^** unit wholly within 12&quot; of this unit to be the target.</characteristic>
-            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">For the rest of the turn, the following effects apply:
+            <characteristic name="Timing" typeId="736-6e3a-d0b5-a1b0">Any Combat Phase</characteristic>
+            <characteristic name="Cost" typeId="a49e-3082-e2a6-e802">1</characteristic>
+            <characteristic name="Declare" typeId="b77f-7548-840e-c086">Pick a visible friendly **^^Ogor Mawtribes Infantry^^** unit wholly within 12&quot; of this unit to be the target.</characteristic>
+            <characteristic name="Effect" typeId="2111-3ca8-61dd-a5f0">For the rest of the turn, the following effects apply:
 • While the target has not had any damage points allocated to it this phase, each time the unmodified hit roll for a combat attack that targets it is 1, inflict 1 mortal damage on the attacking unit after the **^^Fight^^** ability has been resolved.
 • If the target has had any damage points allocated to it this phase, add 1 to the Attacks characteristic of the target's melee weapons.</characteristic>
-            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
-            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+            <characteristic name="Keywords" typeId="445d-f443-5448-e7ce"/>
           </characteristics>
           <attributes>
-            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Red</attribute>
-            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Special</attribute>
-            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+            <attribute typeId="5c69-e4b9-19bc-e801" name="Color">Red</attribute>
+            <attribute typeId="2bd5-08f1-f3d1-86f7" name="Type">Special</attribute>
+            <attribute name="Parent Node" typeId="df75-e7dc-12b5-48a8"/>
           </attributes>
         </profile>
       </profiles>
@@ -3887,34 +3887,33 @@ If the roll is less than the target's Save characteristic, until the start of yo
             <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
           </attributes>
         </profile>
-        <profile name="From the Depths of the Cauldron" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="16c4-b037-5dfa-bfd1">
+                <profile name="From the Depths of the Cauldron" typeId="55ac-f837-dded-5872" typeName="Ability (Command)" hidden="false" id="16c4-b037-5dfa-bfd1">
           <characteristics>
-            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Your Hero Phase</characteristic>
-            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick a visible friendly non-**^^Hero Ogor Mawtribes^^** unit wholly within 12&quot; of this unit to be the target.</characteristic>
-            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">The target can immediately use the 'Eat 'Em Alive' ability as if it were the end of the turn and it were eligible to do so.</characteristic>
-            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
-            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+            <characteristic name="Timing" typeId="736-6e3a-d0b5-a1b0">Your Hero Phase</characteristic>
+            <characteristic name="Cost" typeId="a49e-3082-e2a6-e802">1</characteristic>
+            <characteristic name="Declare" typeId="b77f-7548-840e-c086">Pick a visible friendly non-**^^Hero Ogor Mawtribes^^** unit wholly within 12&quot; of this unit to be the target.</characteristic>
+            <characteristic name="Effect" typeId="2111-3ca8-61dd-a5f0">The target can immediately use the 'Eat 'Em Alive' ability as if it were the end of the turn and it were eligible to do so.</characteristic>
+            <characteristic name="Keywords" typeId="445d-f443-5448-e7ce"/>
           </characteristics>
           <attributes>
-            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Yellow</attribute>
-            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Special</attribute>
-            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+            <attribute typeId="5c69-e4b9-19bc-e801" name="Color">Yellow</attribute>
+            <attribute typeId="2bd5-08f1-f3d1-86f7" name="Type">Special</attribute>
+            <attribute name="Parent Node" typeId="df75-e7dc-12b5-48a8"/>
           </attributes>
         </profile>
-        <profile name="The Maw Opens" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="fe8a-8a18-cf2a-b806">
+                <profile name="The Maw Opens" typeId="7312-8367-c171-f2ef" typeName="Ability (Spell)" hidden="false" id="fe8a-8a18-cf2a-b806">
           <characteristics>
-            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Your Hero Phase</characteristic>
-            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick a visible friendly **^^Ogor Mawtribes^^** unit wholly within 12&quot; of this unit to be the target, then make a casting roll of 2D6.</characteristic>
-            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">If the target is not in combat, it can move up to D3+3&quot; but must end that move no further from the nearest enemy unit that is visible to it. It cannot move into combat during any part of that move.
+            <characteristic name="Timing" typeId="de6f-d57b-248a-83be">Your Hero Phase</characteristic>
+            <characteristic name="Casting Value" typeId="9fc7-b0f6-d018-a608">7</characteristic>
+            <characteristic name="Declare" typeId="24f8-3803-4ab1-3b6c">Pick a visible friendly **^^Ogor Mawtribes^^** unit wholly within 12&quot; of this unit to be the target, then make a casting roll of 2D6.</characteristic>
+            <characteristic name="Effect" typeId="1cb9-a-1345-907f">If the target is not in combat, it can move up to D3+3&quot; but must end that move no further from the nearest enemy unit that is visible to it. It cannot move into combat during any part of that move.
 
 If the target is in combat, inflict D3 mortal damage on each enemy unit in combat with the target, then **Heal (D3)** the target. If the target is a **^^Mawseekers^^** unit, instead inflict 3 mortal damage on each enemy unit in combat with the target, then **Heal (3)** the target.</characteristic>
-            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f">**^^Spell^^**</characteristic>
-            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+            <characteristic name="Keywords" typeId="353f-565e-c351-1cf2">**^^Spell^^**</characteristic>
           </characteristics>
           <attributes>
-            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Yellow</attribute>
-            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Special</attribute>
-            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+            <attribute typeId="16b6-0911-f549-a4bd" name="Color">Yellow</attribute>
+            <attribute typeId="da27-8d61-f955-5031" name="Parent Node">Special</attribute>
           </attributes>
         </profile>
       </profiles>

--- a/Ogor Mawtribes - Library.cat
+++ b/Ogor Mawtribes - Library.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="true" id="9a90-83e7-7a45-6aed" name="Ogor Mawtribes - Library" gameSystemId="e51d-b1a3-75fc-dc3g" gameSystemRevision="2" revision="21" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="true" id="9a90-83e7-7a45-6aed" name="Ogor Mawtribes - Library" gameSystemId="e51d-b1a3-75fc-dc3g" gameSystemRevision="2" revision="22" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <sharedSelectionEntries>
     <selectionEntry type="unit" import="true" name="Bloodpelt Hunter" hidden="false" id="a800-1a5b-4097-8f11" publicationId="1ac6-e227-a186-12">
       <entryLinks>
@@ -358,13 +358,13 @@ Then, roll a dice. On a 3+, until the start of your next turn, the target cannot
             <characteristic name="Move" typeId="fed0-d1b3-1bb8-c501">6&quot;</characteristic>
             <characteristic name="Health" typeId="96be-54ae-ce7b-10b7">8</characteristic>
             <characteristic name="Save" typeId="1981-ef09-96f6-7aa9">5+</characteristic>
-            <characteristic name="Control" typeId="6c6f-8510-9ce1-fc6e">5</characteristic>
+            <characteristic name="Control" typeId="6c6f-8510-9ce1-fc6e">3</characteristic>
           </characteristics>
         </profile>
         <profile name="Fill the Pot" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="33e5-a60f-bd45-8223">
           <characteristics>
             <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
-            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">Each time an enemy unit is destroyed by a combat attack made by a friendly **^^Ogor Mawtribes^^** unit wholly within 18&quot; of this unit, give this unit a **grisly remains point**, to a maximum of 3.</characteristic>
+            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">This unit's cauldron is either **filled with grisly remains** or **empty**. It starts the battle **empty**. If an enemy unit that was in combat with this unit this turn is destroyed and this unit's cauldron is **empty**, it becomes **filled with grisly remains**.</characteristic>
           </characteristics>
           <attributes>
             <attribute name="Color" typeId="50fe-4f29-6bc3-dcc6">Red</attribute>
@@ -375,10 +375,10 @@ Then, roll a dice. On a 3+, until the start of your next turn, the target cannot
         <profile name="Great Cauldron" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="3b0e-b90f-3322-1c36">
           <characteristics>
             <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Any Hero Phase</characteristic>
-            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb"/>
-            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">You can spend 1 or more of this unit's **grisly remains points**. For each point spent, pick a friendly **^^Gutbusters^^** unit wholly within 12&quot; of this unit to be the target, then pick 1 of the following effects: 
-***Bloodgruel:*** The target has **^^Ward (5+)^^** for the rest of the turn.
-***Spinemarrow:*** Add 1 to the Attacks characteristic of the target's melee weapons for the rest of the turn.</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">If this unit's cauldron is **filled with grisly remains**, pick a visible friendly **^^Mawseekers^^** unit wholly within 12&quot; of this unit to be the target.</characteristic>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">This unit's cauldron is now **empty**. Pick 1 of the following effects:
+***Bloodgruel:*** The target has **^^Ward (5+)^^** for the rest of the turn.
+***Spinemarrow:*** Add 1 to the Attacks characteristic of the target's melee weapons for the rest of the turn.</characteristic>
             <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
             <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
           </characteristics>
@@ -395,30 +395,13 @@ Then, roll a dice. On a 3+, until the start of your next turn, the target cannot
         <categoryLink name="OGOR MAWTRIBES" hidden="false" id="c2f2-4734-8b6f-559c" targetId="743-1bd8-e3d-ced2" primary="false"/>
         <categoryLink name="INFANTRY" hidden="false" id="e9c9-7a92-6605-b17e" targetId="75d6-6995-dfcc-3898" primary="false"/>
         <categoryLink name="OGOR" hidden="false" id="c0ff-ba69-326c-4158" targetId="ddcb-3c91-472f-c35a" primary="false"/>
-        <categoryLink name="GUTBUSTERS" hidden="false" id="8f89-1fc1-c94b-7c99" targetId="5c0d-5e93-d71f-f0da" primary="false"/>
+        <categoryLink name="MAWSEEKERS" hidden="false" id="8f89-1fc1-c94b-7c99" targetId="b50b-6a98-f92a-c99c" primary="false"/>
         <categoryLink name="WIZARD (1)" hidden="false" id="a324-c9ce-3e79-1390" targetId="6f28-c3f6-4b1b-8aff" primary="false"/>
+      <categoryLink name="WARD (6+)" hidden="false" id="6d2e-8a04-19f7-c3b5" targetId="70a4-383f-421f-52cd" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry type="model" import="true" name="Slaughtermaster" hidden="false" id="dd2-2f8d-5c8a-8208">
           <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Gnoblars&apos; Implements" hidden="false" id="10da-8d85-539c-71f3">
-              <profiles>
-                <profile name="Gnoblars&apos; Implements" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="74f1-93a-a85c-8497">
-                  <characteristics>
-                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">3</characteristic>
-                    <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">5+</characteristic>
-                    <characteristic name="Wnd" typeId="61c1-22cc-40af-2847">5+</characteristic>
-                    <characteristic name="Rnd" typeId="eccc-10fa-6958-fb73">-</characteristic>
-                    <characteristic name="Dmg" typeId="e948-9c71-12a6-6be4">1</characteristic>
-                    <characteristic name="Ability" typeId="eda3-7332-5db1-4159">Companion</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="c194-2042-c328-41bd"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="d772-5cf8-21e8-fe3d"/>
-              </constraints>
-            </selectionEntry>
             <selectionEntry type="upgrade" import="true" name="Stump Blades" hidden="false" id="b1d2-1119-7e20-cd96">
               <profiles>
                 <profile name="Stump Blades" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="23ea-7482-8476-9cb7">
@@ -2210,7 +2193,7 @@ Then, roll a dice. On a 3+, until the start of your next turn, the target cannot
                 <profile name="Leadbelcher Gun" typeId="1fd-a42f-41d3-fe05" typeName="Ranged Weapon" hidden="false" id="5b5e-61bb-c592-c812">
                   <characteristics>
                     <characteristic name="Rng" typeId="c6b5-908c-a604-1a98">15&quot;</characteristic>
-                    <characteristic name="Atk" typeId="aa17-4296-2887-e05d">D3</characteristic>
+                    <characteristic name="Atk" typeId="aa17-4296-2887-e05d">2</characteristic>
                     <characteristic name="Hit" typeId="194d-aeb6-5ba7-83b4">4+</characteristic>
                     <characteristic name="Wnd" typeId="d3d5-9dc6-13de-8d1">3+</characteristic>
                     <characteristic name="Rnd" typeId="d03f-a9ae-3eec-755">1</characteristic>
@@ -4198,7 +4181,7 @@ Add 1 to casting rolls for visible friendly **^^Mawseekers Wizards^^** while the
             <characteristic name="Move" typeId="fed0-d1b3-1bb8-c501">6&quot;</characteristic>
             <characteristic name="Health" typeId="96be-54ae-ce7b-10b7">7</characteristic>
             <characteristic name="Save" typeId="1981-ef09-96f6-7aa9">5+</characteristic>
-            <characteristic name="Control" typeId="6c6f-8510-9ce1-fc6e">5</characteristic>
+            <characteristic name="Control" typeId="6c6f-8510-9ce1-fc6e">3</characteristic>
           </characteristics>
         </profile>
         <profile name="Torrent of Flame" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="8b2e-fc78-685-78b4">
@@ -4284,7 +4267,7 @@ Add 1 to casting rolls for visible friendly **^^Mawseekers Wizards^^** while the
             <characteristic name="Move" typeId="fed0-d1b3-1bb8-c501">6&quot;</characteristic>
             <characteristic name="Health" typeId="96be-54ae-ce7b-10b7">7</characteristic>
             <characteristic name="Save" typeId="1981-ef09-96f6-7aa9">5+</characteristic>
-            <characteristic name="Control" typeId="6c6f-8510-9ce1-fc6e">5</characteristic>
+            <characteristic name="Control" typeId="6c6f-8510-9ce1-fc6e">3</characteristic>
           </characteristics>
         </profile>
         <profile name="Masters of Ambush" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="b4f2-dae1-5bcb-a57a">
@@ -4335,7 +4318,7 @@ Add 1 to casting rolls for visible friendly **^^Mawseekers Wizards^^** while the
                     <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">4+</characteristic>
                     <characteristic name="Wnd" typeId="61c1-22cc-40af-2847">2+</characteristic>
                     <characteristic name="Rnd" typeId="eccc-10fa-6958-fb73">-</characteristic>
-                    <characteristic name="Dmg" typeId="e948-9c71-12a6-6be4">1</characteristic>
+                    <characteristic name="Dmg" typeId="e948-9c71-12a6-6be4">2</characteristic>
                     <characteristic name="Ability" typeId="eda3-7332-5db1-4159">Anti-**^^Monster^^** (+1 Rend)</characteristic>
                   </characteristics>
                 </profile>
@@ -4345,14 +4328,14 @@ Add 1 to casting rolls for visible friendly **^^Mawseekers Wizards^^** while the
                 <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="84ba-f5d7-44d9-f903"/>
               </constraints>
             </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Hunter&apos;s Crossbow" hidden="false" id="2efb-4abb-d000-8b93">
+            <selectionEntry type="upgrade" import="true" name="Great Throwing Spear and Crossbow" hidden="false" id="2efb-4abb-d000-8b93">
               <profiles>
-                <profile name="Hunter&apos;s Crossbow" typeId="1fd-a42f-41d3-fe05" typeName="Ranged Weapon" hidden="false" id="13ea-3879-837c-235e">
+                <profile name="Great Throwing Spear and Crossbow" typeId="1fd-a42f-41d3-fe05" typeName="Ranged Weapon" hidden="false" id="13ea-3879-837c-235e">
                   <characteristics>
                     <characteristic name="Rng" typeId="c6b5-908c-a604-1a98">12&quot;</characteristic>
-                    <characteristic name="Atk" typeId="aa17-4296-2887-e05d">1</characteristic>
+                    <characteristic name="Atk" typeId="aa17-4296-2887-e05d">2</characteristic>
                     <characteristic name="Hit" typeId="194d-aeb6-5ba7-83b4">4+</characteristic>
-                    <characteristic name="Wnd" typeId="d3d5-9dc6-13de-8d1">2+</characteristic>
+                    <characteristic name="Wnd" typeId="d3d5-9dc6-13de-8d1">3+</characteristic>
                     <characteristic name="Rnd" typeId="d03f-a9ae-3eec-755">-</characteristic>
                     <characteristic name="Dmg" typeId="96c2-d0a5-ea1e-653b">D3</characteristic>
                     <characteristic name="Ability" typeId="d793-3dd7-9c13-741e">Anti-**^^Monster^^** (+1 Rend)</characteristic>
@@ -4362,25 +4345,6 @@ Add 1 to casting rolls for visible friendly **^^Mawseekers Wizards^^** while the
               <constraints>
                 <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="e070-44a1-ab8c-b44"/>
                 <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ab0f-4d3a-43a6-f85f"/>
-              </constraints>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Great Throwing Spear" hidden="false" id="9483-f961-5fc5-f52d">
-              <profiles>
-                <profile name="Great Throwing Spear" typeId="1fd-a42f-41d3-fe05" typeName="Ranged Weapon" hidden="false" id="1ec1-3c5f-b756-9ba0">
-                  <characteristics>
-                    <characteristic name="Rng" typeId="c6b5-908c-a604-1a98">10&quot;</characteristic>
-                    <characteristic name="Atk" typeId="aa17-4296-2887-e05d">1</characteristic>
-                    <characteristic name="Hit" typeId="194d-aeb6-5ba7-83b4">4+</characteristic>
-                    <characteristic name="Wnd" typeId="d3d5-9dc6-13de-8d1">3+</characteristic>
-                    <characteristic name="Rnd" typeId="d03f-a9ae-3eec-755">1</characteristic>
-                    <characteristic name="Dmg" typeId="96c2-d0a5-ea1e-653b">D3</characteristic>
-                    <characteristic name="Ability" typeId="d793-3dd7-9c13-741e">Anti-**^^Monster^^** (+1 Rend)</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="353-f3ce-5618-7f82"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="166a-22ac-4e34-c696"/>
               </constraints>
             </selectionEntry>
           </selectionEntries>
@@ -4414,6 +4378,17 @@ Add 1 to casting rolls for visible friendly **^^Mawseekers Wizards^^** while the
           <attributes>
             <attribute name="Color" typeId="50fe-4f29-6bc3-dcc6">Green</attribute>
             <attribute name="Type" typeId="bf11-4e10-3ab1-06f4">Defensive</attribute>
+            <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
+          </attributes>
+        </profile>
+        <profile name="Gutless" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="1f5a-3b2c-9d81-4e60">
+          <characteristics>
+            <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
+            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">This unit cannot use the 'Bull Charge' ability.</characteristic>
+          </characteristics>
+          <attributes>
+            <attribute name="Color" typeId="50fe-4f29-6bc3-dcc6">Red</attribute>
+            <attribute name="Type" typeId="bf11-4e10-3ab1-06f4">Special</attribute>
             <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
           </attributes>
         </profile>
@@ -4456,7 +4431,7 @@ Add 1 to casting rolls for visible friendly **^^Mawseekers Wizards^^** while the
                     <characteristic name="Wnd" typeId="61c1-22cc-40af-2847">3+</characteristic>
                     <characteristic name="Rnd" typeId="eccc-10fa-6958-fb73">1</characteristic>
                     <characteristic name="Dmg" typeId="e948-9c71-12a6-6be4">1</characteristic>
-                    <characteristic name="Ability" typeId="eda3-7332-5db1-4159">-</characteristic>
+                    <characteristic name="Ability" typeId="eda3-7332-5db1-4159">Companion</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
@@ -4495,6 +4470,17 @@ Add 1 to casting rolls for visible friendly **^^Mawseekers Wizards^^** while the
             <attribute name="Color" typeId="5a11-eab3-180c-ddf5">Orange</attribute>
             <attribute name="Type" typeId="6d16-c86b-2698-85a4">Offensive</attribute>
             <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+          </attributes>
+        </profile>
+        <profile name="Gutless" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="2c6b-4d3e-8a92-5f71">
+          <characteristics>
+            <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
+            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">This unit cannot use the 'Bull Charge' ability.</characteristic>
+          </characteristics>
+          <attributes>
+            <attribute name="Color" typeId="50fe-4f29-6bc3-dcc6">Red</attribute>
+            <attribute name="Type" typeId="bf11-4e10-3ab1-06f4">Special</attribute>
+            <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
           </attributes>
         </profile>
       </profiles>
@@ -4613,7 +4599,6 @@ Add 1 to casting rolls for visible friendly **^^Mawseekers Wizards^^** while the
         <categoryLink name="DESTRUCTION" hidden="false" id="5267-3363-61e6-989e" targetId="9057-5a29-dda5-3c28" primary="false"/>
         <categoryLink name="BEASTCLAW" hidden="false" id="4a-5403-2c22-17d1" targetId="410d-6b15-3cf4-88d0" primary="false"/>
         <categoryLink name="INFANTRY" hidden="false" id="27e6-f6c1-8e02-f8ce" targetId="75d6-6995-dfcc-3898" primary="true"/>
-        <categoryLink name="WARD (6+)" hidden="false" id="79d5-99c8-5df6-ad95" targetId="70a4-383f-421f-52cd" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry type="model" import="true" name="Icefall Yhetee" hidden="false" id="9e89-4d5f-6604-4a47" defaultAmount="3">
@@ -4725,7 +4710,7 @@ Add 1 to casting rolls for visible friendly **^^Mawseekers Wizards^^** while the
                     <characteristic name="Hit" typeId="194d-aeb6-5ba7-83b4">3+</characteristic>
                     <characteristic name="Wnd" typeId="d3d5-9dc6-13de-8d1">3+</characteristic>
                     <characteristic name="Rnd" typeId="d03f-a9ae-3eec-755">1</characteristic>
-                    <characteristic name="Dmg" typeId="96c2-d0a5-ea1e-653b">D3</characteristic>
+                    <characteristic name="Dmg" typeId="96c2-d0a5-ea1e-653b">2</characteristic>
                     <characteristic name="Ability" typeId="d793-3dd7-9c13-741e">Shoot in Combat</characteristic>
                   </characteristics>
                 </profile>
@@ -4776,17 +4761,6 @@ Add 1 to casting rolls for visible friendly **^^Mawseekers Wizards^^** while the
           <attributes>
             <attribute name="Color" typeId="50fe-4f29-6bc3-dcc6">Black</attribute>
             <attribute name="Type" typeId="bf11-4e10-3ab1-06f4">Special</attribute>
-            <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
-          </attributes>
-        </profile>
-        <profile name="Lumpen Wall of Flesh" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="3c2-be9b-e291-75a1">
-          <characteristics>
-            <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
-            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">Subtract 1 from wound rolls for shooting attacks that target friendly **^^Beastclaw Raiders^^** units while they are within this unit's combat range.</characteristic>
-          </characteristics>
-          <attributes>
-            <attribute name="Color" typeId="50fe-4f29-6bc3-dcc6">Green</attribute>
-            <attribute name="Type" typeId="bf11-4e10-3ab1-06f4">Defensive</attribute>
             <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
           </attributes>
         </profile>
@@ -4850,42 +4824,11 @@ Add 1 to casting rolls for visible friendly **^^Mawseekers Wizards^^** while the
                     <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">4+</characteristic>
                     <characteristic name="Wnd" typeId="61c1-22cc-40af-2847">2+</characteristic>
                     <characteristic name="Rnd" typeId="eccc-10fa-6958-fb73">1</characteristic>
-                    <characteristic name="Dmg" typeId="e948-9c71-12a6-6be4">2</characteristic>
-                    <characteristic name="Ability" typeId="eda3-7332-5db1-4159">Companion</characteristic>
+                    <characteristic name="Dmg" typeId="e948-9c71-12a6-6be4">1</characteristic>
+                    <characteristic name="Ability" typeId="eda3-7332-5db1-4159">Charge (+1 Damage), Companion</characteristic>
                   </characteristics>
                 </profile>
               </profiles>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Ironlock Pistol" hidden="false" id="262e-28e0-3f84-5967">
-              <constraints>
-                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="86a8-34ce-c79a-acf3" automatic="true"/>
-                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="5285-c12f-ecce-bb05" automatic="true"/>
-              </constraints>
-              <profiles>
-                <profile name="Ironlock Pistol" typeId="1fd-a42f-41d3-fe05" typeName="Ranged Weapon" hidden="false" id="7386-d945-36a3-ac92">
-                  <characteristics>
-                    <characteristic name="Rng" typeId="c6b5-908c-a604-1a98">10&quot;</characteristic>
-                    <characteristic name="Atk" typeId="aa17-4296-2887-e05d">1</characteristic>
-                    <characteristic name="Hit" typeId="194d-aeb6-5ba7-83b4">4+</characteristic>
-                    <characteristic name="Wnd" typeId="d3d5-9dc6-13de-8d1">3+</characteristic>
-                    <characteristic name="Rnd" typeId="d03f-a9ae-3eec-755">1</characteristic>
-                    <characteristic name="Dmg" typeId="96c2-d0a5-ea1e-653b">D3</characteristic>
-                    <characteristic name="Ability" typeId="d793-3dd7-9c13-741e">Shoot in Combat</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <modifiers>
-                <modifier type="set" value="0" field="5285-c12f-ecce-bb05">
-                  <conditions>
-                    <condition type="lessThan" value="1" field="selections" scope="parent" childId="31e7-5cb6-3efe-99c3" shared="true"/>
-                  </conditions>
-                </modifier>
-                <modifier type="set" value="0" field="86a8-34ce-c79a-acf3">
-                  <conditions>
-                    <condition type="lessThan" value="1" field="selections" scope="parent" childId="31e7-5cb6-3efe-99c3" shared="true"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups>

--- a/Ogor Mawtribes - Library.cat
+++ b/Ogor Mawtribes - Library.cat
@@ -348,7 +348,7 @@ Then, roll a dice. On a 3+, until the start of your next turn, the target cannot
         </selectionEntry>
       </selectionEntries>
     </selectionEntry>
-    <selectionEntry type="unit" import="true" name="Slaughtermaster (Scourge of Ghyran)" hidden="false" id="3d51-af3a-455e-2373" publicationId="f894-7929-f79a-a269">
+    <selectionEntry type="unit" import="true" name="Slaughtermaster" hidden="false" id="3d51-af3a-455e-2373" publicationId="1ac6-e227-a186-12">
       <entryLinks>
         <entryLink import="true" name="General" hidden="false" id="14f4-e9ed-ba86-f601" type="selectionEntry" targetId="a56b-952e-ad15-7868"/>
       </entryLinks>
@@ -2138,7 +2138,7 @@ Then, roll a dice. On a 3+, until the start of your next turn, the target cannot
         </selectionEntry>
       </selectionEntries>
     </selectionEntry>
-    <selectionEntry type="unit" import="true" name="Leadbelchers (Scourge of Ghyran)" hidden="false" id="15cd-469c-4ed6-afef" publicationId="f894-7929-f79a-a269">
+    <selectionEntry type="unit" import="true" name="Leadbelchers" hidden="false" id="15cd-469c-4ed6-afef" publicationId="1ac6-e227-a186-12">
       <profiles>
         <profile name="Leadbelchers" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="7623-a53d-8c13-ace">
           <characteristics>
@@ -4187,6 +4187,830 @@ Add 1 to casting rolls for visible friendly **^^Mawseekers Wizards^^** while the
           </rules>
         </selectionEntry>
       </selectionEntries>
+    </selectionEntry>
+    <selectionEntry type="unit" import="true" name="Firebelly" hidden="false" id="d5f3-a7f1-7345-ee4b" publicationId="1ac6-e227-a186-12">
+      <entryLinks>
+        <entryLink import="true" name="General" hidden="false" id="865f-cc20-a5e0-c728" type="selectionEntry" targetId="a56b-952e-ad15-7868"/>
+      </entryLinks>
+      <profiles>
+        <profile name="Firebelly" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="2958-d07d-bc66-6747">
+          <characteristics>
+            <characteristic name="Move" typeId="fed0-d1b3-1bb8-c501">6&quot;</characteristic>
+            <characteristic name="Health" typeId="96be-54ae-ce7b-10b7">7</characteristic>
+            <characteristic name="Save" typeId="1981-ef09-96f6-7aa9">5+</characteristic>
+            <characteristic name="Control" typeId="6c6f-8510-9ce1-fc6e">5</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Torrent of Flame" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="8b2e-fc78-685-78b4">
+          <characteristics>
+            <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
+            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">Add 1 to the Damage characteristic of this unit's **Fire Breath** for attacks that target **^^Infantry^^**.</characteristic>
+          </characteristics>
+          <attributes>
+            <attribute name="Color" typeId="50fe-4f29-6bc3-dcc6">Blue</attribute>
+            <attribute name="Type" typeId="bf11-4e10-3ab1-06f4">Shooting</attribute>
+            <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
+          </attributes>
+        </profile>
+      </profiles>
+      <categoryLinks>
+        <categoryLink name="HERO" hidden="false" id="6bb3-8d4d-d217-88d3" targetId="6e72-1656-d554-528a" primary="true"/>
+        <categoryLink name="DESTRUCTION" hidden="false" id="5b6a-b415-a4e6-db20" targetId="9057-5a29-dda5-3c28" primary="false"/>
+        <categoryLink name="OGOR MAWTRIBES" hidden="false" id="ea30-e422-7d9e-89ed" targetId="743-1bd8-e3d-ced2" primary="false"/>
+        <categoryLink name="INFANTRY" hidden="false" id="f474-7dd3-c9f5-2617" targetId="75d6-6995-dfcc-3898" primary="false"/>
+        <categoryLink name="OGOR" hidden="false" id="4955-50e5-1900-e3de" targetId="ddcb-3c91-472f-c35a" primary="false"/>
+        <categoryLink name="WIZARD (1)" hidden="false" id="e306-a79e-9af5-c2df" targetId="6f28-c3f6-4b1b-8aff" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry type="model" import="true" name="Firebelly" hidden="false" id="f0d1-9063-8c9a-d0f6">
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Basalt Hammer" hidden="false" id="c24-66b0-8815-56db">
+              <profiles>
+                <profile name="Basalt Hammer" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="f18c-1456-2035-ade2">
+                  <characteristics>
+                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">3</characteristic>
+                    <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">4+</characteristic>
+                    <characteristic name="Wnd" typeId="61c1-22cc-40af-2847">2+</characteristic>
+                    <characteristic name="Rnd" typeId="eccc-10fa-6958-fb73">1</characteristic>
+                    <characteristic name="Dmg" typeId="e948-9c71-12a6-6be4">D3</characteristic>
+                    <characteristic name="Ability" typeId="eda3-7332-5db1-4159">-</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="ecd0-42e9-16b4-6458"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="7a9-f0be-16da-bbb"/>
+              </constraints>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Fire Breath" hidden="false" id="65bc-2922-ba40-1500">
+              <profiles>
+                <profile name="Fire Breath" typeId="1fd-a42f-41d3-fe05" typeName="Ranged Weapon" hidden="false" id="51ca-d54-3a37-d00">
+                  <characteristics>
+                    <characteristic name="Rng" typeId="c6b5-908c-a604-1a98">8&quot;</characteristic>
+                    <characteristic name="Atk" typeId="aa17-4296-2887-e05d">6</characteristic>
+                    <characteristic name="Hit" typeId="194d-aeb6-5ba7-83b4">2+</characteristic>
+                    <characteristic name="Wnd" typeId="d3d5-9dc6-13de-8d1">3+</characteristic>
+                    <characteristic name="Rnd" typeId="d03f-a9ae-3eec-755">-</characteristic>
+                    <characteristic name="Dmg" typeId="96c2-d0a5-ea1e-653b">1</characteristic>
+                    <characteristic name="Ability" typeId="d793-3dd7-9c13-741e">Shoot in Combat</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="d78d-2d4c-4370-16c"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="d913-78b-72dc-f834"/>
+              </constraints>
+            </selectionEntry>
+          </selectionEntries>
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="ffed-8784-f559-b554"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="2f6f-e2d3-9fb5-1a8"/>
+          </constraints>
+          <rules>
+            <rule name="Base Size" id="ef78-eac8-1f73-4c29" hidden="true">
+              <description>50mm</description>
+            </rule>
+          </rules>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntry>
+    <selectionEntry type="unit" import="true" name="Icebrow Hunter" hidden="false" id="8ea1-2719-4da0-2b1f" publicationId="1ac6-e227-a186-12">
+      <entryLinks>
+        <entryLink import="true" name="General" hidden="false" id="d23b-ec94-dd1d-159a" type="selectionEntry" targetId="a56b-952e-ad15-7868"/>
+      </entryLinks>
+      <profiles>
+        <profile name="Icebrow Hunter" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="1865-2c41-af66-d56e">
+          <characteristics>
+            <characteristic name="Move" typeId="fed0-d1b3-1bb8-c501">6&quot;</characteristic>
+            <characteristic name="Health" typeId="96be-54ae-ce7b-10b7">7</characteristic>
+            <characteristic name="Save" typeId="1981-ef09-96f6-7aa9">5+</characteristic>
+            <characteristic name="Control" typeId="6c6f-8510-9ce1-fc6e">5</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Masters of Ambush" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="b4f2-dae1-5bcb-a57a">
+          <characteristics>
+            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Deployment Phase</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick this unit and up to 2 friendly **Frost Sabres** units if those units have not been deployed.</characteristic>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Set up those units in reserve **outflanking the prey**. They have now been deployed.</characteristic>
+            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f">**^^Deploy^^**</characteristic>
+            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+          </characteristics>
+          <attributes>
+            <attribute name="Color" typeId="5a11-eab3-180c-ddf5">Black</attribute>
+            <attribute name="Type" typeId="6d16-c86b-2698-85a4">Special</attribute>
+            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+          </attributes>
+        </profile>
+        <profile name="The Hunt Is On" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="166-c7f0-b1cf-33e8">
+          <characteristics>
+            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Your Movement Phase</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick this unit if it is **outflanking the prey**.</characteristic>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Set up this unit wholly within 9&quot; of a battlefield edge and more than 9&quot; from all enemy units. Then, set up each **Frost Sabres** unit that was set up **outflanking the prey** with this unit wholly within 12&quot; of it and more than 9&quot; from all enemy units.</characteristic>
+            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+          </characteristics>
+          <attributes>
+            <attribute name="Color" typeId="5a11-eab3-180c-ddf5">Gray</attribute>
+            <attribute name="Type" typeId="6d16-c86b-2698-85a4">Movement</attribute>
+            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+          </attributes>
+        </profile>
+      </profiles>
+      <categoryLinks>
+        <categoryLink name="HERO" hidden="false" id="dfd7-5488-ce47-a3d7" targetId="6e72-1656-d554-528a" primary="true"/>
+        <categoryLink name="DESTRUCTION" hidden="false" id="9087-af28-325c-589c" targetId="9057-5a29-dda5-3c28" primary="false"/>
+        <categoryLink name="OGOR MAWTRIBES" hidden="false" id="136c-eb6a-4143-2f86" targetId="743-1bd8-e3d-ced2" primary="false"/>
+        <categoryLink name="INFANTRY" hidden="false" id="86ff-142e-51c-48bc" targetId="75d6-6995-dfcc-3898" primary="false"/>
+        <categoryLink name="OGOR" hidden="false" id="11cf-a129-32f2-133b" targetId="ddcb-3c91-472f-c35a" primary="false"/>
+        <categoryLink name="BEASTCLAW" hidden="false" id="db40-8cfe-e17b-3d98" targetId="410d-6b15-3cf4-88d0" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry type="model" import="true" name="Icebrow Hunter" hidden="false" id="3a2c-8e6-4439-9c84">
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Culling Club" hidden="false" id="3f64-7243-e90d-ab5d">
+              <profiles>
+                <profile name="Culling Club" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="8e54-8457-3296-f432">
+                  <characteristics>
+                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">4</characteristic>
+                    <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">4+</characteristic>
+                    <characteristic name="Wnd" typeId="61c1-22cc-40af-2847">2+</characteristic>
+                    <characteristic name="Rnd" typeId="eccc-10fa-6958-fb73">-</characteristic>
+                    <characteristic name="Dmg" typeId="e948-9c71-12a6-6be4">1</characteristic>
+                    <characteristic name="Ability" typeId="eda3-7332-5db1-4159">Anti-**^^Monster^^** (+1 Rend)</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="5cbf-dd27-d0da-6791"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="84ba-f5d7-44d9-f903"/>
+              </constraints>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Hunter&apos;s Crossbow" hidden="false" id="2efb-4abb-d000-8b93">
+              <profiles>
+                <profile name="Hunter&apos;s Crossbow" typeId="1fd-a42f-41d3-fe05" typeName="Ranged Weapon" hidden="false" id="13ea-3879-837c-235e">
+                  <characteristics>
+                    <characteristic name="Rng" typeId="c6b5-908c-a604-1a98">12&quot;</characteristic>
+                    <characteristic name="Atk" typeId="aa17-4296-2887-e05d">1</characteristic>
+                    <characteristic name="Hit" typeId="194d-aeb6-5ba7-83b4">4+</characteristic>
+                    <characteristic name="Wnd" typeId="d3d5-9dc6-13de-8d1">2+</characteristic>
+                    <characteristic name="Rnd" typeId="d03f-a9ae-3eec-755">-</characteristic>
+                    <characteristic name="Dmg" typeId="96c2-d0a5-ea1e-653b">D3</characteristic>
+                    <characteristic name="Ability" typeId="d793-3dd7-9c13-741e">Anti-**^^Monster^^** (+1 Rend)</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="e070-44a1-ab8c-b44"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ab0f-4d3a-43a6-f85f"/>
+              </constraints>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Great Throwing Spear" hidden="false" id="9483-f961-5fc5-f52d">
+              <profiles>
+                <profile name="Great Throwing Spear" typeId="1fd-a42f-41d3-fe05" typeName="Ranged Weapon" hidden="false" id="1ec1-3c5f-b756-9ba0">
+                  <characteristics>
+                    <characteristic name="Rng" typeId="c6b5-908c-a604-1a98">10&quot;</characteristic>
+                    <characteristic name="Atk" typeId="aa17-4296-2887-e05d">1</characteristic>
+                    <characteristic name="Hit" typeId="194d-aeb6-5ba7-83b4">4+</characteristic>
+                    <characteristic name="Wnd" typeId="d3d5-9dc6-13de-8d1">3+</characteristic>
+                    <characteristic name="Rnd" typeId="d03f-a9ae-3eec-755">1</characteristic>
+                    <characteristic name="Dmg" typeId="96c2-d0a5-ea1e-653b">D3</characteristic>
+                    <characteristic name="Ability" typeId="d793-3dd7-9c13-741e">Anti-**^^Monster^^** (+1 Rend)</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="353-f3ce-5618-7f82"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="166a-22ac-4e34-c696"/>
+              </constraints>
+            </selectionEntry>
+          </selectionEntries>
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="280-b9a8-7efd-afc5"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="7af1-19c4-b276-2082"/>
+          </constraints>
+          <rules>
+            <rule name="Base Size" id="554d-c614-1cef-a582" hidden="true">
+              <description>50mm</description>
+            </rule>
+          </rules>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntry>
+    <selectionEntry type="unit" import="true" name="Frost Sabres" hidden="false" id="bdf9-1644-707-f0df" publicationId="1ac6-e227-a186-12">
+      <profiles>
+        <profile name="Frost Sabres" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="343a-5c3b-d57c-8e3f">
+          <characteristics>
+            <characteristic name="Move" typeId="fed0-d1b3-1bb8-c501">9&quot;</characteristic>
+            <characteristic name="Health" typeId="96be-54ae-ce7b-10b7">3</characteristic>
+            <characteristic name="Save" typeId="1981-ef09-96f6-7aa9">6+</characteristic>
+            <characteristic name="Control" typeId="6c6f-8510-9ce1-fc6e">1</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Hunters of the Frozen Wilds" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="4659-aaed-5769-40f3">
+          <characteristics>
+            <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
+            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">This unit is not visible to enemy units while it is within 3&quot; of a terrain feature and more than 9&quot; from all enemy units.</characteristic>
+          </characteristics>
+          <attributes>
+            <attribute name="Color" typeId="50fe-4f29-6bc3-dcc6">Green</attribute>
+            <attribute name="Type" typeId="bf11-4e10-3ab1-06f4">Defensive</attribute>
+            <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
+          </attributes>
+        </profile>
+      </profiles>
+      <categoryLinks>
+        <categoryLink name="OGOR MAWTRIBES" hidden="false" id="5d52-99e5-9fc8-3a93" targetId="743-1bd8-e3d-ced2" primary="false"/>
+        <categoryLink name="DESTRUCTION" hidden="false" id="cf-ff21-afdd-1cd3" targetId="9057-5a29-dda5-3c28" primary="false"/>
+        <categoryLink name="BEAST" hidden="false" id="f874-6ee0-f64b-761c" targetId="b224-8c8e-ca93-9860" primary="true"/>
+        <categoryLink name="BEASTCLAW" hidden="false" id="70b9-4dcc-cf8b-ce89" targetId="410d-6b15-3cf4-88d0" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry type="model" import="true" name="Frost Sabre" hidden="false" id="ff22-edda-bf1c-6de1" defaultAmount="2">
+          <constraints>
+            <constraint type="min" value="2" field="selections" scope="parent" shared="false" id="48d1-272a-3da2-de"/>
+            <constraint type="max" value="2" field="selections" scope="parent" shared="false" id="9cff-ff53-3dbc-5b40"/>
+          </constraints>
+          <modifiers>
+            <modifier type="increment" value="2" field="48d1-272a-3da2-de">
+              <repeats>
+                <repeat value="1" repeats="1" field="selections" scope="bdf9-1644-707-f0df" childId="1b37-82b8-c062-eb82" shared="true" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="increment" value="2" field="9cff-ff53-3dbc-5b40">
+              <repeats>
+                <repeat value="1" repeats="1" field="selections" scope="bdf9-1644-707-f0df" childId="1b37-82b8-c062-eb82" shared="true" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Tusks and Claws" hidden="false" id="9fe7-4ca7-2b5d-b6da">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="6de8-fd16-d86-113a"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="afca-d218-c049-dab4"/>
+              </constraints>
+              <profiles>
+                <profile name="Tusks and Claws" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="cee1-6bd7-fcc1-d28c">
+                  <characteristics>
+                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">3</characteristic>
+                    <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">4+</characteristic>
+                    <characteristic name="Wnd" typeId="61c1-22cc-40af-2847">3+</characteristic>
+                    <characteristic name="Rnd" typeId="eccc-10fa-6958-fb73">1</characteristic>
+                    <characteristic name="Dmg" typeId="e948-9c71-12a6-6be4">1</characteristic>
+                    <characteristic name="Ability" typeId="eda3-7332-5db1-4159">-</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+          </selectionEntries>
+          <rules>
+            <rule name="Base Size" id="8211-b56a-3619-4357" hidden="true">
+              <description>60x35mm</description>
+            </rule>
+          </rules>
+        </selectionEntry>
+      </selectionEntries>
+      <infoLinks>
+        <infoLink name="Beast" id="ccc9-33e2-bd41-5361" hidden="false" type="profile" targetId="8e01-c681-8a44-8f44"/>
+      </infoLinks>
+    </selectionEntry>
+    <selectionEntry type="unit" import="true" name="Gnoblars" hidden="false" id="5d4b-756c-2229-3dd9" publicationId="1ac6-e227-a186-12">
+      <profiles>
+        <profile name="Gnoblars" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="87a-6fb7-c2d8-390e">
+          <characteristics>
+            <characteristic name="Move" typeId="fed0-d1b3-1bb8-c501">5&quot;</characteristic>
+            <characteristic name="Health" typeId="96be-54ae-ce7b-10b7">1</characteristic>
+            <characteristic name="Save" typeId="1981-ef09-96f6-7aa9">6+</characteristic>
+            <characteristic name="Control" typeId="6c6f-8510-9ce1-fc6e">1</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Nasty Traps and Tricks" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="7e21-a3f-d35e-eb57">
+          <characteristics>
+            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Any Charge Phase</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick an enemy unit within 6&quot; of this unit and that used a **^^Move^^** ability this turn to be the target. You cannot pick the same unit to be the target of this ability more than once per turn.</characteristic>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Roll a D3. On a 2+, inflict an amount of mortal damage on the target equal to the roll.</characteristic>
+            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+          </characteristics>
+          <attributes>
+            <attribute name="Color" typeId="5a11-eab3-180c-ddf5">Orange</attribute>
+            <attribute name="Type" typeId="6d16-c86b-2698-85a4">Offensive</attribute>
+            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+          </attributes>
+        </profile>
+      </profiles>
+      <categoryLinks>
+        <categoryLink name="INFANTRY" hidden="false" id="4f8f-e30-4c75-d020" targetId="75d6-6995-dfcc-3898" primary="true"/>
+        <categoryLink name="OGOR MAWTRIBES" hidden="false" id="4b13-c29d-65ed-a361" targetId="743-1bd8-e3d-ced2" primary="false"/>
+        <categoryLink name="DESTRUCTION" hidden="false" id="eba-e0c1-61e0-c82e" targetId="9057-5a29-dda5-3c28" primary="false"/>
+        <categoryLink name="CHAMPION" hidden="false" id="11-8130-ff14-2dff" targetId="f679-3bcb-d664-9ac3" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry type="model" import="true" name="Gnoblar" hidden="false" id="ce03-420-a035-4327" defaultAmount="1,19">
+          <constraints>
+            <constraint type="min" value="20" field="selections" scope="parent" shared="false" id="3c54-863a-cddb-6fe4"/>
+            <constraint type="max" value="20" field="selections" scope="parent" shared="false" id="e3fa-18b0-1061-48f9"/>
+          </constraints>
+          <modifiers>
+            <modifier type="increment" value="20" field="3c54-863a-cddb-6fe4">
+              <repeats>
+                <repeat value="1" repeats="1" field="selections" scope="5d4b-756c-2229-3dd9" childId="1b37-82b8-c062-eb82" shared="true" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="increment" value="20" field="e3fa-18b0-1061-48f9">
+              <repeats>
+                <repeat value="1" repeats="1" field="selections" scope="5d4b-756c-2229-3dd9" childId="1b37-82b8-c062-eb82" shared="true" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Sharp Stuff" hidden="false" id="f1c4-67d3-d408-bb0d">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="e38-ab8f-f89f-c453"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4fcc-ab16-6679-728c"/>
+              </constraints>
+              <profiles>
+                <profile name="Sharp Stuff" typeId="1fd-a42f-41d3-fe05" typeName="Ranged Weapon" hidden="false" id="580a-b610-a19f-6a8a">
+                  <characteristics>
+                    <characteristic name="Rng" typeId="c6b5-908c-a604-1a98">8&quot;</characteristic>
+                    <characteristic name="Atk" typeId="aa17-4296-2887-e05d">1</characteristic>
+                    <characteristic name="Hit" typeId="194d-aeb6-5ba7-83b4">4+</characteristic>
+                    <characteristic name="Wnd" typeId="d3d5-9dc6-13de-8d1">5+</characteristic>
+                    <characteristic name="Rnd" typeId="d03f-a9ae-3eec-755">-</characteristic>
+                    <characteristic name="Dmg" typeId="96c2-d0a5-ea1e-653b">1</characteristic>
+                    <characteristic name="Ability" typeId="d793-3dd7-9c13-741e">-</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Motley Assortment of Weapons" hidden="false" id="5561-763f-1fcf-729">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="a907-f671-dba4-f6d6"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="81db-bdb6-4ea9-97e"/>
+              </constraints>
+              <profiles>
+                <profile name="Motley Assortment of Weapons" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="4de8-7ad9-7563-18d8">
+                  <characteristics>
+                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">1</characteristic>
+                    <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">5+</characteristic>
+                    <characteristic name="Wnd" typeId="61c1-22cc-40af-2847">5+</characteristic>
+                    <characteristic name="Rnd" typeId="eccc-10fa-6958-fb73">-</characteristic>
+                    <characteristic name="Dmg" typeId="e948-9c71-12a6-6be4">1</characteristic>
+                    <characteristic name="Ability" typeId="eda3-7332-5db1-4159">-</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups>
+            <selectionEntryGroup name="Command Models" id="4acc-725-71cf-afe1" hidden="false">
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6424-7289-b3e3-971b"/>
+              </constraints>
+              <entryLinks>
+                <entryLink import="true" name="Champion" hidden="false" id="6943-180a-f7fb-871f" type="selectionEntry" targetId="9c21-1746-9873-a5b5" defaultAmount="1,0">
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="5d4b-756c-2229-3dd9" shared="true" id="d5fd-4968-e0dd-a935" includeChildSelections="true"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <rules>
+            <rule name="Base Size" id="bf1a-22e0-8cd8-a2d6" hidden="true">
+              <description>25mm</description>
+            </rule>
+          </rules>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntry>
+    <selectionEntry type="unit" import="true" name="Icefall Yhetees" hidden="false" id="5fed-90de-715-e720" publicationId="1ac6-e227-a186-12">
+      <profiles>
+        <profile name="Icefall Yhetees" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="f517-99cf-b23a-e92c">
+          <characteristics>
+            <characteristic name="Move" typeId="fed0-d1b3-1bb8-c501">6&quot;</characteristic>
+            <characteristic name="Health" typeId="96be-54ae-ce7b-10b7">4</characteristic>
+            <characteristic name="Save" typeId="1981-ef09-96f6-7aa9">6+</characteristic>
+            <characteristic name="Control" typeId="6c6f-8510-9ce1-fc6e">1</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Bounding Leaps" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="4725-1412-71e9-fefb">
+          <characteristics>
+            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Enemy Combat Phase</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb"/>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">This unit can move up to 3&quot;. It can move into combat.</characteristic>
+            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+          </characteristics>
+          <attributes>
+            <attribute name="Color" typeId="5a11-eab3-180c-ddf5">Red</attribute>
+            <attribute name="Type" typeId="6d16-c86b-2698-85a4">Movement</attribute>
+            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+          </attributes>
+        </profile>
+      </profiles>
+      <categoryLinks>
+        <categoryLink name="OGOR MAWTRIBES" hidden="false" id="9564-b525-f870-d7d" targetId="743-1bd8-e3d-ced2" primary="false"/>
+        <categoryLink name="DESTRUCTION" hidden="false" id="5267-3363-61e6-989e" targetId="9057-5a29-dda5-3c28" primary="false"/>
+        <categoryLink name="BEASTCLAW" hidden="false" id="4a-5403-2c22-17d1" targetId="410d-6b15-3cf4-88d0" primary="false"/>
+        <categoryLink name="INFANTRY" hidden="false" id="27e6-f6c1-8e02-f8ce" targetId="75d6-6995-dfcc-3898" primary="true"/>
+        <categoryLink name="WARD (6+)" hidden="false" id="79d5-99c8-5df6-ad95" targetId="70a4-383f-421f-52cd" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry type="model" import="true" name="Icefall Yhetee" hidden="false" id="9e89-4d5f-6604-4a47" defaultAmount="3">
+          <constraints>
+            <constraint type="min" value="3" field="selections" scope="parent" shared="false" id="9bb8-d985-c80d-2d1d"/>
+            <constraint type="max" value="3" field="selections" scope="parent" shared="false" id="f6f3-6487-12ad-9c78"/>
+          </constraints>
+          <modifiers>
+            <modifier type="increment" value="3" field="9bb8-d985-c80d-2d1d">
+              <repeats>
+                <repeat value="1" repeats="1" field="selections" scope="5fed-90de-715-e720" childId="1b37-82b8-c062-eb82" shared="true" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="increment" value="3" field="f6f3-6487-12ad-9c78">
+              <repeats>
+                <repeat value="1" repeats="1" field="selections" scope="5fed-90de-715-e720" childId="1b37-82b8-c062-eb82" shared="true" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Claws and Ice‑encrusted Weapons" hidden="false" id="8d2c-6b95-b316-59d">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="72ba-fa85-a66f-72c0"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="3ebe-90f3-1bd3-20e0"/>
+              </constraints>
+              <profiles>
+                <profile name="Claws and Ice‑encrusted Weapons" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="f057-a600-e068-bab8">
+                  <characteristics>
+                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">3</characteristic>
+                    <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">4+</characteristic>
+                    <characteristic name="Wnd" typeId="61c1-22cc-40af-2847">3+</characteristic>
+                    <characteristic name="Rnd" typeId="eccc-10fa-6958-fb73">1</characteristic>
+                    <characteristic name="Dmg" typeId="e948-9c71-12a6-6be4">2</characteristic>
+                    <characteristic name="Ability" typeId="eda3-7332-5db1-4159">-</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+          </selectionEntries>
+          <rules>
+            <rule name="Base Size" id="71c5-08f2-92d1-3fed" hidden="true">
+              <description>50mm</description>
+            </rule>
+          </rules>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntry>
+    <selectionEntry type="unit" import="true" name="Maneaters" hidden="false" id="f4ef-9156-1fd1-4b91" publicationId="1ac6-e227-a186-12">
+      <profiles>
+        <profile name="Maneaters" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="5108-f68-b882-ff9f">
+          <characteristics>
+            <characteristic name="Move" typeId="fed0-d1b3-1bb8-c501">6&quot;</characteristic>
+            <characteristic name="Health" typeId="96be-54ae-ce7b-10b7">4</characteristic>
+            <characteristic name="Save" typeId="1981-ef09-96f6-7aa9">5+</characteristic>
+            <characteristic name="Control" typeId="6c6f-8510-9ce1-fc6e">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Been There, Done That" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="250a-62aa-c07d-da93">
+          <characteristics>
+            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Turn (Army), Reaction: This unit was picked as the target of a non-**^^Core^^** ability</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb"/>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Roll a dice. On a 4+, that ability has no effect on this unit.</characteristic>
+            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+          </characteristics>
+          <attributes>
+            <attribute name="Color" typeId="5a11-eab3-180c-ddf5">Green</attribute>
+            <attribute name="Type" typeId="6d16-c86b-2698-85a4">Defensive</attribute>
+            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+          </attributes>
+        </profile>
+      </profiles>
+      <categoryLinks>
+        <categoryLink name="GUTBUSTERS" hidden="false" id="57a2-5623-1e35-dcec" targetId="5c0d-5e93-d71f-f0da"/>
+        <categoryLink name="INFANTRY" hidden="false" id="1634-1134-8da1-120f" targetId="75d6-6995-dfcc-3898" primary="true"/>
+        <categoryLink name="OGOR MAWTRIBES" hidden="false" id="8a29-12ba-d139-6ca6" targetId="743-1bd8-e3d-ced2" primary="false"/>
+        <categoryLink name="DESTRUCTION" hidden="false" id="99f6-5f47-1b4-fc64" targetId="9057-5a29-dda5-3c28" primary="false"/>
+        <categoryLink name="OGOR" hidden="false" id="8d5f-aae8-e6ea-2b6b" targetId="ddcb-3c91-472f-c35a" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry type="model" import="true" name="Maneater" hidden="false" id="228-71e4-5e10-bea5" defaultAmount="3">
+          <constraints>
+            <constraint type="min" value="3" field="selections" scope="parent" shared="false" id="f7c0-d527-9900-42bc"/>
+            <constraint type="max" value="3" field="selections" scope="parent" shared="false" id="2fd0-988-86de-c023"/>
+          </constraints>
+          <modifiers>
+            <modifier type="increment" value="3" field="f7c0-d527-9900-42bc">
+              <repeats>
+                <repeat value="1" repeats="1" field="selections" scope="f4ef-9156-1fd1-4b91" childId="1b37-82b8-c062-eb82" shared="true" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="increment" value="3" field="2fd0-988-86de-c023">
+              <repeats>
+                <repeat value="1" repeats="1" field="selections" scope="f4ef-9156-1fd1-4b91" childId="1b37-82b8-c062-eb82" shared="true" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Pistols or Throwing Weapons" hidden="false" id="5de9-7c5a-8446-20fe">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="80c9-898e-99a8-94c1"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="6e2f-c0b4-5771-5960"/>
+              </constraints>
+              <profiles>
+                <profile name="Pistols or Throwing Weapons" typeId="1fd-a42f-41d3-fe05" typeName="Ranged Weapon" hidden="false" id="cbcc-815f-f2dd-ecc5">
+                  <characteristics>
+                    <characteristic name="Rng" typeId="c6b5-908c-a604-1a98">10&quot;</characteristic>
+                    <characteristic name="Atk" typeId="aa17-4296-2887-e05d">1</characteristic>
+                    <characteristic name="Hit" typeId="194d-aeb6-5ba7-83b4">3+</characteristic>
+                    <characteristic name="Wnd" typeId="d3d5-9dc6-13de-8d1">3+</characteristic>
+                    <characteristic name="Rnd" typeId="d03f-a9ae-3eec-755">1</characteristic>
+                    <characteristic name="Dmg" typeId="96c2-d0a5-ea1e-653b">D3</characteristic>
+                    <characteristic name="Ability" typeId="d793-3dd7-9c13-741e">Shoot in Combat</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Maneater Weapons" hidden="false" id="f59e-e83f-25c5-7b6a">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="5895-6e2f-41fd-99a2"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="f205-f395-4c1f-2e1b"/>
+              </constraints>
+              <profiles>
+                <profile name="Maneater Weapons" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="130-9cb-91f6-82c5">
+                  <characteristics>
+                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">4</characteristic>
+                    <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">4+</characteristic>
+                    <characteristic name="Wnd" typeId="61c1-22cc-40af-2847">2+</characteristic>
+                    <characteristic name="Rnd" typeId="eccc-10fa-6958-fb73">1</characteristic>
+                    <characteristic name="Dmg" typeId="e948-9c71-12a6-6be4">2</characteristic>
+                    <characteristic name="Ability" typeId="eda3-7332-5db1-4159">-</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+          </selectionEntries>
+          <rules>
+            <rule name="Base Size" id="3199-9ff5-56e4-4605" hidden="true">
+              <description>50mm</description>
+            </rule>
+          </rules>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntry>
+    <selectionEntry type="unit" import="true" name="Mournfang Pack" hidden="false" id="b91b-cba6-89af-7225" publicationId="1ac6-e227-a186-12">
+      <profiles>
+        <profile name="Mournfang Pack" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="9fe6-b824-610c-cc8a">
+          <characteristics>
+            <characteristic name="Move" typeId="fed0-d1b3-1bb8-c501">9&quot;</characteristic>
+            <characteristic name="Health" typeId="96be-54ae-ce7b-10b7">6</characteristic>
+            <characteristic name="Save" typeId="1981-ef09-96f6-7aa9">4+</characteristic>
+            <characteristic name="Control" typeId="6c6f-8510-9ce1-fc6e">2</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Alpha Cavalry" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="aedb-3fcf-b1c9-b703">
+          <characteristics>
+            <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
+            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">The **Charge (+1 Damage)** weapon ability has no effect on attacks that target this unit.</characteristic>
+          </characteristics>
+          <attributes>
+            <attribute name="Color" typeId="50fe-4f29-6bc3-dcc6">Black</attribute>
+            <attribute name="Type" typeId="bf11-4e10-3ab1-06f4">Special</attribute>
+            <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
+          </attributes>
+        </profile>
+        <profile name="Lumpen Wall of Flesh" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="3c2-be9b-e291-75a1">
+          <characteristics>
+            <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
+            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">Subtract 1 from wound rolls for shooting attacks that target friendly **^^Beastclaw Raiders^^** units while they are within this unit's combat range.</characteristic>
+          </characteristics>
+          <attributes>
+            <attribute name="Color" typeId="50fe-4f29-6bc3-dcc6">Green</attribute>
+            <attribute name="Type" typeId="bf11-4e10-3ab1-06f4">Defensive</attribute>
+            <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
+          </attributes>
+        </profile>
+      </profiles>
+      <categoryLinks>
+        <categoryLink name="CHAMPION" hidden="false" id="769f-1572-2cf3-8c5b" targetId="f679-3bcb-d664-9ac3" primary="false"/>
+        <categoryLink name="OGOR MAWTRIBES" hidden="false" id="bf8f-f93a-4caf-d724" targetId="743-1bd8-e3d-ced2" primary="false"/>
+        <categoryLink name="DESTRUCTION" hidden="false" id="d7d4-b41e-47a5-ab04" targetId="9057-5a29-dda5-3c28" primary="false"/>
+        <categoryLink name="OGOR" hidden="false" id="8789-5af5-e267-80f0" targetId="ddcb-3c91-472f-c35a" primary="false"/>
+        <categoryLink name="MUSICIAN (1/4)" hidden="false" id="5817-52fa-639f-52f4" targetId="fe9c-1d27-a698-5f31" primary="false"/>
+        <categoryLink name="STANDARD BEARER (1/4)" hidden="false" id="5336-4224-b811-a441" targetId="7528-e097-91b0-f4f9" primary="false"/>
+        <categoryLink name="CAVALRY" hidden="false" id="a85e-1ee5-4e0f-ed07" targetId="926c-df8c-6841-d49e" primary="true"/>
+        <categoryLink name="BEASTCLAW" hidden="false" id="f0dc-2790-18cc-d999" targetId="410d-6b15-3cf4-88d0" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry type="model" import="true" name="Mournfang" hidden="false" id="8bf5-b52e-76a-a6ce" defaultAmount="1,1">
+          <constraints>
+            <constraint type="min" value="2" field="selections" scope="parent" shared="false" id="1111-cd61-e080-95b8"/>
+            <constraint type="max" value="2" field="selections" scope="parent" shared="false" id="9ea2-7f14-d4f9-e78c"/>
+          </constraints>
+          <modifiers>
+            <modifier type="increment" value="2" field="1111-cd61-e080-95b8">
+              <repeats>
+                <repeat value="1" repeats="1" field="selections" scope="b91b-cba6-89af-7225" childId="1b37-82b8-c062-eb82" shared="true" roundUp="false"/>
+              </repeats>
+            </modifier>
+            <modifier type="increment" value="2" field="9ea2-7f14-d4f9-e78c">
+              <repeats>
+                <repeat value="1" repeats="1" field="selections" scope="b91b-cba6-89af-7225" childId="1b37-82b8-c062-eb82" shared="true" roundUp="false"/>
+              </repeats>
+            </modifier>
+          </modifiers>
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Mournfang Rider Weapon" hidden="false" id="43c-cfb6-e4b5-d9cf">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="bfa9-21e3-2241-9b"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="65d0-31f0-73e9-f261"/>
+              </constraints>
+              <profiles>
+                <profile name="Mournfang Rider Weapon" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="e994-67d8-c77e-4ae5">
+                  <characteristics>
+                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">3</characteristic>
+                    <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">4+</characteristic>
+                    <characteristic name="Wnd" typeId="61c1-22cc-40af-2847">2+</characteristic>
+                    <characteristic name="Rnd" typeId="eccc-10fa-6958-fb73">1</characteristic>
+                    <characteristic name="Dmg" typeId="e948-9c71-12a6-6be4">2</characteristic>
+                    <characteristic name="Ability" typeId="eda3-7332-5db1-4159">Anti-**^^Cavalry^^** (+1 Rend)</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Mournfang&apos;s Tusks" hidden="false" id="9fc3-9e71-5da-c7da">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="7a50-4840-338e-95ea"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="a5b4-124a-9b89-cbc0"/>
+              </constraints>
+              <profiles>
+                <profile name="Mournfang&apos;s Tusks" typeId="9074-76b6-9e2f-81e3" typeName="Melee Weapon" hidden="false" id="70cf-ed25-c637-e60e">
+                  <characteristics>
+                    <characteristic name="Atk" typeId="60e-35aa-31ed-e488">4</characteristic>
+                    <characteristic name="Hit" typeId="26dc-168-b2fd-cb93">4+</characteristic>
+                    <characteristic name="Wnd" typeId="61c1-22cc-40af-2847">2+</characteristic>
+                    <characteristic name="Rnd" typeId="eccc-10fa-6958-fb73">1</characteristic>
+                    <characteristic name="Dmg" typeId="e948-9c71-12a6-6be4">2</characteristic>
+                    <characteristic name="Ability" typeId="eda3-7332-5db1-4159">Companion</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Ironlock Pistol" hidden="false" id="262e-28e0-3f84-5967">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="86a8-34ce-c79a-acf3" automatic="true"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="5285-c12f-ecce-bb05" automatic="true"/>
+              </constraints>
+              <profiles>
+                <profile name="Ironlock Pistol" typeId="1fd-a42f-41d3-fe05" typeName="Ranged Weapon" hidden="false" id="7386-d945-36a3-ac92">
+                  <characteristics>
+                    <characteristic name="Rng" typeId="c6b5-908c-a604-1a98">10&quot;</characteristic>
+                    <characteristic name="Atk" typeId="aa17-4296-2887-e05d">1</characteristic>
+                    <characteristic name="Hit" typeId="194d-aeb6-5ba7-83b4">4+</characteristic>
+                    <characteristic name="Wnd" typeId="d3d5-9dc6-13de-8d1">3+</characteristic>
+                    <characteristic name="Rnd" typeId="d03f-a9ae-3eec-755">1</characteristic>
+                    <characteristic name="Dmg" typeId="96c2-d0a5-ea1e-653b">D3</characteristic>
+                    <characteristic name="Ability" typeId="d793-3dd7-9c13-741e">Shoot in Combat</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <modifiers>
+                <modifier type="set" value="0" field="5285-c12f-ecce-bb05">
+                  <conditions>
+                    <condition type="lessThan" value="1" field="selections" scope="parent" childId="31e7-5cb6-3efe-99c3" shared="true"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" value="0" field="86a8-34ce-c79a-acf3">
+                  <conditions>
+                    <condition type="lessThan" value="1" field="selections" scope="parent" childId="31e7-5cb6-3efe-99c3" shared="true"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+            </selectionEntry>
+          </selectionEntries>
+          <selectionEntryGroups>
+            <selectionEntryGroup name="Command Models" id="ac09-9b3e-8a4a-d40f" hidden="false">
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="53fb-64f0-505f-fc39"/>
+              </constraints>
+              <entryLinks>
+                <entryLink import="true" name="Champion" hidden="false" id="31e7-5cb6-3efe-99c3" type="selectionEntry" targetId="9c21-1746-9873-a5b5" defaultAmount="1,0">
+                  <constraints>
+                    <constraint type="max" value="1" field="selections" scope="b91b-cba6-89af-7225" shared="true" id="39b7-f889-a2ee-f0ba" includeChildSelections="true"/>
+                  </constraints>
+                </entryLink>
+                <entryLink import="true" name="Standard Bearer" hidden="false" id="5ad5-5d3b-a307-fcac" type="selectionEntry" targetId="7f34-77c9-597-62c3" defaultAmount="0">
+                  <constraints>
+                    <constraint type="max" value="0" field="selections" scope="b91b-cba6-89af-7225" shared="true" id="11fb-bc3b-b32-7aa7" includeChildSelections="true"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="226f-38fb-3432-fa76"/>
+                  </constraints>
+                  <modifiers>
+                    <modifier type="increment" value="1" field="11fb-bc3b-b32-7aa7">
+                      <repeats>
+                        <repeat value="1" repeats="1" field="selections" scope="root-entry" childId="1b37-82b8-c062-eb82" shared="true" roundUp="false" includeChildSelections="true"/>
+                      </repeats>
+                    </modifier>
+                  </modifiers>
+                </entryLink>
+                <entryLink import="true" name="Musician" hidden="false" id="62e5-5365-2d6b-b95c" type="selectionEntry" targetId="2475-183b-3802-4431" defaultAmount="0">
+                  <constraints>
+                    <constraint type="max" value="0" field="selections" scope="b91b-cba6-89af-7225" shared="true" id="2838-a10e-f05f-71df" includeChildSelections="true"/>
+                    <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="77ee-a6f8-8dc3-6b9d"/>
+                  </constraints>
+                  <modifiers>
+                    <modifier type="increment" value="1" field="2838-a10e-f05f-71df">
+                      <repeats>
+                        <repeat value="1" repeats="1" field="selections" scope="root-entry" childId="1b37-82b8-c062-eb82" shared="true" roundUp="false" includeChildSelections="true"/>
+                      </repeats>
+                    </modifier>
+                  </modifiers>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <rules>
+            <rule name="Base Size" id="472e-0ead-edef-95b4" hidden="true">
+              <description>90x52mm</description>
+            </rule>
+          </rules>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntry>
+    <selectionEntry type="unit" import="true" name="Great Mawpot" hidden="false" id="2586-d28e-7404-b64e" publicationId="1ac6-e227-a186-12">
+      <categoryLinks>
+        <categoryLink name="FACTION TERRAIN" hidden="false" id="5881-79e3-fd84-7d8e" targetId="cdd6-ffa1-9b32-4cb8" primary="true"/>
+        <categoryLink name="DESTRUCTION" hidden="false" id="94fa-be80-135c-2694" targetId="9057-5a29-dda5-3c28" primary="false"/>
+        <categoryLink name="OGOR MAWTRIBES" hidden="false" id="ce04-3850-8fd0-d050" targetId="743-1bd8-e3d-ced2" primary="false"/>
+      </categoryLinks>
+      <profiles>
+        <profile name="Great Mawpot" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="a716-182b-d7ec-1794">
+          <characteristics>
+            <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
+            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">The **Great Mawpot** is either **full** or **empty**. It starts the battle **full**.</characteristic>
+          </characteristics>
+          <attributes>
+            <attribute name="Color" typeId="50fe-4f29-6bc3-dcc6">Black</attribute>
+            <attribute name="Type" typeId="bf11-4e10-3ab1-06f4">Special</attribute>
+            <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
+          </attributes>
+        </profile>
+        <profile name="Great Mawpot" typeId="ff03-376e-972f-8ab2" typeName="Unit" hidden="false" id="b94f-154c-51e9-8dc8">
+          <characteristics>
+            <characteristic name="Move" typeId="fed0-d1b3-1bb8-c501">-</characteristic>
+            <characteristic name="Health" typeId="96be-54ae-ce7b-10b7">6</characteristic>
+            <characteristic name="Save" typeId="1981-ef09-96f6-7aa9">5+</characteristic>
+            <characteristic name="Control" typeId="6c6f-8510-9ce1-fc6e">-</characteristic>
+          </characteristics>
+        </profile>
+        <profile name="Battlebroth" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="5d44-3637-a984-d185">
+          <characteristics>
+            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Your Hero Phase</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb"/>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">If the **Great Mawpot** is full, **Heal (D3)** each friendly unit wholly within 18&quot; of it. After you have done so, the **Great Mawpot** is empty.</characteristic>
+            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+          </characteristics>
+          <attributes>
+            <attribute name="Color" typeId="5a11-eab3-180c-ddf5">Yellow</attribute>
+            <attribute name="Type" typeId="6d16-c86b-2698-85a4">Defensive</attribute>
+            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+          </attributes>
+        </profile>
+        <profile name="Vessel of the Gulping God" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="21dc-31c8-ec8a-48aa">
+          <characteristics>
+            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Your Hero Phase</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">If the **Great Mawpot** is full, pick a friendly **^^Ogor Wizard^^** within 3&quot; of it to be the target.</characteristic>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Add 1 to the power level of the target for the rest of the turn.</characteristic>
+            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+          </characteristics>
+          <attributes>
+            <attribute name="Color" typeId="5a11-eab3-180c-ddf5">Yellow</attribute>
+            <attribute name="Type" typeId="6d16-c86b-2698-85a4">Special</attribute>
+            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+          </attributes>
+        </profile>
+        <profile name="Throw &apos;Em In" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="b0aa-620-8f45-ade0">
+          <characteristics>
+            <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
+            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">If an enemy model is slain within 6&quot; of the **Great Mawpot** when it is **empty**, it becomes **full**.</characteristic>
+          </characteristics>
+          <attributes>
+            <attribute name="Color" typeId="50fe-4f29-6bc3-dcc6">Black</attribute>
+            <attribute name="Type" typeId="bf11-4e10-3ab1-06f4">Special</attribute>
+            <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
+          </attributes>
+        </profile>
+      </profiles>
+      <rules>
+        <rule name="Great Mawpot" id="f456-7b92-79b3-c496" hidden="false">
+          <description>**The following universal terrain abilities apply to this terrain feature (Terrain, 1.2):
+Cover, Impassable**</description>
+        </rule>
+        <rule name="Base Size" id="9ef7-034c-f4d6-8429" hidden="true">
+          <description>Use model</description>
+        </rule>
+      </rules>
     </selectionEntry>
   </sharedSelectionEntries>
 </catalogue>

--- a/Ogor Mawtribes - Mawseeker Gollop.cat
+++ b/Ogor Mawtribes - Mawseeker Gollop.cat
@@ -1,0 +1,481 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue library="false" id="5dbd-f273-4a31-505e" name="Ogor Mawtribes - Mawseeker Gollop" gameSystemId="e51d-b1a3-75fc-dc3g" gameSystemRevision="2" revision="1" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <entryLinks>
+    <entryLink import="true" name="Butcher" hidden="false" id="b0eb-607d-5c1f-8927" type="selectionEntry" targetId="1688-fcbe-1470-a4ee">
+      <categoryLinks>
+        <categoryLink name="GOLLOP" hidden="false" id="a191-2500-ea44-354f" targetId="e216-2af1-9621-4956" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink import="true" name="Heroic Traits" hidden="false" id="4718-abe9-b74d-51de" type="selectionEntryGroup" targetId="8b16-67b6-8247-a7af"/>
+        <entryLink import="true" name="Artefacts of Power" hidden="false" id="f129-6f8d-adc9-7e05" type="selectionEntryGroup" targetId="ce8d-ae74-0f6f-d94d"/>
+        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="b2d0-3b06-144c-1f7f" type="selectionEntryGroup" targetId="2257-b8b2-7e29-bbba"/>
+        <entryLink import="true" name="Paths" hidden="false" id="59ca-2cf2-b100-b28c" type="selectionEntryGroup" targetId="8e0e-c373-30cc-14da"/>
+        <entryLink import="true" name="Warlord" hidden="false" id="8392-3fae-2fae-5dda" type="selectionEntry" targetId="bb28-fa4a-bf5f-f793"/>
+        <entryLink import="true" name="Renown" hidden="false" id="290d-862e-29b7-e7b7" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="7900-fadd-becc-5073" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="170"/>
+      </costs>
+      <modifiers>
+        <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="lessThan" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true" includeChildForces="true"/>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="set" value="true" field="hidden">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <modifierGroups>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.5c0d-5e93-d71f-f0da"/>
+            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.c79e-2820-22fd-7869"/>
+          </modifiers>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
+          </conditions>
+        </modifierGroup>
+      </modifierGroups>
+    </entryLink>
+    <entryLink import="true" name="Gorger Mawpack" hidden="false" id="c79e-2820-22fd-7869" type="selectionEntry" targetId="8d6b-1912-d60a-5163">
+      <categoryLinks>
+        <categoryLink name="GOLLOP" hidden="false" id="4f11-3b2a-3a24-d6ef" targetId="e216-2af1-9621-4956" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink import="true" name="Reinforced" hidden="false" id="b90c-05ab-befa-4553" type="selectionEntry" targetId="1b37-82b8-c062-eb82"/>
+        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="9c3a-fe95-27ea-d0a4" type="selectionEntryGroup" targetId="2257-b8b2-7e29-bbba"/>
+        <entryLink import="true" name="Paths" hidden="false" id="be05-956e-4b64-f05e" type="selectionEntryGroup" targetId="8e0e-c373-30cc-14da"/>
+        <entryLink import="true" name="Renown" hidden="false" id="2e0e-2544-d285-008b" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+      </entryLinks>
+      <modifiers>
+        <modifier type="multiply" value="2" field="points">
+          <conditions>
+            <condition type="atLeast" value="1" field="selections" scope="self" childId="1b37-82b8-c062-eb82" shared="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="set" value="true" field="hidden">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="db3a-7199-c92e-f3cf" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <costs>
+        <cost name="pts" typeId="points" value="240"/>
+      </costs>
+    </entryLink>
+    <entryLink import="true" name="Redd the Maw, High Slaughtermaster" hidden="false" id="585d-e5b9-f17f-7635" type="selectionEntry" targetId="63b1-7b0e-39da-a18f">
+      <categoryLinks>
+        <categoryLink name="GOLLOP" hidden="false" id="bcf6-b5b8-f580-1256" targetId="e216-2af1-9621-4956" primary="false"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="400"/>
+      </costs>
+      <entryLinks>
+        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="e766-2a0a-aaeb-1904" type="selectionEntryGroup" targetId="2257-b8b2-7e29-bbba"/>
+      </entryLinks>
+    </entryLink>
+    <entryLink import="true" name="Cleavers" hidden="false" id="bfec-ef46-75a4-d7d9" type="selectionEntry" targetId="7ad4-12cf-f68d-953f">
+      <categoryLinks>
+        <categoryLink name="GOLLOP" hidden="false" id="a684-adfa-f87d-e04e" targetId="e216-2af1-9621-4956" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink import="true" name="Reinforced" hidden="false" id="59f6-af66-2a58-cc08" type="selectionEntry" targetId="1b37-82b8-c062-eb82"/>
+        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="2967-3cd5-211e-6b24" type="selectionEntryGroup" targetId="2257-b8b2-7e29-bbba"/>
+        <entryLink import="true" name="Paths" hidden="false" id="bde5-73a9-45e5-3e40" type="selectionEntryGroup" targetId="8e0e-c373-30cc-14da"/>
+        <entryLink import="true" name="Renown" hidden="false" id="8ed8-14f8-dc6d-e155" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+      </entryLinks>
+      <modifiers>
+        <modifier type="multiply" value="2" field="points">
+          <conditions>
+            <condition type="atLeast" value="1" field="selections" scope="self" childId="1b37-82b8-c062-eb82" shared="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <costs>
+        <cost name="pts" typeId="points" value="220"/>
+      </costs>
+    </entryLink>
+    <entryLink import="true" name="Gutseers" hidden="false" id="2c21-2901-155d-e3a5" type="selectionEntry" targetId="5b64-1820-427e-0379">
+      <categoryLinks>
+        <categoryLink name="GOLLOP" hidden="false" id="06e9-9b40-f289-1fb2" targetId="e216-2af1-9621-4956" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink import="true" name="Reinforced" hidden="false" id="1b09-31e5-db1d-d6d9" type="selectionEntry" targetId="1b37-82b8-c062-eb82"/>
+        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="1a13-621b-3947-65a5" type="selectionEntryGroup" targetId="2257-b8b2-7e29-bbba"/>
+        <entryLink import="true" name="Paths" hidden="false" id="6974-a134-0267-9ae6" type="selectionEntryGroup" targetId="8e0e-c373-30cc-14da"/>
+        <entryLink import="true" name="Renown" hidden="false" id="3fdc-4063-1a44-1ba2" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+      </entryLinks>
+      <modifiers>
+        <modifier type="multiply" value="2" field="points">
+          <conditions>
+            <condition type="atLeast" value="1" field="selections" scope="self" childId="1b37-82b8-c062-eb82" shared="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <costs>
+        <cost name="pts" typeId="points" value="200"/>
+      </costs>
+    </entryLink>
+    <entryLink import="true" name="Battle Traits: Mawseeker Gollop" hidden="false" id="cb7f-e7a1-083a-41f8" type="selectionEntry" targetId="0dca-a9ed-0498-64f5"/>
+  </entryLinks>
+  <catalogueLinks>
+    <catalogueLink type="catalogue" name="Ogor Mawtribes - Library" id="40bf-b776-135e-6522" targetId="9a90-83e7-7a45-6aed"/>
+    <catalogueLink type="catalogue" name="✦ Path to Glory - Ravaged Coast" id="6900-5d45-c6e0-d148" importRootEntries="true" targetId="a434-b1ba-922b-7624"/>
+    <catalogueLink type="catalogue" name="❖ Lores" id="5b2a-55b0-e0cb-d7a3" targetId="0a11-cd61-2a4e-8e04" importRootEntries="true"/>
+    <catalogueLink type="catalogue" name="✦ Path to Glory - Ascension" id="2c11-23e1-bd74-a931" targetId="3a8b-7496-526f-feab" importRootEntries="true"/>
+    <catalogueLink type="catalogue" name="✦ Path to Glory - Blighted Wilds" id="f476-8c71-237e-4388" targetId="e0ff-dc7c-8795-bfb9" importRootEntries="true"/>
+  </catalogueLinks>
+  <categoryEntries>
+    <categoryEntry name="GOLLOP" id="e216-2af1-9621-4956" hidden="false"/>
+  </categoryEntries>
+  <sharedSelectionEntries>
+    <selectionEntry type="upgrade" import="true" name="Battle Traits: Mawseeker Gollop" hidden="false" id="0dca-a9ed-0498-64f5" publicationId="1ac6-e227-a186-12">
+      <profiles>
+        <profile name="Prepare the Feast" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="db6d-784b-de1c-00f3">
+          <characteristics>
+            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Turn (Army), Start of Any Turn</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb"/>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">If there is no friendly **Feastmaster** on the battlefield, pick a friendly **^^Gollop Hero^^** to be the **Feastmaster** for the rest of the battle.</characteristic>
+            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+          </characteristics>
+          <attributes>
+            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Black</attribute>
+            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Special</attribute>
+            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+          </attributes>
+        </profile>
+        <profile name="Ooh, That Looks Tasty..." typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="d28e-11ab-bb21-afe3">
+          <characteristics>
+            <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
+            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">Each time an enemy unit is destroyed, you gain a number of **raw ingredients**.
+
+The number of **raw ingredients** yielded by a destroyed unit is the Health characteristic of that unit multiplied by the number of starting models in that unit.
+
+***Designer&apos;s Note**: If a destroyed enemy unit had a Health characteristic of 2 and its starting size was 10 models, it would yield 20 raw ingredients when it was destroyed.*</characteristic>
+          </characteristics>
+          <attributes>
+            <attribute typeId="50fe-4f29-6bc3-dcc6" name="Color">Black</attribute>
+            <attribute typeId="bf11-4e10-3ab1-06f4" name="Type">Special</attribute>
+            <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
+          </attributes>
+        </profile>
+        <profile name="Gland Goulash" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="eb89-d0ed-2738-1cf7">
+          <characteristics>
+            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Turn (Army), Any Hero Phase</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Spend 10 **raw ingredients**.</characteristic>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">For the rest of the phase, add 1 to the number of dice rolled, to a maximum of 3, when making casting rolls and unbinding rolls for friendly **^^Gollop^^** units while they are wholly within 12&quot; of and visible to a friendly **Feastmaster**.</characteristic>
+            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+          </characteristics>
+          <attributes>
+            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Yellow</attribute>
+            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Special</attribute>
+            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+          </attributes>
+        </profile>
+        <profile name="Bone-Slurry Soup" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="0659-a33d-68df-5fcc">
+          <characteristics>
+            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Turn (Army), Any Shooting Phase</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Spend 5 **raw ingredients**.</characteristic>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Heal (D6) each friendly **^^Gollop^^** unit that is wholly within 12&quot; of and visible to a friendly **Feastmaster**.</characteristic>
+            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+          </characteristics>
+          <attributes>
+            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Blue</attribute>
+            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Rallying</attribute>
+            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+          </attributes>
+        </profile>
+        <profile name="The Organ Platter" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="d0db-2900-4f3d-fb40">
+          <characteristics>
+            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Turn (Army), Any Combat Phase</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Spend 20 **raw ingredients**.</characteristic>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">For the rest of the phase, while they are wholly within 12&quot; of a friendly **Feastmaster**, melee weapons used by friendly **^^Gollop^^** units have **Crit (Mortal)**.</characteristic>
+            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+          </characteristics>
+          <attributes>
+            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Red</attribute>
+            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Offensive</attribute>
+            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+          </attributes>
+        </profile>
+        <profile name="Gore-Offal Dumplings" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="4a8d-6f73-3c3f-1921">
+          <characteristics>
+            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Turn (Army), End of Any Turn</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Spend 10 **raw ingredients**.</characteristic>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Each friendly **^^Gollop^^** unit that is wholly within 12&quot; of and visible to a friendly **Feastmaster** can immediately use a **^^Charge^^** ability as if it were your charge phase, but subtract 1 from the number of dice rolled when making the charge roll for that unit.</characteristic>
+            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+          </characteristics>
+          <attributes>
+            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Purple</attribute>
+            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Movement</attribute>
+            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+          </attributes>
+        </profile>
+        <profile name="Unwashed Innards" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="44db-b0fb-04cb-f673">
+          <characteristics>
+            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Turn (Army), Any Movement Phase</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Spend 5 **raw ingredients**.</characteristic>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">For the rest of the phase, add 4 to run rolls for friendly **^^Gollop^^** units while they are wholly within 12&quot; of and visible to a friendly **Feastmaster**.</characteristic>
+            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+          </characteristics>
+          <attributes>
+            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Gray</attribute>
+            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Movement</attribute>
+            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+          </attributes>
+        </profile>
+        <profile name="Fried Limbs" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="d335-a0b2-52d9-142c">
+          <characteristics>
+            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Turn (Army), Any Charge Phase</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Spend 10 **raw ingredients**.</characteristic>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">For the rest of the phase, add 3 to charge rolls for friendly **^^Gollop^^** units while they are wholly within 12&quot; of and visible to a friendly **Feastmaster**.</characteristic>
+            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+          </characteristics>
+          <attributes>
+            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Orange</attribute>
+            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Movement</attribute>
+            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+          </attributes>
+        </profile>
+      </profiles>
+    </selectionEntry>
+  </sharedSelectionEntries>
+  <sharedSelectionEntryGroups>
+    <selectionEntryGroup name="Artefacts of Power" id="ce8d-ae74-0f6f-d94d" hidden="false">
+      <selectionEntryGroups>
+        <selectionEntryGroup name="Gollop Artefacts of Power" id="2f7b-77fa-0f27-5d1d" hidden="false">
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Overflowing Larder" hidden="false" id="8351-5f48-4e35-472e">
+              <profiles>
+                    <profile name="Overflowing Larder" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="f4be-f72c-f4d3-1d4c">
+                      <characteristics>
+                        <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Battle, Your Hero Phase</characteristic>
+                        <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb"/>
+                        <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Gain D6 **raw ingredients**. If this unit is a **Feastmaster**, gain D3+3 **raw ingredients** instead.</characteristic>
+                        <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+                        <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+                      </characteristics>
+                      <attributes>
+                        <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Yellow</attribute>
+                        <attribute typeId="6d16-c86b-2698-85a4" name="Type">Special</attribute>
+                        <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+                      </attributes>
+                    </profile>
+              </profiles>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="bfef-25f9-c31a-d65f" includeChildSelections="true"/>
+              </constraints>
+            </selectionEntry>
+          </selectionEntries>
+          <rules>
+            <rule name="Enhancement Restrictions" id="9497-e989-be1f-ec63" hidden="true">
+              <description>**^^Hero^^** only</description>
+            </rule>
+          </rules>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink import="true" name="Artefacts of Power" hidden="false" id="2264-e73c-7e60-89f6" type="selectionEntryGroup" targetId="e1b2-cedf-56a5-6bb1" flatten="true"/>
+        <entryLink import="true" name="Artefacts of Power" hidden="false" id="7f79-caeb-3932-8529" type="selectionEntryGroup" targetId="d563-838a-a901-097e"/>
+      </entryLinks>
+      <modifiers>
+        <modifier type="set" value="-1" field="d92a-9c0d-0538-4b45">
+          <conditions>
+            <condition type="atLeast" value="1" field="e63c-79ff-93ba-c5eb" scope="roster" childId="any" shared="true" includeChildSelections="true" includeChildForces="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="d92a-9c0d-0538-4b45" includeChildSelections="true"/>
+        <constraint type="max" value="1" field="selections" scope="root-entry" shared="true" id="aa3c-d025-6ad1-ddc9"/>
+      </constraints>
+    </selectionEntryGroup>
+    <selectionEntryGroup name="Heroic Traits" id="8b16-67b6-8247-a7af" hidden="false">
+      <selectionEntryGroups>
+        <selectionEntryGroup name="Gollop Heroic Traits" id="a830-da3e-280c-5501" hidden="false">
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Indomitable Guts" hidden="false" id="c864-2d4b-7a96-4b16">
+              <profiles>
+                    <profile name="Indomitable Guts" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="9a1f-4340-0ed9-0b85">
+                      <characteristics>
+                        <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
+                        <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">Add 1 to ward rolls for this unit.</characteristic>
+                      </characteristics>
+                      <attributes>
+                        <attribute typeId="50fe-4f29-6bc3-dcc6" name="Color">Green</attribute>
+                        <attribute typeId="bf11-4e10-3ab1-06f4" name="Type">Defensive</attribute>
+                        <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
+                      </attributes>
+                    </profile>
+              </profiles>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="a770-b0b7-be5f-49e6" includeChildSelections="true"/>
+              </constraints>
+            </selectionEntry>
+          </selectionEntries>
+          <rules>
+            <rule name="Enhancement Restrictions" id="ecf0-0192-e8bf-5355" hidden="true">
+              <description>**^^Hero^^** only</description>
+            </rule>
+          </rules>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink import="true" name="Heroic Traits" hidden="false" id="a3b2-c204-4984-d2a4" type="selectionEntryGroup" targetId="c437-e34c-5e1c-95e6" flatten="true"/>
+        <entryLink import="true" name="Heroic Traits" hidden="false" id="a505-723e-3af5-faa1" type="selectionEntryGroup" targetId="59df-5a5c-f4ee-ab6e"/>
+      </entryLinks>
+      <modifiers>
+        <modifier type="set" value="-1" field="46da-24e4-f24e-bbf3">
+          <conditions>
+            <condition type="atLeast" value="1" field="e63c-79ff-93ba-c5eb" scope="roster" childId="any" shared="true" includeChildSelections="true" includeChildForces="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="46da-24e4-f24e-bbf3" includeChildSelections="true"/>
+        <constraint type="max" value="1" field="selections" scope="root-entry" shared="true" id="7159-3237-b20d-7970"/>
+      </constraints>
+    </selectionEntryGroup>
+    <selectionEntryGroup name="Spell Lores" id="b269-ae32-8470-848b" hidden="false" flatten="true">
+      <selectionEntries>
+        <selectionEntry type="upgrade" import="true" name="Spell Lore: Mawseeker Gollop" hidden="false" id="2a2e-4275-1c49-b31b">
+          <constraints>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="e5e9-73ea-361e-61bb"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="points" value="0"/>
+          </costs>
+          <entryLinks>
+            <entryLink import="true" name="Spell Lore: Mawseeker Gollop" hidden="false" id="5fb2-cf81-64c6-a2ef" type="selectionEntryGroup" targetId="6fbc-8802-19c4-8cba">
+              <constraints>
+                <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="7d9c-4040-c9a1-79a8"/>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="67a2-be48-6fe5-79b9"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+        </selectionEntry>
+      </selectionEntries>
+      <constraints>
+        <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="544a-c961-a70c-1edd" includeChildSelections="true"/>
+      </constraints>
+    </selectionEntryGroup>
+    <selectionEntryGroup name="Battle Wounds + Scars" id="2257-b8b2-7e29-bbba" hidden="true" collapsible="true">
+      <modifiers>
+        <modifier type="set" value="false" field="hidden">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="atLeast" value="1" field="e63c-79ff-93ba-c5eb" scope="roster" childId="any" shared="true" includeChildSelections="true" includeChildForces="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="1bed-ddb5-0c50-16d2" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <entryLinks>
+        <entryLink import="true" name="Ravaged Coast Battle Scars" hidden="false" id="7002-ea22-e1bc-3e55" type="selectionEntryGroup" targetId="5559-80df-ba01-66a7" flatten="true"/>
+        <entryLink import="true" name="Blighted Wilds Battle Scars" hidden="false" id="1305-7d84-e5b0-07ae" type="selectionEntryGroup" targetId="374e-3b5e-1810-b56a"/>
+        <entryLink import="true" name="Blighted Wilds Paths" hidden="false" id="fdc7-727b-df5c-a378" type="selectionEntryGroup" targetId="3f1b-26c1-aa71-73f8"/>
+      </entryLinks>
+      <selectionEntries>
+        <selectionEntry type="upgrade" import="true" name="Battle Wounds" hidden="false" id="a541-57d7-ef6e-57f9"/>
+        <selectionEntry type="upgrade" import="true" name="Drained" hidden="true" id="e5da-5cb6-dbd7-7735">
+          <constraints>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="dcda-2e30-c021-ca68"/>
+          </constraints>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="root-entry" childId="6e72-1656-d554-528a" shared="true"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup name="Paths" id="8e0e-c373-30cc-14da" hidden="true">
+      <entryLinks>
+        <entryLink import="true" name="Ravaged Coast Paths" hidden="false" id="571f-dfde-2342-a69a" type="selectionEntryGroup" targetId="7bae-23cb-3977-3ece" flatten="true"/>
+        <entryLink import="true" name="Ascension Paths" hidden="false" id="2e6e-94dc-61fc-5736" type="selectionEntryGroup" targetId="9b2e-ad88-381f-5c49" flatten="true"/>
+        <entryLink import="true" name="Blighted Wilds Paths" hidden="false" id="98ee-ba5c-79d1-7b4b" type="selectionEntryGroup" targetId="3f1b-26c1-aa71-73f8"/>
+      </entryLinks>
+      <modifiers>
+        <modifier type="set" value="false" field="hidden">
+          <conditions>
+            <condition type="atLeast" value="1" field="e63c-79ff-93ba-c5eb" scope="roster" childId="any" shared="true" includeChildSelections="true" includeChildForces="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="4056-d119-6dbc-a41a"/>
+      </constraints>
+    </selectionEntryGroup>
+  </sharedSelectionEntryGroups>
+  <selectionEntries>
+    <selectionEntry type="upgrade" import="true" name="Manifestation Lore" hidden="true" id="e71c-1b6e-90c6-be50" defaultAmount="1">
+      <entryLinks>
+        <entryLink import="true" name="Manifestation Lores" hidden="false" id="c24e-cb7f-d9e8-e569" type="selectionEntryGroup" targetId="748f-5d65-2d45-95c5" flatten="true"/>
+      </entryLinks>
+      <constraints>
+        <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="df3c-cb2a-45ac-f3dc"/>
+        <constraint type="max" value="1" field="selections" scope="self" shared="true" id="f9ee-6489-ed69-de07"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink name="Army Composition" hidden="false" id="e678-08e8-1f5b-ee0c" targetId="ac97-b27c-7e35-7ab9" primary="true"/>
+      </categoryLinks>
+      <modifiers>
+        <modifier type="set" value="false" field="hidden">
+          <conditions>
+            <condition type="atLeast" value="1" field="de92-2099-fbf7-a156" scope="roster" childId="any" shared="true" includeChildSelections="true" includeChildForces="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+    </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Spell Lore" hidden="true" id="52df-512a-f4d0-7b84" defaultAmount="1">
+      <categoryLinks>
+        <categoryLink name="Army Composition" hidden="false" id="0eb2-e72e-238f-3208" targetId="ac97-b27c-7e35-7ab9" primary="true"/>
+      </categoryLinks>
+      <constraints>
+        <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="b404-8636-3eac-c0ff"/>
+        <constraint type="max" value="1" field="selections" scope="self" shared="true" id="6d5d-bcce-a226-8ab8"/>
+      </constraints>
+      <entryLinks>
+        <entryLink import="true" name="Spell Lores" hidden="false" id="cad6-e56e-de75-85f1" type="selectionEntryGroup" targetId="b269-ae32-8470-848b" flatten="true" collective="false"/>
+      </entryLinks>
+      <modifiers>
+        <modifier type="set" value="false" field="hidden">
+          <conditions>
+            <condition type="atLeast" value="1" field="de92-2099-fbf7-a156" scope="roster" childId="any" shared="true" includeChildSelections="true" includeChildForces="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+    </selectionEntry>
+  </selectionEntries>
+</catalogue>

--- a/Ogor Mawtribes - Meatfist Mawtribe.cat
+++ b/Ogor Mawtribes - Meatfist Mawtribe.cat
@@ -1,0 +1,564 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<catalogue library="false" id="d7cb-df20-b24b-fcf3" name="Ogor Mawtribes - Meatfist Mawtribe" gameSystemId="e51d-b1a3-75fc-dc3g" gameSystemRevision="2" revision="1" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <entryLinks>
+    <entryLink import="true" name="Tyrant" hidden="false" id="561b-d896-349b-4f61" type="selectionEntry" targetId="8af5-807c-4c2e-2ceb">
+      <categoryLinks>
+        <categoryLink name="MEATFIST" hidden="false" id="cde7-bed2-2c52-b0b2" targetId="6630-2134-f9f8-2aa5" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink import="true" name="Heroic Traits" hidden="false" id="a17b-acf1-73ae-e09f" type="selectionEntryGroup" targetId="8a71-2ef5-b6d0-e2ea"/>
+        <entryLink import="true" name="Artefacts of Power" hidden="false" id="fca0-251a-408f-4c57" type="selectionEntryGroup" targetId="7a2b-f1f7-9213-5bba"/>
+        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="3ea2-ea88-79aa-fd03" type="selectionEntryGroup" targetId="7206-20b1-7a1e-7906"/>
+        <entryLink import="true" name="Paths" hidden="false" id="a6d5-0ce6-fe84-6603" type="selectionEntryGroup" targetId="f6d7-ee8c-cc6e-f2ac"/>
+        <entryLink import="true" name="Warlord" hidden="false" id="c70a-b256-713b-dfbe" type="selectionEntry" targetId="bb28-fa4a-bf5f-f793"/>
+        <entryLink import="true" name="Renown" hidden="false" id="08e8-5cc6-024d-eeec" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="aa9f-7093-9df8-2c2f" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="150"/>
+      </costs>
+      <modifiers>
+        <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="lessThan" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true" includeChildForces="true"/>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="set" value="true" field="hidden">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <modifierGroups>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.743-1bd8-e3d-ced2"/>
+          </modifiers>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
+          </conditions>
+        </modifierGroup>
+      </modifierGroups>
+    </entryLink>
+    <entryLink import="true" name="Ironblaster" hidden="false" id="2d7b-83f1-4de2-41d6" type="selectionEntry" targetId="7f12-bfdf-bff5-c0fd">
+      <categoryLinks>
+        <categoryLink name="MEATFIST" hidden="false" id="eff9-7792-afb2-fb07" targetId="6630-2134-f9f8-2aa5" primary="false"/>
+      </categoryLinks>
+      <modifiers>
+        <modifier type="multiply" value="2" field="points">
+          <conditions>
+            <condition type="atLeast" value="1" field="selections" scope="self" childId="1b37-82b8-c062-eb82" shared="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="set" value="true" field="hidden">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="db3a-7199-c92e-f3cf" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <costs>
+        <cost name="pts" typeId="points" value="180"/>
+      </costs>
+      <entryLinks>
+        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="c6bc-c5c5-57f0-cb25" type="selectionEntryGroup" targetId="7206-20b1-7a1e-7906"/>
+        <entryLink import="true" name="Paths" hidden="false" id="b608-f207-58a5-ded5" type="selectionEntryGroup" targetId="f6d7-ee8c-cc6e-f2ac"/>
+        <entryLink import="true" name="Renown" hidden="false" id="c90c-8db5-fc52-7fb6" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+      </entryLinks>
+    </entryLink>
+    <entryLink import="true" name="Gluttons" hidden="false" id="c98d-6af3-2c1a-b46f" type="selectionEntry" targetId="e93b-4897-f014-9b88">
+      <categoryLinks>
+        <categoryLink name="MEATFIST" hidden="false" id="5453-86dd-92be-d14f" targetId="6630-2134-f9f8-2aa5" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink import="true" name="Reinforced" hidden="false" id="20d0-8e89-a32b-da12" type="selectionEntry" targetId="1b37-82b8-c062-eb82"/>
+        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="0978-a20a-5ceb-cc1d" type="selectionEntryGroup" targetId="7206-20b1-7a1e-7906"/>
+        <entryLink import="true" name="Paths" hidden="false" id="8390-4f5f-d492-4d28" type="selectionEntryGroup" targetId="f6d7-ee8c-cc6e-f2ac"/>
+        <entryLink import="true" name="Renown" hidden="false" id="8259-d1d0-2b5d-e23e" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+      </entryLinks>
+      <modifiers>
+        <modifier type="multiply" value="2" field="points">
+          <conditions>
+            <condition type="atLeast" value="1" field="selections" scope="self" childId="1b37-82b8-c062-eb82" shared="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="set" value="true" field="hidden">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="db3a-7199-c92e-f3cf" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <costs>
+        <cost name="pts" typeId="points" value="200"/>
+      </costs>
+    </entryLink>
+    <entryLink import="true" name="Ironguts" hidden="false" id="dead-a73e-d1b2-7741" type="selectionEntry" targetId="7ea4-f81b-b7cc-b16e">
+      <categoryLinks>
+        <categoryLink name="MEATFIST" hidden="false" id="0803-84c9-f6d4-0e99" targetId="6630-2134-f9f8-2aa5" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink import="true" name="Reinforced" hidden="false" id="57f5-fa83-e797-897e" type="selectionEntry" targetId="1b37-82b8-c062-eb82"/>
+        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="4dd6-ca25-1e29-ca4f" type="selectionEntryGroup" targetId="7206-20b1-7a1e-7906"/>
+        <entryLink import="true" name="Paths" hidden="false" id="743f-1923-5c3a-3e33" type="selectionEntryGroup" targetId="f6d7-ee8c-cc6e-f2ac"/>
+        <entryLink import="true" name="Renown" hidden="false" id="0743-ca40-7fc1-4f8e" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+      </entryLinks>
+      <modifiers>
+        <modifier type="multiply" value="2" field="points">
+          <conditions>
+            <condition type="atLeast" value="1" field="selections" scope="self" childId="1b37-82b8-c062-eb82" shared="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="set" value="true" field="hidden">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="db3a-7199-c92e-f3cf" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <costs>
+        <cost name="pts" typeId="points" value="200"/>
+      </costs>
+    </entryLink>
+    <entryLink import="true" name="Morga the Mighty, Overtyrant" hidden="false" id="c540-7a68-d88d-ce4c" type="selectionEntry" targetId="bbbf-3088-d9ef-ab3e">
+      <categoryLinks>
+        <categoryLink name="MEATFIST" hidden="false" id="3ff5-72d0-6565-c754" targetId="6630-2134-f9f8-2aa5" primary="false"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="430"/>
+      </costs>
+      <entryLinks>
+        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="94ea-d707-fe2d-efe4" type="selectionEntryGroup" targetId="7206-20b1-7a1e-7906"/>
+      </entryLinks>
+    </entryLink>
+    <entryLink import="true" name="Grell Firefist" hidden="false" id="4da9-cfe2-e6fe-2a3d" type="selectionEntry" targetId="3fb5-d2d7-81b4-6a19">
+      <categoryLinks>
+        <categoryLink name="MEATFIST" hidden="false" id="e602-50a9-1b79-a0e5" targetId="6630-2134-f9f8-2aa5" primary="false"/>
+      </categoryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="150"/>
+      </costs>
+      <entryLinks>
+        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="2936-25d5-9f03-c1e8" type="selectionEntryGroup" targetId="7206-20b1-7a1e-7906"/>
+      </entryLinks>
+    </entryLink>
+    <entryLink import="true" name="Tyrant on Glutthorn" hidden="false" id="c3f0-231f-9f87-0cfe" type="selectionEntry" targetId="9e4e-efb1-3f18-b23d">
+      <categoryLinks>
+        <categoryLink name="MEATFIST" hidden="false" id="9041-19ea-0708-6446" targetId="6630-2134-f9f8-2aa5" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink import="true" name="Heroic Traits" hidden="false" id="ced2-8cae-a84c-d28f" type="selectionEntryGroup" targetId="8a71-2ef5-b6d0-e2ea"/>
+        <entryLink import="true" name="Artefacts of Power" hidden="false" id="83c0-91a6-7a1f-83f1" type="selectionEntryGroup" targetId="7a2b-f1f7-9213-5bba"/>
+        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="bfdb-cb07-1dc3-a4d9" type="selectionEntryGroup" targetId="7206-20b1-7a1e-7906"/>
+        <entryLink import="true" name="Paths" hidden="false" id="3d9d-f778-fded-e3a6" type="selectionEntryGroup" targetId="f6d7-ee8c-cc6e-f2ac"/>
+        <entryLink import="true" name="Warlord" hidden="false" id="e98f-8831-24bf-4857" type="selectionEntry" targetId="bb28-fa4a-bf5f-f793"/>
+        <entryLink import="true" name="Renown" hidden="false" id="52d6-a6aa-3df8-3776" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="818e-42a2-48f0-57c7" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="400"/>
+      </costs>
+    </entryLink>
+    <entryLink import="true" name="Maulbeast Cavalry" hidden="false" id="fff3-aed4-cd0f-ba1f" type="selectionEntry" targetId="4781-28ae-2385-ff02">
+      <categoryLinks>
+        <categoryLink name="MEATFIST" hidden="false" id="7942-3a76-e8ec-58f6" targetId="6630-2134-f9f8-2aa5" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink import="true" name="Reinforced" hidden="false" id="56c2-d00a-1d65-22db" type="selectionEntry" targetId="1b37-82b8-c062-eb82"/>
+        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="7ebb-2f4c-3faa-e4a1" type="selectionEntryGroup" targetId="7206-20b1-7a1e-7906"/>
+        <entryLink import="true" name="Paths" hidden="false" id="c2ba-85e1-c32f-0c89" type="selectionEntryGroup" targetId="f6d7-ee8c-cc6e-f2ac"/>
+        <entryLink import="true" name="Renown" hidden="false" id="25e9-7b06-7876-13c4" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+      </entryLinks>
+      <modifiers>
+        <modifier type="multiply" value="2" field="points">
+          <conditions>
+            <condition type="atLeast" value="1" field="selections" scope="self" childId="1b37-82b8-c062-eb82" shared="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <costs>
+        <cost name="pts" typeId="points" value="280"/>
+      </costs>
+    </entryLink>
+    <entryLink import="true" name="Battle Traits: Meatfist Mawtribe" hidden="false" id="0240-0535-2e95-b14b" type="selectionEntry" targetId="f097-1b22-65d1-4cb5"/>
+  </entryLinks>
+  <catalogueLinks>
+    <catalogueLink type="catalogue" name="Ogor Mawtribes - Library" id="e787-921f-f05c-0407" targetId="9a90-83e7-7a45-6aed"/>
+    <catalogueLink type="catalogue" name="✦ Path to Glory - Ravaged Coast" id="59f6-86ed-87a6-c374" importRootEntries="true" targetId="a434-b1ba-922b-7624"/>
+    <catalogueLink type="catalogue" name="❖ Lores" id="034e-76a2-6781-89d9" targetId="0a11-cd61-2a4e-8e04" importRootEntries="true"/>
+    <catalogueLink type="catalogue" name="✦ Path to Glory - Ascension" id="4ddc-1ede-60cc-8713" targetId="3a8b-7496-526f-feab" importRootEntries="true"/>
+    <catalogueLink type="catalogue" name="✦ Path to Glory - Blighted Wilds" id="304f-f13c-3133-92f4" targetId="e0ff-dc7c-8795-bfb9" importRootEntries="true"/>
+  </catalogueLinks>
+  <categoryEntries>
+    <categoryEntry name="MEATFIST" id="6630-2134-f9f8-2aa5" hidden="false"/>
+  </categoryEntries>
+  <sharedSelectionEntries>
+    <selectionEntry type="upgrade" import="true" name="Battle Traits: Meatfist Mawtribe" hidden="false" id="f097-1b22-65d1-4cb5" publicationId="1ac6-e227-a186-12">
+      <profiles>
+        <profile name="Bloodthirsty Arrogance" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="8e20-6fc4-2646-6c94">
+          <characteristics>
+            <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
+            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">Each time you make an unmodified save roll of 1 for a combat attack that targets a friendly **^^Meatfist Infantry^^** unit that did not charge in the same turn, inflict 1 mortal damage on the attacking unit after the **^^Fight^^** ability has been resolved.</characteristic>
+          </characteristics>
+          <attributes>
+            <attribute typeId="50fe-4f29-6bc3-dcc6" name="Color">Red</attribute>
+            <attribute typeId="bf11-4e10-3ab1-06f4" name="Type">Offensive</attribute>
+            <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
+          </attributes>
+        </profile>
+        <profile name="Fleshy Stampede" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="c289-8ed5-9976-8676">
+          <characteristics>
+            <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
+            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">Add 2 to run rolls for friendly **^^Meatfist^^** units.</characteristic>
+          </characteristics>
+          <attributes>
+            <attribute typeId="50fe-4f29-6bc3-dcc6" name="Color">Black</attribute>
+            <attribute typeId="bf11-4e10-3ab1-06f4" name="Type">Movement</attribute>
+            <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
+          </attributes>
+        </profile>
+        <profile name="Meaty Charge" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="6410-a29d-95ed-c24c">
+          <characteristics>
+            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Any Charge Phase</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick a friendly **^^Meatfist^^** unit that charged this turn to use this ability, then pick a visible enemy unit within 1&quot; of it and that has not been picked to be the target of this ability this phase to be the target.</characteristic>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Make a meaty charge roll by rolling a number of dice equal to the unmodified charge roll made this turn for the unit using this ability. Add 1 to the roll if the unit using this ability has more models than the target unit. For each 5+, inflict 1 mortal damage on the target.</characteristic>
+            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+          </characteristics>
+          <attributes>
+            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Orange</attribute>
+            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Offensive</attribute>
+            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+          </attributes>
+        </profile>
+        <profile name="The Unstoppable Feast" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="eec5-e134-9e92-24be">
+          <characteristics>
+            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Turn (Army), Your Charge Phase</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick a friendly **^^Meatfist^^** unit that has not used a **^^Fight^^** ability this battle to be the target.</characteristic>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">For the rest of the turn, the target can use **^^Charge^^** abilities even if it used a **^^Run^^** or **^^Retreat^^** ability earlier in the same turn.</characteristic>
+            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+          </characteristics>
+          <attributes>
+            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Orange</attribute>
+            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Movement</attribute>
+            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+          </attributes>
+        </profile>
+        <profile name="Gluttonous Conquerors" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="08cf-aea9-6fdf-25b7">
+          <characteristics>
+            <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
+            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">Add 1 to the Control characteristic of friendly **^^Meatfist^^** units while they are in combat.</characteristic>
+          </characteristics>
+          <attributes>
+            <attribute typeId="50fe-4f29-6bc3-dcc6" name="Color">Purple</attribute>
+            <attribute typeId="bf11-4e10-3ab1-06f4" name="Type">Control</attribute>
+            <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
+          </attributes>
+        </profile>
+        <profile name="Greedy Chompers" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="aa1a-e99f-c869-3729">
+          <characteristics>
+            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Turn (Army), End of Your Turn</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick up to 3 friendly **^^Meatfist^^** units that are in combat to be the targets.</characteristic>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Roll a D3 for each target. On a 2+, **Heal (X)** the target where X is equal to the roll.</characteristic>
+            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+          </characteristics>
+          <attributes>
+            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Purple</attribute>
+            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Rallying</attribute>
+            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+          </attributes>
+        </profile>
+        <profile name="Gruesome Devourers" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="0ac8-2e45-2c0d-4fdd">
+          <characteristics>
+            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Turn (Army), End of Any Turn</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick an enemy unit that had any damage points allocated to it this turn by a friendly **^^Meatfist^^** unit&apos;s combat attacks to be the target.</characteristic>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Roll a dice. On a 3+, until the start of your next turn, the target cannot use **^^Retreat^^** abilities.</characteristic>
+            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+          </characteristics>
+          <attributes>
+            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Purple</attribute>
+            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Movement</attribute>
+            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+          </attributes>
+        </profile>
+      </profiles>
+    </selectionEntry>
+  </sharedSelectionEntries>
+  <sharedSelectionEntryGroups>
+    <selectionEntryGroup name="Artefacts of Power" id="7a2b-f1f7-9213-5bba" hidden="false">
+      <selectionEntryGroups>
+        <selectionEntryGroup name="Meatfist Artefacts of Power" id="35be-b50b-47b9-e136" hidden="false">
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Snott, Gnoblar Thief" hidden="false" id="39c2-9ca7-a55f-022e">
+              <profiles>
+                    <profile name="Snott, Gnoblar Thief" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="f3cb-7981-fca2-50b8">
+                      <characteristics>
+                        <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Start of Any Turn</characteristic>
+                        <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick a visible enemy **^^Hero^^** that has any artefacts of power to be the target.</characteristic>
+                        <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Roll a dice. If the roll is equal to or lower than the current battle round number, the target no longer has any artefacts of power.</characteristic>
+                        <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+                        <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+                      </characteristics>
+                      <attributes>
+                        <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Black</attribute>
+                        <attribute typeId="6d16-c86b-2698-85a4" name="Type">Special</attribute>
+                        <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+                      </attributes>
+                    </profile>
+              </profiles>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="6fae-6c0a-4046-456d" includeChildSelections="true"/>
+              </constraints>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Trapper&apos;s Arsenal" hidden="false" id="33f2-08fc-0bc5-16c7">
+              <profiles>
+                    <profile name="Trapper's Arsenal" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="0c2c-359b-cb90-ab7c">
+                      <characteristics>
+                        <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Battle, Any Combat Phase</characteristic>
+                        <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick an enemy unit in combat with this unit and that charged this turn to be the target.</characteristic>
+                        <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Roll a dice. On a 4+, the target has **^^Strike-Last^^** for the rest of the turn.</characteristic>
+                        <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+                        <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+                      </characteristics>
+                      <attributes>
+                        <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Red</attribute>
+                        <attribute typeId="6d16-c86b-2698-85a4" name="Type">Defensive</attribute>
+                        <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+                      </attributes>
+                    </profile>
+              </profiles>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="f161-0cd8-1f16-7f47" includeChildSelections="true"/>
+              </constraints>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Rusty Leadbelcher Gun" hidden="false" id="4768-022f-b04c-c5b2">
+              <profiles>
+                    <profile name="Rusty Leadbelcher Gun" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="9973-476a-29f2-9433">
+                      <characteristics>
+                        <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Battle, Your Shooting Phase</characteristic>
+                        <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick a visible enemy unit within 12&quot; of this unit to be the target.</characteristic>
+                        <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Pick to load the gun with **Jagged Shrapnel** or **Lumpen Metal Scrap**, then apply the corresponding effect below:
+
+***Jagged Shrapnel***: Inflict D3 mortal damage on the target. If any models were slain by that mortal damage, halve the target&apos;s Move characteristic until the start of your next turn.
+
+***Lumpen Metal Scrap***: Inflict D6 mortal damage on the target.</characteristic>
+                        <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+                        <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+                      </characteristics>
+                      <attributes>
+                        <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Blue</attribute>
+                        <attribute typeId="6d16-c86b-2698-85a4" name="Type">Shooting</attribute>
+                        <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+                      </attributes>
+                    </profile>
+              </profiles>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="1dc0-755d-ea06-040d" includeChildSelections="true"/>
+              </constraints>
+            </selectionEntry>
+          </selectionEntries>
+          <rules>
+            <rule name="Enhancement Restrictions" id="8936-e14e-ccc8-4f4c" hidden="true">
+              <description>**^^Hero^^** only</description>
+            </rule>
+          </rules>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink import="true" name="Artefacts of Power" hidden="false" id="4a5e-c9a0-6540-17b2" type="selectionEntryGroup" targetId="e1b2-cedf-56a5-6bb1" flatten="true"/>
+        <entryLink import="true" name="Artefacts of Power" hidden="false" id="bac6-5e75-6363-c5fe" type="selectionEntryGroup" targetId="d563-838a-a901-097e"/>
+      </entryLinks>
+      <modifiers>
+        <modifier type="set" value="-1" field="c86a-5656-c9cd-76a7">
+          <conditions>
+            <condition type="atLeast" value="1" field="e63c-79ff-93ba-c5eb" scope="roster" childId="any" shared="true" includeChildSelections="true" includeChildForces="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="c86a-5656-c9cd-76a7" includeChildSelections="true"/>
+        <constraint type="max" value="1" field="selections" scope="root-entry" shared="true" id="3b64-2645-130c-b74c"/>
+      </constraints>
+    </selectionEntryGroup>
+    <selectionEntryGroup name="Heroic Traits" id="8a71-2ef5-b6d0-e2ea" hidden="false">
+      <selectionEntryGroups>
+        <selectionEntryGroup name="Meatfist Heroic Traits" id="70c6-9af2-fe57-e434" hidden="false">
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Thick Blubber" hidden="false" id="aaf6-09db-6ca9-1478">
+              <profiles>
+                    <profile name="Thick Blubber" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="30b9-d11d-4a46-b901">
+                      <characteristics>
+                        <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
+                        <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">Subtract 1 from wound rolls for shooting attacks that target this unit.</characteristic>
+                      </characteristics>
+                      <attributes>
+                        <attribute typeId="50fe-4f29-6bc3-dcc6" name="Color">Green</attribute>
+                        <attribute typeId="bf11-4e10-3ab1-06f4" name="Type">Defensive</attribute>
+                        <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
+                      </attributes>
+                    </profile>
+              </profiles>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="5e38-8af0-480f-65f2" includeChildSelections="true"/>
+              </constraints>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Overpowering Mass" hidden="false" id="5024-466a-183d-fac4">
+              <profiles>
+                    <profile name="Overpowering Mass" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="da5d-5875-16d9-7cba">
+                      <characteristics>
+                        <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
+                        <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">When making meaty charge rolls for this unit, you can re-roll unmodified rolls of 1.</characteristic>
+                      </characteristics>
+                      <attributes>
+                        <attribute typeId="50fe-4f29-6bc3-dcc6" name="Color">Orange</attribute>
+                        <attribute typeId="bf11-4e10-3ab1-06f4" name="Type">Movement</attribute>
+                        <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
+                      </attributes>
+                    </profile>
+              </profiles>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="1661-dc8e-b62c-109f" includeChildSelections="true"/>
+              </constraints>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Force of Savage Personality" hidden="false" id="8d8d-3927-42a2-a7eb">
+              <profiles>
+                    <profile name="Force of Savage Personality" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="2261-207c-4452-8a5d">
+                      <characteristics>
+                        <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
+                        <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">Enemy units and enemy **^^Manifestations^^** cannot be set up within 12&quot; of this unit.</characteristic>
+                      </characteristics>
+                      <attributes>
+                        <attribute typeId="50fe-4f29-6bc3-dcc6" name="Color">Black</attribute>
+                        <attribute typeId="bf11-4e10-3ab1-06f4" name="Type">Special</attribute>
+                        <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
+                      </attributes>
+                    </profile>
+              </profiles>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="d652-3861-d676-8341" includeChildSelections="true"/>
+              </constraints>
+            </selectionEntry>
+          </selectionEntries>
+          <rules>
+            <rule name="Enhancement Restrictions" id="f80b-1380-ac32-9450" hidden="true">
+              <description>**^^Hero^^** only</description>
+            </rule>
+          </rules>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink import="true" name="Heroic Traits" hidden="false" id="694c-a6b0-e6bf-f143" type="selectionEntryGroup" targetId="c437-e34c-5e1c-95e6" flatten="true"/>
+        <entryLink import="true" name="Heroic Traits" hidden="false" id="6c92-4d5f-db7a-9a53" type="selectionEntryGroup" targetId="59df-5a5c-f4ee-ab6e"/>
+      </entryLinks>
+      <modifiers>
+        <modifier type="set" value="-1" field="5cd4-b6c1-7fb2-ecf5">
+          <conditions>
+            <condition type="atLeast" value="1" field="e63c-79ff-93ba-c5eb" scope="roster" childId="any" shared="true" includeChildSelections="true" includeChildForces="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="5cd4-b6c1-7fb2-ecf5" includeChildSelections="true"/>
+        <constraint type="max" value="1" field="selections" scope="root-entry" shared="true" id="ec0f-cbd7-2bb2-ffea"/>
+      </constraints>
+    </selectionEntryGroup>
+    <selectionEntryGroup name="Battle Wounds + Scars" id="7206-20b1-7a1e-7906" hidden="true" collapsible="true">
+      <modifiers>
+        <modifier type="set" value="false" field="hidden">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="atLeast" value="1" field="e63c-79ff-93ba-c5eb" scope="roster" childId="any" shared="true" includeChildSelections="true" includeChildForces="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="ancestor" childId="1bed-ddb5-0c50-16d2" shared="true" includeChildSelections="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <entryLinks>
+        <entryLink import="true" name="Ravaged Coast Battle Scars" hidden="false" id="5187-22b4-1d58-c622" type="selectionEntryGroup" targetId="5559-80df-ba01-66a7" flatten="true"/>
+        <entryLink import="true" name="Blighted Wilds Battle Scars" hidden="false" id="7ca4-f64b-dcc2-e3c3" type="selectionEntryGroup" targetId="374e-3b5e-1810-b56a"/>
+        <entryLink import="true" name="Blighted Wilds Paths" hidden="false" id="5a62-fa4a-be5a-bf07" type="selectionEntryGroup" targetId="3f1b-26c1-aa71-73f8"/>
+      </entryLinks>
+      <selectionEntries>
+        <selectionEntry type="upgrade" import="true" name="Battle Wounds" hidden="false" id="9f8f-fcf6-ad0c-ea2a"/>
+        <selectionEntry type="upgrade" import="true" name="Drained" hidden="true" id="6710-780f-0fcb-51e2">
+          <constraints>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="280e-6714-15a2-e4fe"/>
+          </constraints>
+          <modifiers>
+            <modifier type="set" value="false" field="hidden">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="root-entry" childId="6e72-1656-d554-528a" shared="true"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup name="Paths" id="f6d7-ee8c-cc6e-f2ac" hidden="true">
+      <entryLinks>
+        <entryLink import="true" name="Ravaged Coast Paths" hidden="false" id="5f12-986b-c776-ea2e" type="selectionEntryGroup" targetId="7bae-23cb-3977-3ece" flatten="true"/>
+        <entryLink import="true" name="Ascension Paths" hidden="false" id="c9e3-cf3f-d8df-492b" type="selectionEntryGroup" targetId="9b2e-ad88-381f-5c49" flatten="true"/>
+        <entryLink import="true" name="Blighted Wilds Paths" hidden="false" id="9491-eb59-e300-00db" type="selectionEntryGroup" targetId="3f1b-26c1-aa71-73f8"/>
+      </entryLinks>
+      <modifiers>
+        <modifier type="set" value="false" field="hidden">
+          <conditions>
+            <condition type="atLeast" value="1" field="e63c-79ff-93ba-c5eb" scope="roster" childId="any" shared="true" includeChildSelections="true" includeChildForces="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="a8fe-6010-7e5e-6c6e"/>
+      </constraints>
+    </selectionEntryGroup>
+  </sharedSelectionEntryGroups>
+  <selectionEntries>
+    <selectionEntry type="upgrade" import="true" name="Manifestation Lore" hidden="true" id="4f36-54b4-a134-8be2" defaultAmount="1">
+      <entryLinks>
+        <entryLink import="true" name="Manifestation Lores" hidden="false" id="41bd-a015-4e5e-a5b2" type="selectionEntryGroup" targetId="748f-5d65-2d45-95c5" flatten="true"/>
+      </entryLinks>
+      <constraints>
+        <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="8771-2d2a-54a3-1b35"/>
+        <constraint type="max" value="1" field="selections" scope="self" shared="true" id="2c13-6b70-e2ee-92c4"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink name="Army Composition" hidden="false" id="3ff1-5072-c1d1-7bb2" targetId="ac97-b27c-7e35-7ab9" primary="true"/>
+      </categoryLinks>
+      <modifiers>
+        <modifier type="set" value="false" field="hidden">
+          <conditions>
+            <condition type="atLeast" value="1" field="de92-2099-fbf7-a156" scope="roster" childId="any" shared="true" includeChildSelections="true" includeChildForces="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+    </selectionEntry>
+  </selectionEntries>
+</catalogue>

--- a/Ogor Mawtribes - Meatfist Mawtribe.cat
+++ b/Ogor Mawtribes - Meatfist Mawtribe.cat
@@ -204,6 +204,118 @@
       </costs>
     </entryLink>
     <entryLink import="true" name="Battle Traits: Meatfist Mawtribe" hidden="false" id="0240-0535-2e95-b14b" type="selectionEntry" targetId="f097-1b22-65d1-4cb5"/>
+    <entryLink import="true" name="Leadbelchers" hidden="false" id="8f01-2791-406e-30f3" type="selectionEntry" targetId="15cd-469c-4ed6-afef">
+      <categoryLinks>
+        <categoryLink name="MEATFIST" hidden="false" id="bb7d-6b04-8000-e63b" targetId="6630-2134-f9f8-2aa5" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink import="true" name="Reinforced" hidden="false" id="f8c3-7935-2925-9696" type="selectionEntry" targetId="1b37-82b8-c062-eb82"/>
+        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="735c-f680-e0f5-3af7" type="selectionEntryGroup" targetId="7206-20b1-7a1e-7906"/>
+        <entryLink import="true" name="Paths" hidden="false" id="df92-357e-56f3-268c" type="selectionEntryGroup" targetId="f6d7-ee8c-cc6e-f2ac"/>
+        <entryLink import="true" name="Renown" hidden="false" id="e4d7-68f9-19a5-c2c7" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+      </entryLinks>
+      <modifiers>
+        <modifier type="multiply" value="2" field="points">
+          <conditions>
+            <condition type="atLeast" value="1" field="selections" scope="self" childId="1b37-82b8-c062-eb82" shared="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="set" value="true" field="hidden">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="db3a-7199-c92e-f3cf" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <costs>
+        <cost name="pts" typeId="points" value="140"/>
+      </costs>
+    </entryLink>
+    <entryLink import="true" name="Maneaters" hidden="false" id="214f-999a-965f-45dc" type="selectionEntry" targetId="f4ef-9156-1fd1-4b91">
+      <categoryLinks>
+        <categoryLink name="MEATFIST" hidden="false" id="0030-ac72-59a4-1e3a" targetId="6630-2134-f9f8-2aa5" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink import="true" name="Reinforced" hidden="false" id="ea38-d30b-ef29-80b5" type="selectionEntry" targetId="1b37-82b8-c062-eb82"/>
+        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="a47a-3b70-2fc5-272d" type="selectionEntryGroup" targetId="7206-20b1-7a1e-7906"/>
+        <entryLink import="true" name="Paths" hidden="false" id="4770-0d09-392b-c090" type="selectionEntryGroup" targetId="f6d7-ee8c-cc6e-f2ac"/>
+        <entryLink import="true" name="Renown" hidden="false" id="59ef-dd4b-a272-34d4" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+      </entryLinks>
+      <modifiers>
+        <modifier type="multiply" value="2" field="points">
+          <conditions>
+            <condition type="atLeast" value="1" field="selections" scope="self" childId="1b37-82b8-c062-eb82" shared="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="set" value="true" field="hidden">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="db3a-7199-c92e-f3cf" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <costs>
+        <cost name="pts" typeId="points" value="180"/>
+      </costs>
+    </entryLink>
+    <entryLink import="true" name="Slaughtermaster" hidden="false" id="baf4-e012-8406-cfae" type="selectionEntry" targetId="3d51-af3a-455e-2373">
+      <categoryLinks>
+        <categoryLink name="MEATFIST" hidden="false" id="b894-ed6a-6ce2-732a" targetId="6630-2134-f9f8-2aa5" primary="false"/>
+      </categoryLinks>
+      <entryLinks>
+        <entryLink import="true" name="Heroic Traits" hidden="false" id="2003-ad5d-6c1f-25d3" type="selectionEntryGroup" targetId="8a71-2ef5-b6d0-e2ea"/>
+        <entryLink import="true" name="Artefacts of Power" hidden="false" id="e400-8687-053b-f79e" type="selectionEntryGroup" targetId="7a2b-f1f7-9213-5bba"/>
+        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="61e3-27c4-4785-e63e" type="selectionEntryGroup" targetId="7206-20b1-7a1e-7906"/>
+        <entryLink import="true" name="Paths" hidden="false" id="d0ba-bb96-a0c8-a810" type="selectionEntryGroup" targetId="f6d7-ee8c-cc6e-f2ac"/>
+        <entryLink import="true" name="Warlord" hidden="false" id="e5a4-43fb-545e-bb04" type="selectionEntry" targetId="bb28-fa4a-bf5f-f793"/>
+        <entryLink import="true" name="Renown" hidden="false" id="4784-2cd3-ed68-51dc" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="c229-0d70-e3c8-7e3b" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="160"/>
+      </costs>
+      <modifiers>
+        <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="lessThan" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true" includeChildForces="true"/>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="set" value="true" field="hidden">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <modifierGroups>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.5c0d-5e93-d71f-f0da"/>
+          </modifiers>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
+          </conditions>
+        </modifierGroup>
+      </modifierGroups>
+    </entryLink>
   </entryLinks>
   <catalogueLinks>
     <catalogueLink type="catalogue" name="Ogor Mawtribes - Library" id="e787-921f-f05c-0407" targetId="9a90-83e7-7a45-6aed"/>

--- a/Ogor Mawtribes.cat
+++ b/Ogor Mawtribes.cat
@@ -99,9 +99,9 @@
         </selectionEntryGroup>
         <selectionEntryGroup name="Plunder of the Mawtribes" id="9aa0-1529-3d0f-56ec" hidden="false">
           <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Trophy Rack" hidden="false" id="83c8-3774-9488-0c4b" publicationId="feba-6749-6df3-ea9e">
+            <selectionEntry type="upgrade" import="true" name="Trophy Rack" hidden="false" id="83c8-3774-9488-0c4b" publicationId="1ac6-e227-a186-12">
               <profiles>
-                <profile name="Trophy Rack" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="f96f-c778-c701-56eb" publicationId="feba-6749-6df3-ea9e">
+                <profile name="Trophy Rack" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="f96f-c778-c701-56eb" publicationId="1ac6-e227-a186-12">
                   <characteristics>
                     <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Deployment Phase</characteristic>
                     <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb"/>
@@ -124,9 +124,9 @@
                 <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="86e2-93ca-e345-55da" includeChildSelections="true"/>
               </constraints>
             </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Carvalox Hide" hidden="false" id="2193-1dd2-2471-649b" publicationId="feba-6749-6df3-ea9e">
+            <selectionEntry type="upgrade" import="true" name="Carvalox Hide" hidden="false" id="2193-1dd2-2471-649b" publicationId="1ac6-e227-a186-12">
               <profiles>
-                <profile name="Carvalox Hide" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="0137-ba57-4ee0-7ae0" publicationId="feba-6749-6df3-ea9e">
+                <profile name="Carvalox Hide" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="0137-ba57-4ee0-7ae0" publicationId="1ac6-e227-a186-12">
                   <characteristics>
                     <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
                     <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">This unit has **^^Ward (6+)^^**. It also has **^^Ward (4+)^^** against damage points inflicted by **^^Spell^^** abilities, **^^Prayer^^** abilities and abilities used by **^^Manifestations^^**.</characteristic>
@@ -142,9 +142,9 @@
                 <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="920f-a51a-b2a4-ed54" includeChildSelections="true"/>
               </constraints>
             </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Mantle of Entrails" hidden="false" id="8310-9dcb-6401-6d7a" publicationId="feba-6749-6df3-ea9e">
+            <selectionEntry type="upgrade" import="true" name="Mantle of Entrails" hidden="false" id="8310-9dcb-6401-6d7a" publicationId="1ac6-e227-a186-12">
               <profiles>
-                <profile name="Mantle of Entrails" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="935a-8605-77e6-9a0f" publicationId="feba-6749-6df3-ea9e">
+                <profile name="Mantle of Entrails" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="935a-8605-77e6-9a0f" publicationId="1ac6-e227-a186-12">
                   <characteristics>
                     <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Battle (Army), Any Hero Phase</characteristic>
                     <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick a visible enemy unit within 12&quot; of this unit to be the target.</characteristic>
@@ -189,74 +189,83 @@
     </selectionEntryGroup>
     <selectionEntryGroup name="Battle Formations: Ogor Mawtribes" id="3b1e-9d81-77cb-328d" hidden="false" flatten="true">
       <selectionEntries>
-        <selectionEntry type="upgrade" import="true" name="Blackpowder Fanatics" hidden="false" id="731b-5d69-6627-855a" publicationId="1ac6-e227-a186-12">
+        <selectionEntry type="upgrade" import="true" name="Hunger-Filled Tribe" hidden="false" id="3cad-0dd7-2887-3d79" publicationId="1ac6-e227-a186-12">
           <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="84a9-6423-6099-4cf7"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="0b9e-2335-b828-113e"/>
           </constraints>
           <profiles>
-            <profile name="Feed Yer Cannons!" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="499b-6c5e-823d-b3a5">
+            <profile name="Feast of Bloodshed" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="3c5d-5de4-0320-8913">
               <characteristics>
-                <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
-                <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">Ranged weapons used by friendly **Leadbelchers** and **Ironblaster** units have **Shoot in Combat** while they are within the combat range of a friendly **^^Ogor Mawtribes Hero^^**.</characteristic>
+                <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Turn (Army), End of Any Turn</characteristic>
+                <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">For each enemy unit that was destroyed this turn, pick a friendly **^^Ogor Mawtribes^^** unit that is not in combat and has not used the &apos;Power Through&apos; command this turn to be the target.</characteristic>
+                <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Each target can move up to 3&quot;. It can move through the combat ranges of enemy units and can end that move in combat.</characteristic>
+                <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f">**^^Move^^**</characteristic>
+                <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
               </characteristics>
               <attributes>
-                <attribute typeId="50fe-4f29-6bc3-dcc6" name="Color">Blue</attribute>
-                <attribute typeId="bf11-4e10-3ab1-06f4" name="Type">Shooting</attribute>
-                <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
+                <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Purple</attribute>
+                <attribute typeId="6d16-c86b-2698-85a4" name="Type">Movement</attribute>
+                <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
               </attributes>
             </profile>
           </profiles>
         </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="Prophets of the Gulping God" hidden="false" id="b5d5-6c0b-1c48-654a" publicationId="1ac6-e227-a186-12">
+        <selectionEntry type="upgrade" import="true" name="Vanguard of the Mawpath" hidden="false" id="e71d-2ecb-2f7b-9978" publicationId="1ac6-e227-a186-12">
           <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="bf32-6de5-21e8-1382"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="fe39-933c-38f5-4dd9"/>
           </constraints>
           <profiles>
-            <profile name="Master Butchers" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="5774-ab7-89df-1921">
+            <profile name="Smash and Grab" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="c4de-f11d-f9ab-0f61">
               <characteristics>
-                <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
-                <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">Add 1 to casting rolls for friendly **^^Ogor Mawtribes Wizards^^**.</characteristic>
+                <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Turn (Army), Any Charge Phase</characteristic>
+                <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick each friendly **^^Ogor Mawtribes^^** unit that charged this turn and for which the unmodified charge roll was 8+ to be the targets.</characteristic>
+                <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Each target can move up to 3&quot;. It can move through the combat ranges of enemy units but must end that move in combat with the units it was in combat with at the start of the move.</characteristic>
+                <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+                <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
               </characteristics>
               <attributes>
-                <attribute typeId="50fe-4f29-6bc3-dcc6" name="Color">Yellow</attribute>
-                <attribute typeId="bf11-4e10-3ab1-06f4" name="Type">Special</attribute>
-                <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
+                <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Orange</attribute>
+                <attribute typeId="6d16-c86b-2698-85a4" name="Type">Movement</attribute>
+                <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
               </attributes>
             </profile>
           </profiles>
         </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="Beast Handlers" hidden="false" id="deba-7834-7ac4-ffae" publicationId="1ac6-e227-a186-12">
+        <selectionEntry type="upgrade" import="true" name="Hinterland Hunters" hidden="false" id="3b05-60c4-9f6f-dea7" publicationId="1ac6-e227-a186-12">
           <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="9c36-65ef-2759-c6e1"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8b37-7089-5e45-6288"/>
           </constraints>
           <profiles>
-            <profile name="Brutal Stock" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="b301-5bcd-c591-5956">
+            <profile name="Prowling Predators" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="d82f-10d6-702a-eadc">
               <characteristics>
                 <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
-                <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">Each time a friendly **^^Beastclaw Raiders Monster^^** uses the &apos;Trampling Charge&apos; ability, add 1 to the amount of mortal damage inflicted, if any.</characteristic>
-              </characteristics>
-              <attributes>
-                <attribute typeId="50fe-4f29-6bc3-dcc6" name="Color">Orange</attribute>
-                <attribute typeId="bf11-4e10-3ab1-06f4" name="Type">Offensive</attribute>
-                <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
-              </attributes>
-            </profile>
-          </profiles>
-        </selectionEntry>
-        <selectionEntry type="upgrade" import="true" name="Heralds of the Everwinter" hidden="false" id="59b2-61e4-7146-687a" publicationId="1ac6-e227-a186-12">
-          <constraints>
-            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="b3fd-c885-5419-607"/>
-          </constraints>
-          <profiles>
-            <profile name="Eyes of the Storm" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="26db-8ee8-81f0-32f6">
-              <characteristics>
-                <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
-                <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">Subtract 1 from hit rolls for shooting attacks that target friendly **^^Ogor Mawtribes Infantry^^** units while they are wholly within 12&quot; of any friendly **^^Beastclaw Raiders Heroes^^**.</characteristic>
+                <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">Subtract 1 from hit rolls for attacks that target friendly **^^Ogor Mawtribes^^** units while they are wholly within 9&quot; of a battlefield edge and have not charged this turn.</characteristic>
               </characteristics>
               <attributes>
                 <attribute typeId="50fe-4f29-6bc3-dcc6" name="Color">Green</attribute>
                 <attribute typeId="bf11-4e10-3ab1-06f4" name="Type">Defensive</attribute>
                 <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
+              </attributes>
+            </profile>
+          </profiles>
+        </selectionEntry>
+        <selectionEntry type="upgrade" import="true" name="Maw-Cult Fanatics" hidden="false" id="ae26-07a1-9b69-4549" publicationId="1ac6-e227-a186-12">
+          <constraints>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="8c70-3c27-c55a-1c0c"/>
+          </constraints>
+          <profiles>
+            <profile name="Grub&apos;s Up, Mateys!" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="eb4f-7ba2-6a2d-988d">
+              <characteristics>
+                <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Turn (Army), End of Any Turn</characteristic>
+                <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick each friendly **^^Ogor Mawtribes^^** unit that has been picked to be a target of the &apos;Eat &apos;Em Alive&apos; ability this battle to be the targets.</characteristic>
+                <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Heal (D3) each target.</characteristic>
+                <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+                <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+              </characteristics>
+              <attributes>
+                <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Purple</attribute>
+                <attribute typeId="6d16-c86b-2698-85a4" name="Type">Rallying</attribute>
+                <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
               </attributes>
             </profile>
           </profiles>
@@ -372,9 +381,9 @@
       <selectionEntryGroups>
         <selectionEntryGroup name="Traits of Endless Hunger" id="a5a-92de-7f93-c15e" hidden="false">
           <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Leave Not a Morsel" hidden="false" id="b279-4201-e5bd-8ef3" publicationId="feba-6749-6df3-ea9e">
+            <selectionEntry type="upgrade" import="true" name="Leave Not a Morsel" hidden="false" id="b279-4201-e5bd-8ef3" publicationId="1ac6-e227-a186-12">
               <profiles>
-                <profile name="Leave Not a Morsel" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="aeac-1f3f-e463-c025" publicationId="feba-6749-6df3-ea9e">
+                <profile name="Leave Not a Morsel" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="aeac-1f3f-e463-c025" publicationId="1ac6-e227-a186-12">
                   <characteristics>
                     <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
                     <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">While they are within 6&quot; of and visible to this unit, enemy units cannot be healed or have slain models returned to them.</characteristic>
@@ -390,9 +399,9 @@
                 <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="7465-5a09-028c-6354" includeChildSelections="true"/>
               </constraints>
             </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Dreaded Far and Wide" hidden="false" id="b63a-a9f5-1f8b-5cbc" publicationId="feba-6749-6df3-ea9e">
+            <selectionEntry type="upgrade" import="true" name="Dreaded Far and Wide" hidden="false" id="b63a-a9f5-1f8b-5cbc" publicationId="1ac6-e227-a186-12">
               <profiles>
-                <profile name="Dreaded Far and Wide" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="ebcf-81b7-f136-b6db" publicationId="feba-6749-6df3-ea9e">
+                <profile name="Dreaded Far and Wide" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="ebcf-81b7-f136-b6db" publicationId="1ac6-e227-a186-12">
                   <characteristics>
                     <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
                     <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">Ignore negative modifiers to:
@@ -412,9 +421,9 @@
                 <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="80f1-b758-d285-17ff" includeChildSelections="true"/>
               </constraints>
             </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="The Crusherguts" hidden="false" id="b6f3-c71d-0335-9c2b" publicationId="feba-6749-6df3-ea9e">
+            <selectionEntry type="upgrade" import="true" name="The Crusherguts" hidden="false" id="b6f3-c71d-0335-9c2b" publicationId="1ac6-e227-a186-12">
               <profiles>
-                <profile name="The Crusherguts" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="21b3-86a4-4748-bcd5" publicationId="feba-6749-6df3-ea9e">
+                <profile name="The Crusherguts" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="21b3-86a4-4748-bcd5" publicationId="1ac6-e227-a186-12">
                   <characteristics>
                     <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Turn (Army), Any Combat Phase</characteristic>
                     <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">If this unit charged this turn, pick an enemy unit in combat with it to be the target.</characteristic>
@@ -775,7 +784,7 @@ Then, roll a dice. The target can move a distance in inches up to the roll. It c
   <sharedSelectionEntries>
     <selectionEntry type="upgrade" import="true" name="Battle Traits: Ogor Mawtribes" hidden="false" id="93f7-a632-9dda-5515">
       <profiles>
-        <profile name="Eat &apos;Em Alive" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="9f51-0b9d-387e-f209" publicationId="feba-6749-6df3-ea9e">
+        <profile name="Eat &apos;Em Alive" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="9f51-0b9d-387e-f209" publicationId="1ac6-e227-a186-12">
           <characteristics>
             <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">End of Any Turn</characteristic>
             <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick a friendly **^^Ogor^^** unit that used a **^^Fight^^** ability that targeted a unit, excluding **^^Faction Terrain^^**, this turn to use this ability. Then, you can pick an enemy unit in combat with it to be the target. The same enemy unit cannot be picked to be the target of this ability more than once per turn.</characteristic>
@@ -798,7 +807,7 @@ Then, roll a dice. The target can move a distance in inches up to the roll. It c
             <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
           </attributes>
         </profile>
-        <profile name="Bull Charge" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="af33-ad3b-ecfd-28aa" publicationId="feba-6749-6df3-ea9e">
+        <profile name="Bull Charge" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="af33-ad3b-ecfd-28aa" publicationId="1ac6-e227-a186-12">
           <characteristics>
             <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Turn (Army), Any Charge Phase</characteristic>
             <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick a friendly **^^Ogor Mawtribes^^** unit that charged this turn and has not used a **^^Rampage^^** ability this turn to use this ability, then pick an enemy unit in combat with it to be the target.</characteristic>
@@ -818,7 +827,7 @@ Then, the unit using this ability can make a pile-in move. If the target of this
             <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
           </attributes>
         </profile>
-        <profile name="Jaws of the Beast" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="f64a-7291-75dd-646d" publicationId="feba-6749-6df3-ea9e">
+        <profile name="Jaws of the Beast" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="f64a-7291-75dd-646d" publicationId="1ac6-e227-a186-12">
           <characteristics>
             <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Battle (Army), Deployment Phase</characteristic>
             <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick a friendly **^^Beastclaw Hero^^** that is leading a regiment and that has not been deployed, then pick a non-**^^Hero^^** unit in that **^^Hero^^**&apos;s regiment that has not been deployed.</characteristic>
@@ -832,7 +841,7 @@ Then, the unit using this ability can make a pile-in move. If the target of this
             <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
           </attributes>
         </profile>
-        <profile name="Closing the Jaws" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="9488-ba78-79fe-da9a" publicationId="feba-6749-6df3-ea9e">
+        <profile name="Closing the Jaws" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="9488-ba78-79fe-da9a" publicationId="1ac6-e227-a186-12">
           <characteristics>
             <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Your Movement Phase</characteristic>
             <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick a friendly **^^Beastclaw Hero^^** that is **tracking the prey**.</characteristic>

--- a/Ogor Mawtribes.cat
+++ b/Ogor Mawtribes.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="6353-cb84-ac7f-9a15" name="Ogor Mawtribes" gameSystemId="e51d-b1a3-75fc-dc3g" gameSystemRevision="2" revision="31" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="false" id="6353-cb84-ac7f-9a15" name="Ogor Mawtribes" gameSystemId="e51d-b1a3-75fc-dc3g" gameSystemRevision="2" revision="32" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <sharedSelectionEntryGroups>
     <selectionEntryGroup name="Spell Lores" id="daa3-d823-9bac-b8d" hidden="false" flatten="true">
       <selectionEntries>

--- a/Ogor Mawtribes.cat
+++ b/Ogor Mawtribes.cat
@@ -3,12 +3,12 @@
   <sharedSelectionEntryGroups>
     <selectionEntryGroup name="Spell Lores" id="daa3-d823-9bac-b8d" hidden="false" flatten="true">
       <selectionEntries>
-        <selectionEntry type="upgrade" import="true" name="Lore of Maw-magic" hidden="false" id="6a3a-b741-eace-7001">
+        <selectionEntry type="upgrade" import="true" name="Lore of Gut Magic" hidden="false" id="6a3a-b741-eace-7001">
           <constraints>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="b727-ace3-0548-6538"/>
           </constraints>
           <entryLinks>
-            <entryLink import="true" name="Lore of Maw-magic" hidden="false" id="d403-e0ac-3c28-ef79" type="selectionEntryGroup" targetId="6958-4e79-e1d0-14e8"/>
+            <entryLink import="true" name="Lore of Gut Magic" hidden="false" id="d403-e0ac-3c28-ef79" type="selectionEntryGroup" targetId="1708-0960-47ad-a552"/>
           </entryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -99,64 +99,68 @@
         </selectionEntryGroup>
         <selectionEntryGroup name="Plunder of the Mawtribes" id="9aa0-1529-3d0f-56ec" hidden="false">
           <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Gruesome Trophies" hidden="false" id="4088-f0d0-86fd-c5e0" publicationId="1ac6-e227-a186-12">
+            <selectionEntry type="upgrade" import="true" name="Trophy Rack" hidden="false" id="83c8-3774-9488-0c4b" publicationId="feba-6749-6df3-ea9e">
               <profiles>
-                <profile name="Gruesome Trophies" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="537a-fb3e-17c2-6a03">
+                <profile name="Trophy Rack" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="f96f-c778-c701-56eb" publicationId="feba-6749-6df3-ea9e">
                   <characteristics>
-                    <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
-                    <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">Add 1 to hit rolls for combat attacks that target **^^Heroes^^** or **^^Monsters^^** made by friendly **^^Ogor Mawtribes^^** units while they are wholly within 12&quot; of this unit.</characteristic>
-                  </characteristics>
-                  <attributes>
-                    <attribute typeId="50fe-4f29-6bc3-dcc6" name="Color">Red</attribute>
-                    <attribute typeId="bf11-4e10-3ab1-06f4" name="Type">Offensive</attribute>
-                    <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
-                  </attributes>
-                </profile>
-              </profiles>
-              <constraints>
-                <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="353f-d7e7-169c-97c3" includeChildSelections="true"/>
-              </constraints>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Elixir of the Frostwyrm" hidden="false" id="1401-e49e-ff27-5b7b" publicationId="1ac6-e227-a186-12">
-              <profiles>
-                <profile name="Elixir of the Frostwyrm" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="82f8-cef7-573b-f459">
-                  <characteristics>
-                    <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Battle, Any Shooting Phase</characteristic>
-                    <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick an enemy unit in combat with this unit to be the target.</characteristic>
-                    <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Roll a dice. Inflict an amount of mortal damage on the target equal to the roll. Then, **Heal (X)** this unit, where **X** is an amount equal to the roll.</characteristic>
+                    <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Deployment Phase</characteristic>
+                    <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb"/>
+                    <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Pick 1 of the following trophies. For the rest of the battle, melee weapons used by other friendly **^^Ogor Mawtribes^^** units have the corresponding weapon ability while they are wholly within 6&quot; of and visible to this unit:
+
+• ***Squeezed Head***: **^^Anti-Monster (+1 Rend)^^**
+• ***Smashed City Rubble***: **^^Anti-War Machine (+1 Rend)^^**
+• ***Torn Appendages***: **^^Anti-Cavalry (+1 Rend)^^**</characteristic>
                     <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
                     <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
                   </characteristics>
                   <attributes>
-                    <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Blue</attribute>
-                    <attribute typeId="6d16-c86b-2698-85a4" name="Type">Special</attribute>
-                    <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
-                  </attributes>
-                </profile>
-              </profiles>
-              <constraints>
-                <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="3d48-860a-ac7d-1efd" includeChildSelections="true"/>
-              </constraints>
-            </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="The Fang of Ghur" hidden="false" id="105b-b006-1a87-a738" publicationId="1ac6-e227-a186-12">
-              <profiles>
-                <profile name="The Fang of Ghur" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="1bc6-b004-6d8a-3481">
-                  <characteristics>
-                    <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Battle, Any Combat Phase</characteristic>
-                    <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick an enemy unit in combat with this unit to be the target.</characteristic>
-                    <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Ward rolls cannot be made for the target for the rest of the turn.</characteristic>
-                    <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
-                    <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
-                  </characteristics>
-                  <attributes>
-                    <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Red</attribute>
+                    <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Black</attribute>
                     <attribute typeId="6d16-c86b-2698-85a4" name="Type">Offensive</attribute>
                     <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
                   </attributes>
                 </profile>
               </profiles>
               <constraints>
-                <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="8ad9-6ba5-517e-9c9f" includeChildSelections="true"/>
+                <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="86e2-93ca-e345-55da" includeChildSelections="true"/>
+              </constraints>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Carvalox Hide" hidden="false" id="2193-1dd2-2471-649b" publicationId="feba-6749-6df3-ea9e">
+              <profiles>
+                <profile name="Carvalox Hide" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="0137-ba57-4ee0-7ae0" publicationId="feba-6749-6df3-ea9e">
+                  <characteristics>
+                    <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
+                    <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">This unit has **^^Ward (6+)^^**. It also has **^^Ward (4+)^^** against damage points inflicted by **^^Spell^^** abilities, **^^Prayer^^** abilities and abilities used by **^^Manifestations^^**.</characteristic>
+                  </characteristics>
+                  <attributes>
+                    <attribute typeId="50fe-4f29-6bc3-dcc6" name="Color">Green</attribute>
+                    <attribute typeId="bf11-4e10-3ab1-06f4" name="Type">Defensive</attribute>
+                    <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
+                  </attributes>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="920f-a51a-b2a4-ed54" includeChildSelections="true"/>
+              </constraints>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Mantle of Entrails" hidden="false" id="8310-9dcb-6401-6d7a" publicationId="feba-6749-6df3-ea9e">
+              <profiles>
+                <profile name="Mantle of Entrails" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="935a-8605-77e6-9a0f" publicationId="feba-6749-6df3-ea9e">
+                  <characteristics>
+                    <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Battle (Army), Any Hero Phase</characteristic>
+                    <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick a visible enemy unit within 12&quot; of this unit to be the target.</characteristic>
+                    <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Until the start of your next turn, each time the target uses a command, roll a dice as a reaction. On a 3+, that command has no effect, it still counts as having been used and the command points spent to use the command are still lost.</characteristic>
+                    <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+                    <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+                  </characteristics>
+                  <attributes>
+                    <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Yellow</attribute>
+                    <attribute typeId="6d16-c86b-2698-85a4" name="Type">Special</attribute>
+                    <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+                  </attributes>
+                </profile>
+              </profiles>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="db91-f6fa-cf4c-f47d" includeChildSelections="true"/>
               </constraints>
             </selectionEntry>
           </selectionEntries>
@@ -368,12 +372,12 @@
       <selectionEntryGroups>
         <selectionEntryGroup name="Traits of Endless Hunger" id="a5a-92de-7f93-c15e" hidden="false">
           <selectionEntries>
-            <selectionEntry type="upgrade" import="true" name="Great Gutlord" hidden="false" id="8b5f-1d82-5f61-8ba0" publicationId="1ac6-e227-a186-12">
+            <selectionEntry type="upgrade" import="true" name="Leave Not a Morsel" hidden="false" id="b279-4201-e5bd-8ef3" publicationId="feba-6749-6df3-ea9e">
               <profiles>
-                <profile name="Great Gutlord" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="1fc5-d411-e931-907e">
+                <profile name="Leave Not a Morsel" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="aeac-1f3f-e463-c025" publicationId="feba-6749-6df3-ea9e">
                   <characteristics>
                     <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
-                    <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">Ignore negative modifiers to this unit&apos;s control score and to hit rolls and wound rolls for this unit&apos;s attacks.</characteristic>
+                    <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">While they are within 6&quot; of and visible to this unit, enemy units cannot be healed or have slain models returned to them.</characteristic>
                   </characteristics>
                   <attributes>
                     <attribute typeId="50fe-4f29-6bc3-dcc6" name="Color">Black</attribute>
@@ -383,63 +387,50 @@
                 </profile>
               </profiles>
               <constraints>
-                <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="511d-1bba-4e64-943f" includeChildSelections="true"/>
+                <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="7465-5a09-028c-6354" includeChildSelections="true"/>
               </constraints>
             </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Touched by the Everwinter" hidden="false" id="af2-467a-2ba3-229d" publicationId="1ac6-e227-a186-12">
+            <selectionEntry type="upgrade" import="true" name="Dreaded Far and Wide" hidden="false" id="b63a-a9f5-1f8b-5cbc" publicationId="feba-6749-6df3-ea9e">
               <profiles>
-                <profile name="Touched by the Everwinter" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="6303-612b-74bb-f4ab">
+                <profile name="Dreaded Far and Wide" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="ebcf-81b7-f136-b6db" publicationId="feba-6749-6df3-ea9e">
                   <characteristics>
                     <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
-                    <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">If this unit is not a **^^Priest^^**, it has **^^Priest (1)^^**. If this unit is already a **^^Priest^^**, you can re-roll chanting rolls of 1 for it instead. If this unit is a **^^Wizard^^**, it cannot use **^^Spell^^** abilities and **^^Prayer^^** abilities in the same phase.</characteristic>
+                    <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">Ignore negative modifiers to:
+• This unit&apos;s control score.
+• Hit rolls and wound rolls for this unit&apos;s non-**Companion** attacks.
+• Charge rolls for this unit.
+• The number of dice rolled when making charge rolls for this unit.</characteristic>
                   </characteristics>
                   <attributes>
-                    <attribute typeId="50fe-4f29-6bc3-dcc6" name="Color">Yellow</attribute>
+                    <attribute typeId="50fe-4f29-6bc3-dcc6" name="Color">Black</attribute>
                     <attribute typeId="bf11-4e10-3ab1-06f4" name="Type">Special</attribute>
                     <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
                   </attributes>
                 </profile>
               </profiles>
               <constraints>
-                <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="a780-bde4-99a3-527d" includeChildSelections="true"/>
+                <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="80f1-b758-d285-17ff" includeChildSelections="true"/>
               </constraints>
-              <costs>
-                <cost name="pts" typeId="points" value="20"/>
-                <cost name="Destiny Points" typeId="bc33-05f5-8d3f-af43" value="0"/>
-                <cost name="Force Category - PTG" typeId="e63c-79ff-93ba-c5eb" value="0"/>
-                <cost name="Force Category - GHB" typeId="de92-2099-fbf7-a156" value="0"/>
-              </costs>
-              <modifiers>
-                <modifier type="set" value="0" field="points">
-                  <conditionGroups>
-                    <conditionGroup type="or">
-                      <conditions>
-                        <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="1bed-ddb5-0c50-16d2" shared="true" includeChildSelections="true"/>
-                        <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="01b1-5112-ab45-1afc" shared="true" includeChildSelections="true"/>
-                        <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="f079-501a-2738-6844" shared="true" includeChildSelections="true"/>
-                        <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="8e6f-2dd7-a7ed-489e" shared="true" includeChildSelections="true"/>
-                      </conditions>
-                    </conditionGroup>
-                  </conditionGroups>
-                </modifier>
-              </modifiers>
             </selectionEntry>
-            <selectionEntry type="upgrade" import="true" name="Booming Roar" hidden="false" id="c080-e0a1-5c1d-a5ec" publicationId="1ac6-e227-a186-12">
+            <selectionEntry type="upgrade" import="true" name="The Crusherguts" hidden="false" id="b6f3-c71d-0335-9c2b" publicationId="feba-6749-6df3-ea9e">
               <profiles>
-                <profile name="Booming Roar" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="cef-6b56-c73-a98a">
+                <profile name="The Crusherguts" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="21b3-86a4-4748-bcd5" publicationId="feba-6749-6df3-ea9e">
                   <characteristics>
-                    <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
-                    <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">Subtract 5 from the control scores of enemy **^^Infantry^^** units while they are in combat with this unit.</characteristic>
+                    <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Turn (Army), Any Combat Phase</characteristic>
+                    <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">If this unit charged this turn, pick an enemy unit in combat with it to be the target.</characteristic>
+                    <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Roll a dice. If the roll exceeds the target&apos;s Health characteristic, 1 model in the target unit is automatically slain and the target cannot make pile-in moves for the rest of the turn.</characteristic>
+                    <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+                    <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
                   </characteristics>
                   <attributes>
-                    <attribute typeId="50fe-4f29-6bc3-dcc6" name="Color">Purple</attribute>
-                    <attribute typeId="bf11-4e10-3ab1-06f4" name="Type">Control</attribute>
-                    <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
+                    <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Red</attribute>
+                    <attribute typeId="6d16-c86b-2698-85a4" name="Type">Offensive</attribute>
+                    <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
                   </attributes>
                 </profile>
               </profiles>
               <constraints>
-                <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="ecdd-14aa-91af-b8d3" includeChildSelections="true"/>
+                <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="6f9c-8497-e34c-d607" includeChildSelections="true"/>
               </constraints>
             </selectionEntry>
           </selectionEntries>
@@ -468,12 +459,12 @@
     </selectionEntryGroup>
     <selectionEntryGroup name="Prayer Lores" id="1f46-cff7-6a73-8ff1" hidden="false" flatten="true">
       <selectionEntries>
-        <selectionEntry type="upgrade" import="true" name="Everwinter Prayers" hidden="false" id="cbf5-9e76-3730-b567">
+        <selectionEntry type="upgrade" import="true" name="Lore of the Everwinter" hidden="false" id="cbf5-9e76-3730-b567">
           <constraints>
             <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="a316-e311-84b8-825a"/>
           </constraints>
           <entryLinks>
-            <entryLink import="true" name="Everwinter Prayers" hidden="false" id="3695-2a72-bee4-85cd" type="selectionEntryGroup" targetId="48ca-ef37-a530-211f"/>
+            <entryLink import="true" name="Lore of the Everwinter" hidden="false" id="3695-2a72-bee4-85cd" type="selectionEntryGroup" targetId="e5b8-86da-de17-d117"/>
           </entryLinks>
         </selectionEntry>
       </selectionEntries>
@@ -784,27 +775,20 @@ Then, roll a dice. The target can move a distance in inches up to the roll. It c
   <sharedSelectionEntries>
     <selectionEntry type="upgrade" import="true" name="Battle Traits: Ogor Mawtribes" hidden="false" id="93f7-a632-9dda-5515">
       <profiles>
-        <profile name="Trampling Charge" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="f3b6-b38e-1f53-b6ef" publicationId="1ac6-e227-a186-12">
+        <profile name="Eat &apos;Em Alive" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="9f51-0b9d-387e-f209" publicationId="feba-6749-6df3-ea9e">
           <characteristics>
-            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Any Charge Phase</characteristic>
-            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick a friendly **^^Ogor^^** or **^^Rhinox^^** unit that charged this turn to use this ability, then pick a visible enemy unit within 1&quot; of it to be the target.</characteristic>
-            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Roll a D3. Add 2 to the roll if this unit is a **^^Monster^^**. On a 2+, inflict an amount of mortal damage on the target equal to the roll.</characteristic>
-            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
-            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
-          </characteristics>
-          <attributes>
-            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Orange</attribute>
-            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Offensive</attribute>
-            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
-          </attributes>
-        </profile>
-        <profile name="Feast on Flesh" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="4d77-faf5-cd3e-90d8" publicationId="1ac6-e227-a186-12">
-          <characteristics>
-            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Battle (Army), End of Any Turn</characteristic>
-            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick each friendly **^^Ogor^^** unit that is in combat or that used a **^^Fight^^** ability this turn to be the targets.</characteristic>
-            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Roll a D3 for each target. On a 2+:
-• Heal (X) the target, where X is an amount equal to the roll. 
-• Pick an enemy unit in combat with the target. You cannot pick the same enemy unit more than once. Inflict an amount of mortal damage on that enemy unit equal to the roll.</characteristic>
+            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">End of Any Turn</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick a friendly **^^Ogor^^** unit that used a **^^Fight^^** ability that targeted a unit, excluding **^^Faction Terrain^^**, this turn to use this ability. Then, you can pick an enemy unit in combat with it to be the target. The same enemy unit cannot be picked to be the target of this ability more than once per turn.</characteristic>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Inflict D3 mortal damage on the target (if any). Then, pick 1 of the following effects to apply to that friendly **^^Ogor^^** unit for the rest of the battle. If any of these effects already apply to it, you can pick a different effect to replace the current effect.
+
+• ***Raw and Bloody Flesh***: Subtract 1 from the Rend characteristic of weapons used for attacks that target that unit.
+• ***Exotic Giblets***: Subtract 1 from ward rolls for damage points inflicted by that unit&apos;s combat attacks made with non-**Companion** weapons.
+• ***Steaming Brains***: Add 2 to that unit&apos;s Control characteristic.
+• ***Crunchy Bones***: That unit&apos;s melee weapons have **Crit (2 Hits)**. If that unit&apos;s melee weapons already have **Crit (2 Hits)**, they have **Crit (Mortal)** instead.
+• ***Slick Innards***: That unit can use **^^Charge^^** abilities even if it used a **^^Run^^** ability in the same turn.
+• ***Mystery Meat***: Subtract 1 from the power level of enemy units while they are in combat with that unit, to a minimum of 0.
+
+***Designer&apos;s Note**: Only 1 of these effects can apply to the same unit at the same time unless specified otherwise. Also note that **Steaming Brains** affects the Control characteristic, not the control score.*</characteristic>
             <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
             <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
           </characteristics>
@@ -814,15 +798,52 @@ Then, roll a dice. The target can move a distance in inches up to the roll. It c
             <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
           </attributes>
         </profile>
-        <profile name="Ravenous Brutes" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="d1a0-c39c-39e-3da4" publicationId="1ac6-e227-a186-12">
+        <profile name="Bull Charge" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="af33-ad3b-ecfd-28aa" publicationId="feba-6749-6df3-ea9e">
           <characteristics>
-            <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
-            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">Add 2 to run rolls for friendly **^^Ogor^^** units while you have not used the &apos;Feast on Flesh&apos; ability this battle.</characteristic>
+            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Turn (Army), Any Charge Phase</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick a friendly **^^Ogor Mawtribes^^** unit that charged this turn and has not used a **^^Rampage^^** ability this turn to use this ability, then pick an enemy unit in combat with it to be the target.</characteristic>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Your opponent must move the target up to 3&quot;. It can move through the combat ranges of your units and can end that move in combat.
+
+After your opponent has done so, roll a dice for each model in the unit using this ability that is within 3&quot; of the target. Add 1 to the roll if the unit using this ability is a **^^Gutbusters^^** unit. For each 3+, inflict 1 mortal damage on the target.
+
+Then, the unit using this ability can make a pile-in move. If the target of this ability is still in combat with the unit using this ability, then the target of this ability must be picked as the target of the pile-in move.
+
+***Designer&apos;s Note**: Your opponent may not be able to move the models in the target unit (or may choose to leave them where they are) but the target still counts as having moved for rules purposes.*</characteristic>
+            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
           </characteristics>
           <attributes>
-            <attribute typeId="50fe-4f29-6bc3-dcc6" name="Color">Gray</attribute>
-            <attribute typeId="bf11-4e10-3ab1-06f4" name="Type">Movement</attribute>
-            <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
+            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Orange</attribute>
+            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Movement</attribute>
+            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+          </attributes>
+        </profile>
+        <profile name="Jaws of the Beast" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="f64a-7291-75dd-646d" publicationId="feba-6749-6df3-ea9e">
+          <characteristics>
+            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Battle (Army), Deployment Phase</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick a friendly **^^Beastclaw Hero^^** that is leading a regiment and that has not been deployed, then pick a non-**^^Hero^^** unit in that **^^Hero^^**&apos;s regiment that has not been deployed.</characteristic>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Set up those units in reserve **tracking the prey**. They have now been deployed.</characteristic>
+            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f">**^^Deploy^^**</characteristic>
+            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+          </characteristics>
+          <attributes>
+            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Black</attribute>
+            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Special</attribute>
+            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+          </attributes>
+        </profile>
+        <profile name="Closing the Jaws" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="9488-ba78-79fe-da9a" publicationId="feba-6749-6df3-ea9e">
+          <characteristics>
+            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Your Movement Phase</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick a friendly **^^Beastclaw Hero^^** that is **tracking the prey**.</characteristic>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Set up that **^^Hero^^** wholly within 9&quot; of a battlefield edge and more than 9&quot; from all enemy units. Then, set up the other friendly unit that is **tracking the prey** wholly within 9&quot; of a battlefield edge, wholly within 9&quot; of that **^^Hero^^** and more than 9&quot; from all enemy units.</characteristic>
+            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+          </characteristics>
+          <attributes>
+            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Gray</attribute>
+            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Movement</attribute>
+            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
           </attributes>
         </profile>
       </profiles>
@@ -851,7 +872,7 @@ Then, roll a dice. The target can move a distance in inches up to the roll. It c
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="9c17-5779-58da-f114" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="130"/>
+        <cost name="pts" typeId="points" value="150"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -900,7 +921,7 @@ Then, roll a dice. The target can move a distance in inches up to the roll. It c
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="056c-6bac-1c4e-62b0" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="110"/>
+        <cost name="pts" typeId="points" value="130"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -962,59 +983,7 @@ Then, roll a dice. The target can move a distance in inches up to the roll. It c
         <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="2aad-78d5-8461-211c" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="150"/>
-      </costs>
-      <modifiers>
-        <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition type="lessThan" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true" includeChildForces="true"/>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-        <modifier type="set" value="true" field="hidden">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true"/>
-                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <modifierGroups>
-        <modifierGroup type="and">
-          <modifiers>
-            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.5c0d-5e93-d71f-f0da"/>
-            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.139a-e1a2-a79a-6fce"/>
-            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.1f2a-58a9-839b-59b0"/>
-            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.7b4c-9343-e884-9b28"/>
-            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.3a87-b1c8-8528-7efd"/>
-          </modifiers>
-          <conditions>
-            <condition type="instanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
-          </conditions>
-        </modifierGroup>
-      </modifierGroups>
-    </entryLink>
-    <entryLink import="true" name="Firebelly" hidden="false" id="85a7-ce71-b015-8261" type="selectionEntry" targetId="d5f3-a7f1-7345-ee4b">
-      <entryLinks>
-        <entryLink import="true" name="Heroic Traits" hidden="false" id="295c-2020-a5b2-296e" type="selectionEntryGroup" targetId="b31d-aee-8d55-5892"/>
-        <entryLink import="true" name="Artefacts of Power" hidden="false" id="383-93a2-3b71-907d" type="selectionEntryGroup" targetId="30c8-590c-42a7-3c48"/>
-        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="858f-28a2-0277-719c" type="selectionEntryGroup" targetId="9b0d-58b7-8982-2128"/>
-        <entryLink import="true" name="Paths" hidden="false" id="1ab3-39c3-c3ee-ed0a" type="selectionEntryGroup" targetId="517c-3059-2a24-89dc"/>
-        <entryLink import="true" name="Warlord" hidden="false" id="8152-c898-bbd8-817b" type="selectionEntry" targetId="bb28-fa4a-bf5f-f793"/>
-        <entryLink import="true" name="Renown" hidden="false" id="3780-3711-9b5d-28ed" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
-        <entryLink import="true" name="Big Names" hidden="false" id="e3c0-d143-6a09-89b9" type="selectionEntryGroup" targetId="c097-d461-7bb0-880c"/>
-        <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="f0d2-b9d3-0808-3309" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="points" value="140"/>
+        <cost name="pts" typeId="points" value="170"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -1067,7 +1036,7 @@ Then, roll a dice. The target can move a distance in inches up to the roll. It c
         <entryLink import="true" name="Monstrous Traits" hidden="false" id="4367-c7c5-59b2-164c" type="selectionEntryGroup" targetId="475a-6503-cce0-9752"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="320"/>
+        <cost name="pts" typeId="points" value="340"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -1117,7 +1086,7 @@ Then, roll a dice. The target can move a distance in inches up to the roll. It c
         <entryLink import="true" name="Monstrous Traits" hidden="false" id="0e50-a589-ae3d-8667" type="selectionEntryGroup" targetId="475a-6503-cce0-9752"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="230"/>
+        <cost name="pts" typeId="points" value="280"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -1217,7 +1186,7 @@ Then, roll a dice. The target can move a distance in inches up to the roll. It c
         <entryLink import="true" name="Monstrous Traits" hidden="false" id="1ad2-3838-838c-78a2" type="selectionEntryGroup" targetId="475a-6503-cce0-9752"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="290"/>
+        <cost name="pts" typeId="points" value="300"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -1281,7 +1250,7 @@ Then, roll a dice. The target can move a distance in inches up to the roll. It c
         <entryLink import="true" name="Monstrous Traits" hidden="false" id="f962-27e7-d6a1-f5f4" type="selectionEntryGroup" targetId="475a-6503-cce0-9752"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="220"/>
+        <cost name="pts" typeId="points" value="280"/>
       </costs>
       <modifiers>
         <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
@@ -1396,69 +1365,6 @@ Then, roll a dice. The target can move a distance in inches up to the roll. It c
         </modifierGroup>
       </modifierGroups>
     </entryLink>
-    <entryLink import="true" name="Icebrow Hunter" hidden="false" id="2fea-de8c-571b-d4dd" type="selectionEntry" targetId="8ea1-2719-4da0-2b1f">
-      <entryLinks>
-        <entryLink import="true" name="Heroic Traits" hidden="false" id="ddce-baa8-e6ba-7a19" type="selectionEntryGroup" targetId="b31d-aee-8d55-5892"/>
-        <entryLink import="true" name="Artefacts of Power" hidden="false" id="f821-aad0-3351-3db" type="selectionEntryGroup" targetId="30c8-590c-42a7-3c48"/>
-        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="d88a-aa61-1515-af99" type="selectionEntryGroup" targetId="9b0d-58b7-8982-2128"/>
-        <entryLink import="true" name="Paths" hidden="false" id="30f1-9899-379c-8d60" type="selectionEntryGroup" targetId="517c-3059-2a24-89dc"/>
-        <entryLink import="true" name="Warlord" hidden="false" id="4db6-b5ac-aae3-c711" type="selectionEntry" targetId="bb28-fa4a-bf5f-f793"/>
-        <entryLink import="true" name="Renown" hidden="false" id="d5f2-02ad-86b2-cb82" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
-        <entryLink import="true" name="Big Names" hidden="false" id="75f9-065e-c1ac-32e5" type="selectionEntryGroup" targetId="c097-d461-7bb0-880c"/>
-        <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="fedf-35a5-e07d-02ec" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="points" value="100"/>
-      </costs>
-      <modifiers>
-        <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition type="lessThan" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true" includeChildForces="true"/>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-        <modifier type="set" value="true" field="hidden">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true"/>
-                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
-                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="8f4b-1fa6-3128-8405" shared="true"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <modifierGroups>
-        <modifierGroup type="and">
-          <modifiers>
-            <modifier type="add" value="bf4e-4b1b-7055-2ec8" field="category"/>
-          </modifiers>
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true"/>
-                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifierGroup>
-        <modifierGroup type="and">
-          <modifiers>
-            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.1a3d-33f9-c4cc-fe0"/>
-          </modifiers>
-          <conditions>
-            <condition type="instanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
-          </conditions>
-        </modifierGroup>
-      </modifierGroups>
-    </entryLink>
     <entryLink import="true" name="Kragnos, the End of Empires" hidden="false" id="effb-1317-8351-5855" type="selectionEntry" targetId="7231-fb13-c283-ff9d">
       <costs>
         <cost name="pts" typeId="points" value="580"/>
@@ -1500,93 +1406,12 @@ Then, roll a dice. The target can move a distance in inches up to the roll. It c
         </modifierGroup>
       </modifierGroups>
     </entryLink>
-    <entryLink import="true" name="Slaughtermaster" hidden="false" id="4dea-ffce-568d-980" type="selectionEntry" targetId="3d51-af3a-455e-2373">
-      <entryLinks>
-        <entryLink import="true" name="Heroic Traits" hidden="false" id="2b3f-5257-d172-facd" type="selectionEntryGroup" targetId="b31d-aee-8d55-5892"/>
-        <entryLink import="true" name="Artefacts of Power" hidden="false" id="e4d5-bbc9-3139-10a4" type="selectionEntryGroup" targetId="30c8-590c-42a7-3c48"/>
-        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="b73b-a620-b91a-4182" type="selectionEntryGroup" targetId="9b0d-58b7-8982-2128"/>
-        <entryLink import="true" name="Paths" hidden="false" id="9052-cfdf-3f26-1720" type="selectionEntryGroup" targetId="517c-3059-2a24-89dc"/>
-        <entryLink import="true" name="Warlord" hidden="false" id="f480-fc9f-2a3c-5912" type="selectionEntry" targetId="bb28-fa4a-bf5f-f793"/>
-        <entryLink import="true" name="Renown" hidden="false" id="9eb8-efc5-88a1-c725" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
-        <entryLink import="true" name="Big Names" hidden="false" id="0a7e-4f41-1aaa-1f84" type="selectionEntryGroup" targetId="c097-d461-7bb0-880c"/>
-        <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="ff58-fb3f-537d-c5a8" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="points" value="150"/>
-      </costs>
-      <modifiers>
-        <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition type="lessThan" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true" includeChildForces="true"/>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-        <modifier type="set" value="true" field="hidden">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true"/>
-                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <modifierGroups>
-        <modifierGroup type="and">
-          <modifiers>
-            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.5c0d-5e93-d71f-f0da"/>
-            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.139a-e1a2-a79a-6fce"/>
-            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.1f2a-58a9-839b-59b0"/>
-            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.7b4c-9343-e884-9b28"/>
-            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.3a87-b1c8-8528-7efd"/>
-          </modifiers>
-          <conditions>
-            <condition type="instanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
-          </conditions>
-        </modifierGroup>
-      </modifierGroups>
-    </entryLink>
     <entryLink import="true" name="Battle Traits: Ogor Mawtribes" hidden="false" id="e8db-74b2-a23c-2a4a" type="selectionEntry" targetId="93f7-a632-9dda-5515">
       <constraints>
         <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="7673-f154-69e-ab0" includeChildSelections="true"/>
       </constraints>
     </entryLink>
-    <entryLink import="true" name="Great Mawpot" hidden="false" id="ea7b-cee5-4266-bbb9" type="selectionEntry" targetId="2586-d28e-7404-b64e"/>
     <entryLink import="true" name="Mawpit" hidden="false" id="6eb8-9171-4859-2b4c" type="selectionEntry" targetId="8e60-2852-1bfc-272"/>
-    <entryLink import="true" name="Frost Sabres" hidden="false" id="6706-c1c2-5c09-3199" type="selectionEntry" targetId="bdf9-1644-707-f0df">
-      <modifiers>
-        <modifier type="multiply" value="2" field="points">
-          <conditions>
-            <condition type="atLeast" value="1" field="selections" scope="self" childId="1b37-82b8-c062-eb82" shared="true"/>
-          </conditions>
-        </modifier>
-        <modifier type="set" value="true" field="hidden">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
-                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="db3a-7199-c92e-f3cf" shared="true"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <entryLinks>
-        <entryLink import="true" name="Reinforced" hidden="false" id="6180-90f0-86d8-79b3" type="selectionEntry" targetId="1b37-82b8-c062-eb82"/>
-        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="746d-4186-2de6-7b5c" type="selectionEntryGroup" targetId="9b0d-58b7-8982-2128"/>
-        <entryLink import="true" name="Paths" hidden="false" id="ff10-b562-8ac9-beaf" type="selectionEntryGroup" targetId="517c-3059-2a24-89dc"/>
-        <entryLink import="true" name="Renown" hidden="false" id="6899-536d-2f1d-ed3c" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="points" value="70"/>
-      </costs>
-    </entryLink>
     <entryLink import="true" name="Gnoblar Scraplauncher" hidden="false" id="7b4c-9343-e884-9b28" type="selectionEntry" targetId="206-8e8e-f77d-e786">
       <modifiers>
         <modifier type="multiply" value="2" field="points">
@@ -1632,7 +1457,7 @@ Then, roll a dice. The target can move a distance in inches up to the roll. It c
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="120"/>
+        <cost name="pts" typeId="points" value="160"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="6f6f-426c-0287-237c" type="selectionEntryGroup" targetId="9b0d-58b7-8982-2128"/>
@@ -1671,34 +1496,6 @@ Then, roll a dice. The target can move a distance in inches up to the roll. It c
         <cost name="pts" typeId="points" value="240"/>
       </costs>
     </entryLink>
-    <entryLink import="true" name="Icefall Yhetees" hidden="false" id="92ef-3f35-c07d-5d50" type="selectionEntry" targetId="5fed-90de-715-e720">
-      <entryLinks>
-        <entryLink import="true" name="Reinforced" hidden="false" id="1199-29d7-21f0-a7c9" type="selectionEntry" targetId="1b37-82b8-c062-eb82"/>
-        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="ea40-5d14-f295-b732" type="selectionEntryGroup" targetId="9b0d-58b7-8982-2128"/>
-        <entryLink import="true" name="Paths" hidden="false" id="8e0d-b0b1-55de-0820" type="selectionEntryGroup" targetId="517c-3059-2a24-89dc"/>
-        <entryLink import="true" name="Renown" hidden="false" id="b0e5-2817-307d-25f0" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
-      </entryLinks>
-      <modifiers>
-        <modifier type="multiply" value="2" field="points">
-          <conditions>
-            <condition type="atLeast" value="1" field="selections" scope="self" childId="1b37-82b8-c062-eb82" shared="true"/>
-          </conditions>
-        </modifier>
-        <modifier type="set" value="true" field="hidden">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
-                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="db3a-7199-c92e-f3cf" shared="true"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <costs>
-        <cost name="pts" typeId="points" value="100"/>
-      </costs>
-    </entryLink>
     <entryLink import="true" name="Ironblaster" hidden="false" id="2ddd-fabd-7d0-d164" type="selectionEntry" targetId="7f12-bfdf-bff5-c0fd">
       <modifiers>
         <modifier type="multiply" value="2" field="points">
@@ -1718,7 +1515,7 @@ Then, roll a dice. The target can move a distance in inches up to the roll. It c
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="160"/>
+        <cost name="pts" typeId="points" value="180"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="e555-e951-b79a-b595" type="selectionEntryGroup" targetId="9b0d-58b7-8982-2128"/>
@@ -1726,91 +1523,7 @@ Then, roll a dice. The target can move a distance in inches up to the roll. It c
         <entryLink import="true" name="Renown" hidden="false" id="c120-b322-a9f0-63b1" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
       </entryLinks>
     </entryLink>
-    <entryLink import="true" name="Leadbelchers" hidden="false" id="96ee-3e88-f022-9f5a" type="selectionEntry" targetId="15cd-469c-4ed6-afef">
-      <entryLinks>
-        <entryLink import="true" name="Reinforced" hidden="false" id="fe19-7963-30ce-cab8" type="selectionEntry" targetId="1b37-82b8-c062-eb82"/>
-        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="83a7-9bca-abbd-4eff" type="selectionEntryGroup" targetId="9b0d-58b7-8982-2128"/>
-        <entryLink import="true" name="Paths" hidden="false" id="9b70-05ce-d9e7-ec26" type="selectionEntryGroup" targetId="517c-3059-2a24-89dc"/>
-        <entryLink import="true" name="Renown" hidden="false" id="2287-5c7b-8898-27bc" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
-      </entryLinks>
-      <modifiers>
-        <modifier type="multiply" value="2" field="points">
-          <conditions>
-            <condition type="atLeast" value="1" field="selections" scope="self" childId="1b37-82b8-c062-eb82" shared="true"/>
-          </conditions>
-        </modifier>
-        <modifier type="set" value="true" field="hidden">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
-                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="db3a-7199-c92e-f3cf" shared="true"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <costs>
-        <cost name="pts" typeId="points" value="120"/>
-      </costs>
-    </entryLink>
-    <entryLink import="true" name="Maneaters" hidden="false" id="c90-9fd3-ed17-5903" type="selectionEntry" targetId="f4ef-9156-1fd1-4b91">
-      <entryLinks>
-        <entryLink import="true" name="Reinforced" hidden="false" id="676c-3037-f5dc-2f20" type="selectionEntry" targetId="1b37-82b8-c062-eb82"/>
-        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="980c-c7e4-8333-fb73" type="selectionEntryGroup" targetId="9b0d-58b7-8982-2128"/>
-        <entryLink import="true" name="Paths" hidden="false" id="6a61-7821-41fd-46fa" type="selectionEntryGroup" targetId="517c-3059-2a24-89dc"/>
-        <entryLink import="true" name="Renown" hidden="false" id="708c-cabd-421f-fe50" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
-      </entryLinks>
-      <modifiers>
-        <modifier type="multiply" value="2" field="points">
-          <conditions>
-            <condition type="atLeast" value="1" field="selections" scope="self" childId="1b37-82b8-c062-eb82" shared="true"/>
-          </conditions>
-        </modifier>
-        <modifier type="set" value="true" field="hidden">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
-                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="db3a-7199-c92e-f3cf" shared="true"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <costs>
-        <cost name="pts" typeId="points" value="160"/>
-      </costs>
-    </entryLink>
-    <entryLink import="true" name="Mournfang Pack" hidden="false" id="b077-f94b-b711-c147" type="selectionEntry" targetId="b91b-cba6-89af-7225">
-      <entryLinks>
-        <entryLink import="true" name="Reinforced" hidden="false" id="6995-2ecc-e512-e33f" type="selectionEntry" targetId="1b37-82b8-c062-eb82"/>
-        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="3ed8-e9cf-27d4-708d" type="selectionEntryGroup" targetId="9b0d-58b7-8982-2128"/>
-        <entryLink import="true" name="Paths" hidden="false" id="18cc-1e6b-da5f-2724" type="selectionEntryGroup" targetId="517c-3059-2a24-89dc"/>
-        <entryLink import="true" name="Renown" hidden="false" id="82ab-7274-def1-fb5f" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
-      </entryLinks>
-      <modifiers>
-        <modifier type="multiply" value="2" field="points">
-          <conditions>
-            <condition type="atLeast" value="1" field="selections" scope="self" childId="1b37-82b8-c062-eb82" shared="true"/>
-          </conditions>
-        </modifier>
-        <modifier type="set" value="true" field="hidden">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
-                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="db3a-7199-c92e-f3cf" shared="true"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <costs>
-        <cost name="pts" typeId="points" value="150"/>
-      </costs>
-    </entryLink>
-    <entryLink import="true" name="Ogor Gluttons" hidden="false" id="ff7f-ced8-cc4c-106f" type="selectionEntry" targetId="e93b-4897-f014-9b88">
+    <entryLink import="true" name="Gluttons" hidden="false" id="ff7f-ced8-cc4c-106f" type="selectionEntry" targetId="e93b-4897-f014-9b88">
       <entryLinks>
         <entryLink import="true" name="Reinforced" hidden="false" id="acf5-b6f8-ff38-648b" type="selectionEntry" targetId="1b37-82b8-c062-eb82"/>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="e312-678b-1150-38a4" type="selectionEntryGroup" targetId="9b0d-58b7-8982-2128"/>
@@ -1835,7 +1548,7 @@ Then, roll a dice. The target can move a distance in inches up to the roll. It c
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="220"/>
+        <cost name="pts" typeId="points" value="200"/>
       </costs>
     </entryLink>
     <entryLink import="true" name="Stonehorn Beastriders" hidden="false" id="81ea-a0e7-bffa-7ebb" type="selectionEntry" targetId="8b95-893a-4c1a-9224">
@@ -1857,7 +1570,7 @@ Then, roll a dice. The target can move a distance in inches up to the roll. It c
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="260"/>
+        <cost name="pts" typeId="points" value="280"/>
       </costs>
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="f468-f1e8-dbd9-2e43" type="selectionEntryGroup" targetId="9b0d-58b7-8982-2128"/>
@@ -1891,35 +1604,7 @@ Then, roll a dice. The target can move a distance in inches up to the roll. It c
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="180"/>
-      </costs>
-    </entryLink>
-    <entryLink import="true" name="Gnoblars" hidden="false" id="139a-e1a2-a79a-6fce" type="selectionEntry" targetId="5d4b-756c-2229-3dd9">
-      <entryLinks>
-        <entryLink import="true" name="Reinforced" hidden="false" id="826e-bc5f-8e03-a2c0" type="selectionEntry" targetId="1b37-82b8-c062-eb82"/>
-        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="1d0c-3b3c-5695-7ef0" type="selectionEntryGroup" targetId="9b0d-58b7-8982-2128"/>
-        <entryLink import="true" name="Paths" hidden="false" id="6818-044b-327d-68f3" type="selectionEntryGroup" targetId="517c-3059-2a24-89dc"/>
-        <entryLink import="true" name="Renown" hidden="false" id="383f-8e77-6025-34e2" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
-      </entryLinks>
-      <modifiers>
-        <modifier type="multiply" value="2" field="points">
-          <conditions>
-            <condition type="atLeast" value="1" field="selections" scope="self" childId="1b37-82b8-c062-eb82" shared="true"/>
-          </conditions>
-        </modifier>
-        <modifier type="set" value="true" field="hidden">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
-                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="db3a-7199-c92e-f3cf" shared="true"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <costs>
-        <cost name="pts" typeId="points" value="130"/>
+        <cost name="pts" typeId="points" value="240"/>
       </costs>
     </entryLink>
     <entryLink import="true" name="Ironguts" hidden="false" id="d797-f5f5-84e3-e83e" type="selectionEntry" targetId="7ea4-f81b-b7cc-b16e">
@@ -1947,7 +1632,7 @@ Then, roll a dice. The target can move a distance in inches up to the roll. It c
         </modifier>
       </modifiers>
       <costs>
-        <cost name="pts" typeId="points" value="210"/>
+        <cost name="pts" typeId="points" value="200"/>
       </costs>
     </entryLink>
     <entryLink import="true" name="Gorlok Blackpowder" hidden="false" id="537a-7689-6beb-958b" type="selectionEntry" targetId="3fb9-0714-39ba-3e65">
@@ -2171,6 +1856,136 @@ Then, roll a dice. The target can move a distance in inches up to the roll. It c
           </conditions>
         </modifierGroup>
       </modifierGroups>
+    </entryLink>
+    <entryLink import="true" name="Morga the Mighty, Overtyrant" hidden="false" id="ba21-6340-2de8-ee18" type="selectionEntry" targetId="bbbf-3088-d9ef-ab3e">
+      <costs>
+        <cost name="pts" typeId="points" value="430"/>
+      </costs>
+      <entryLinks>
+        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="c9ee-c9c8-32cf-d5c0" type="selectionEntryGroup" targetId="9b0d-58b7-8982-2128"/>
+      </entryLinks>
+    </entryLink>
+    <entryLink import="true" name="Grell Firefist" hidden="false" id="29ec-3583-c704-1e15" type="selectionEntry" targetId="3fb5-d2d7-81b4-6a19">
+      <costs>
+        <cost name="pts" typeId="points" value="150"/>
+      </costs>
+      <entryLinks>
+        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="4dcc-5b5f-e726-1d0a" type="selectionEntryGroup" targetId="9b0d-58b7-8982-2128"/>
+      </entryLinks>
+    </entryLink>
+    <entryLink import="true" name="Redd the Maw, High Slaughtermaster" hidden="false" id="ccf2-f7fd-a8ae-c8ae" type="selectionEntry" targetId="63b1-7b0e-39da-a18f">
+      <costs>
+        <cost name="pts" typeId="points" value="400"/>
+      </costs>
+      <entryLinks>
+        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="2589-f0cd-82e6-1536" type="selectionEntryGroup" targetId="9b0d-58b7-8982-2128"/>
+      </entryLinks>
+    </entryLink>
+    <entryLink import="true" name="Tyrant on Glutthorn" hidden="false" id="0d98-17de-fdc4-9899" type="selectionEntry" targetId="9e4e-efb1-3f18-b23d">
+      <entryLinks>
+        <entryLink import="true" name="Heroic Traits" hidden="false" id="b1d9-101a-0e8d-f48d" type="selectionEntryGroup" targetId="b31d-aee-8d55-5892"/>
+        <entryLink import="true" name="Artefacts of Power" hidden="false" id="82fe-b7da-a219-b5f3" type="selectionEntryGroup" targetId="30c8-590c-42a7-3c48"/>
+        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="63ce-60b4-9524-96f3" type="selectionEntryGroup" targetId="9b0d-58b7-8982-2128"/>
+        <entryLink import="true" name="Paths" hidden="false" id="a25e-aef9-6df8-4b8d" type="selectionEntryGroup" targetId="517c-3059-2a24-89dc"/>
+        <entryLink import="true" name="Warlord" hidden="false" id="a8f7-c175-5355-1c7c" type="selectionEntry" targetId="bb28-fa4a-bf5f-f793"/>
+        <entryLink import="true" name="Renown" hidden="false" id="f08e-f156-a27e-36c2" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Big Names" hidden="false" id="c631-494b-8f08-bf87" type="selectionEntryGroup" targetId="c097-d461-7bb0-880c"/>
+        <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="bcb9-1735-a50f-dc0b" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
+        <entryLink import="true" name="Monstrous Traits" hidden="false" id="4b63-4edc-1236-1ea7" type="selectionEntryGroup" targetId="475a-6503-cce0-9752"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="400"/>
+      </costs>
+    </entryLink>
+    <entryLink import="true" name="Maulbeast Cavalry" hidden="false" id="29f5-da35-9731-81b2" type="selectionEntry" targetId="4781-28ae-2385-ff02">
+      <entryLinks>
+        <entryLink import="true" name="Reinforced" hidden="false" id="bcd2-f414-d961-7760" type="selectionEntry" targetId="1b37-82b8-c062-eb82"/>
+        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="7b92-16dc-a92c-256d" type="selectionEntryGroup" targetId="9b0d-58b7-8982-2128"/>
+        <entryLink import="true" name="Paths" hidden="false" id="2849-2875-9770-a00a" type="selectionEntryGroup" targetId="517c-3059-2a24-89dc"/>
+        <entryLink import="true" name="Renown" hidden="false" id="e03e-49c0-b543-c9fb" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+      </entryLinks>
+      <modifiers>
+        <modifier type="multiply" value="2" field="points">
+          <conditions>
+            <condition type="atLeast" value="1" field="selections" scope="self" childId="1b37-82b8-c062-eb82" shared="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <costs>
+        <cost name="pts" typeId="points" value="280"/>
+      </costs>
+    </entryLink>
+    <entryLink import="true" name="Maulbeast Raiders" hidden="false" id="ec2b-3252-0e09-ed97" type="selectionEntry" targetId="a30d-9041-ffdb-5a33">
+      <entryLinks>
+        <entryLink import="true" name="Reinforced" hidden="false" id="3c0d-e52e-5d45-a207" type="selectionEntry" targetId="1b37-82b8-c062-eb82"/>
+        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="9c2e-350e-0310-e529" type="selectionEntryGroup" targetId="9b0d-58b7-8982-2128"/>
+        <entryLink import="true" name="Paths" hidden="false" id="288e-5283-5ecf-98d4" type="selectionEntryGroup" targetId="517c-3059-2a24-89dc"/>
+        <entryLink import="true" name="Renown" hidden="false" id="c0ce-493b-ca96-161a" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+      </entryLinks>
+      <modifiers>
+        <modifier type="multiply" value="2" field="points">
+          <conditions>
+            <condition type="atLeast" value="1" field="selections" scope="self" childId="1b37-82b8-c062-eb82" shared="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <costs>
+        <cost name="pts" typeId="points" value="230"/>
+      </costs>
+    </entryLink>
+    <entryLink import="true" name="Hunters with Sabrefangs" hidden="false" id="47ce-b3b9-daa9-360d" type="selectionEntry" targetId="cdfc-5bdb-a479-48fa">
+      <entryLinks>
+        <entryLink import="true" name="Reinforced" hidden="false" id="6dec-d0af-95a5-51a1" type="selectionEntry" targetId="1b37-82b8-c062-eb82"/>
+        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="e7a6-6a42-19aa-789b" type="selectionEntryGroup" targetId="9b0d-58b7-8982-2128"/>
+        <entryLink import="true" name="Paths" hidden="false" id="dc93-3f77-867c-dd5c" type="selectionEntryGroup" targetId="517c-3059-2a24-89dc"/>
+        <entryLink import="true" name="Renown" hidden="false" id="ca32-6b5d-fb43-db06" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+      </entryLinks>
+      <modifiers>
+        <modifier type="multiply" value="2" field="points">
+          <conditions>
+            <condition type="atLeast" value="1" field="selections" scope="self" childId="1b37-82b8-c062-eb82" shared="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <costs>
+        <cost name="pts" typeId="points" value="160"/>
+      </costs>
+    </entryLink>
+    <entryLink import="true" name="Cleavers" hidden="false" id="c920-4c40-6b6e-c018" type="selectionEntry" targetId="7ad4-12cf-f68d-953f">
+      <entryLinks>
+        <entryLink import="true" name="Reinforced" hidden="false" id="65ae-0eea-e2bb-3922" type="selectionEntry" targetId="1b37-82b8-c062-eb82"/>
+        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="f36d-2d3b-30e1-07b3" type="selectionEntryGroup" targetId="9b0d-58b7-8982-2128"/>
+        <entryLink import="true" name="Paths" hidden="false" id="8213-d75d-fe15-4a69" type="selectionEntryGroup" targetId="517c-3059-2a24-89dc"/>
+        <entryLink import="true" name="Renown" hidden="false" id="249c-ce2e-7301-70d8" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+      </entryLinks>
+      <modifiers>
+        <modifier type="multiply" value="2" field="points">
+          <conditions>
+            <condition type="atLeast" value="1" field="selections" scope="self" childId="1b37-82b8-c062-eb82" shared="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <costs>
+        <cost name="pts" typeId="points" value="220"/>
+      </costs>
+    </entryLink>
+    <entryLink import="true" name="Gutseers" hidden="false" id="5cf8-6413-2a60-4cb0" type="selectionEntry" targetId="5b64-1820-427e-0379">
+      <entryLinks>
+        <entryLink import="true" name="Reinforced" hidden="false" id="d38a-1a77-d4c5-0ae9" type="selectionEntry" targetId="1b37-82b8-c062-eb82"/>
+        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="778b-5ecd-a62c-3aa7" type="selectionEntryGroup" targetId="9b0d-58b7-8982-2128"/>
+        <entryLink import="true" name="Paths" hidden="false" id="cdba-e958-66ce-fb19" type="selectionEntryGroup" targetId="517c-3059-2a24-89dc"/>
+        <entryLink import="true" name="Renown" hidden="false" id="299b-1500-1d38-91c3" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+      </entryLinks>
+      <modifiers>
+        <modifier type="multiply" value="2" field="points">
+          <conditions>
+            <condition type="atLeast" value="1" field="selections" scope="self" childId="1b37-82b8-c062-eb82" shared="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <costs>
+        <cost name="pts" typeId="points" value="200"/>
+      </costs>
     </entryLink>
   </entryLinks>
   <selectionEntries>

--- a/Ogor Mawtribes.cat
+++ b/Ogor Mawtribes.cat
@@ -1996,6 +1996,346 @@ Then, the unit using this ability can make a pile-in move. If the target of this
         <cost name="pts" typeId="points" value="200"/>
       </costs>
     </entryLink>
+    <entryLink import="true" name="Firebelly" hidden="false" id="85a7-ce71-b015-8261" type="selectionEntry" targetId="d5f3-a7f1-7345-ee4b">
+      <entryLinks>
+        <entryLink import="true" name="Heroic Traits" hidden="false" id="295c-2020-a5b2-296e" type="selectionEntryGroup" targetId="b31d-aee-8d55-5892"/>
+        <entryLink import="true" name="Artefacts of Power" hidden="false" id="383-93a2-3b71-907d" type="selectionEntryGroup" targetId="30c8-590c-42a7-3c48"/>
+        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="858f-28a2-0277-719c" type="selectionEntryGroup" targetId="9b0d-58b7-8982-2128"/>
+        <entryLink import="true" name="Paths" hidden="false" id="1ab3-39c3-c3ee-ed0a" type="selectionEntryGroup" targetId="517c-3059-2a24-89dc"/>
+        <entryLink import="true" name="Warlord" hidden="false" id="8152-c898-bbd8-817b" type="selectionEntry" targetId="bb28-fa4a-bf5f-f793"/>
+        <entryLink import="true" name="Renown" hidden="false" id="3780-3711-9b5d-28ed" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Big Names" hidden="false" id="e3c0-d143-6a09-89b9" type="selectionEntryGroup" targetId="c097-d461-7bb0-880c"/>
+        <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="f0d2-b9d3-0808-3309" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="150"/>
+      </costs>
+      <modifiers>
+        <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="lessThan" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true" includeChildForces="true"/>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="set" value="true" field="hidden">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <modifierGroups>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.5c0d-5e93-d71f-f0da"/>
+            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.139a-e1a2-a79a-6fce"/>
+            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.1f2a-58a9-839b-59b0"/>
+            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.7b4c-9343-e884-9b28"/>
+            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.3a87-b1c8-8528-7efd"/>
+          </modifiers>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
+          </conditions>
+        </modifierGroup>
+      </modifierGroups>
+    </entryLink>
+    <entryLink import="true" name="Icebrow Hunter" hidden="false" id="2fea-de8c-571b-d4dd" type="selectionEntry" targetId="8ea1-2719-4da0-2b1f">
+      <entryLinks>
+        <entryLink import="true" name="Heroic Traits" hidden="false" id="ddce-baa8-e6ba-7a19" type="selectionEntryGroup" targetId="b31d-aee-8d55-5892"/>
+        <entryLink import="true" name="Artefacts of Power" hidden="false" id="f821-aad0-3351-3db" type="selectionEntryGroup" targetId="30c8-590c-42a7-3c48"/>
+        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="d88a-aa61-1515-af99" type="selectionEntryGroup" targetId="9b0d-58b7-8982-2128"/>
+        <entryLink import="true" name="Paths" hidden="false" id="30f1-9899-379c-8d60" type="selectionEntryGroup" targetId="517c-3059-2a24-89dc"/>
+        <entryLink import="true" name="Warlord" hidden="false" id="4db6-b5ac-aae3-c711" type="selectionEntry" targetId="bb28-fa4a-bf5f-f793"/>
+        <entryLink import="true" name="Renown" hidden="false" id="d5f2-02ad-86b2-cb82" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Big Names" hidden="false" id="75f9-065e-c1ac-32e5" type="selectionEntryGroup" targetId="c097-d461-7bb0-880c"/>
+        <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="fedf-35a5-e07d-02ec" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="130"/>
+      </costs>
+      <modifiers>
+        <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="lessThan" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true" includeChildForces="true"/>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="set" value="true" field="hidden">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="8f4b-1fa6-3128-8405" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <modifierGroups>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="bf4e-4b1b-7055-2ec8" field="category"/>
+          </modifiers>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifierGroup>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.1a3d-33f9-c4cc-fe0"/>
+          </modifiers>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
+          </conditions>
+        </modifierGroup>
+      </modifierGroups>
+    </entryLink>
+    <entryLink import="true" name="Slaughtermaster" hidden="false" id="4dea-ffce-568d-980" type="selectionEntry" targetId="3d51-af3a-455e-2373">
+      <entryLinks>
+        <entryLink import="true" name="Heroic Traits" hidden="false" id="2b3f-5257-d172-facd" type="selectionEntryGroup" targetId="b31d-aee-8d55-5892"/>
+        <entryLink import="true" name="Artefacts of Power" hidden="false" id="e4d5-bbc9-3139-10a4" type="selectionEntryGroup" targetId="30c8-590c-42a7-3c48"/>
+        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="b73b-a620-b91a-4182" type="selectionEntryGroup" targetId="9b0d-58b7-8982-2128"/>
+        <entryLink import="true" name="Paths" hidden="false" id="9052-cfdf-3f26-1720" type="selectionEntryGroup" targetId="517c-3059-2a24-89dc"/>
+        <entryLink import="true" name="Warlord" hidden="false" id="f480-fc9f-2a3c-5912" type="selectionEntry" targetId="bb28-fa4a-bf5f-f793"/>
+        <entryLink import="true" name="Renown" hidden="false" id="9eb8-efc5-88a1-c725" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+        <entryLink import="true" name="Big Names" hidden="false" id="0a7e-4f41-1aaa-1f84" type="selectionEntryGroup" targetId="c097-d461-7bb0-880c"/>
+        <entryLink import="true" name="Ghyranite Concoctions" hidden="false" id="ff58-fb3f-537d-c5a8" type="selectionEntryGroup" targetId="17d6-baae-dbeb-3e2c"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="160"/>
+      </costs>
+      <modifiers>
+        <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="lessThan" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true" includeChildForces="true"/>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="set" value="true" field="hidden">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <modifierGroups>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.5c0d-5e93-d71f-f0da"/>
+            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.139a-e1a2-a79a-6fce"/>
+            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.1f2a-58a9-839b-59b0"/>
+            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.7b4c-9343-e884-9b28"/>
+            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.3a87-b1c8-8528-7efd"/>
+          </modifiers>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
+          </conditions>
+        </modifierGroup>
+      </modifierGroups>
+    </entryLink>
+    <entryLink import="true" name="Frost Sabres" hidden="false" id="6706-c1c2-5c09-3199" type="selectionEntry" targetId="bdf9-1644-707-f0df">
+      <modifiers>
+        <modifier type="multiply" value="2" field="points">
+          <conditions>
+            <condition type="atLeast" value="1" field="selections" scope="self" childId="1b37-82b8-c062-eb82" shared="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="set" value="true" field="hidden">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="db3a-7199-c92e-f3cf" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <entryLinks>
+        <entryLink import="true" name="Reinforced" hidden="false" id="6180-90f0-86d8-79b3" type="selectionEntry" targetId="1b37-82b8-c062-eb82"/>
+        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="746d-4186-2de6-7b5c" type="selectionEntryGroup" targetId="9b0d-58b7-8982-2128"/>
+        <entryLink import="true" name="Paths" hidden="false" id="ff10-b562-8ac9-beaf" type="selectionEntryGroup" targetId="517c-3059-2a24-89dc"/>
+        <entryLink import="true" name="Renown" hidden="false" id="6899-536d-2f1d-ed3c" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="70"/>
+      </costs>
+    </entryLink>
+    <entryLink import="true" name="Gnoblars" hidden="false" id="139a-e1a2-a79a-6fce" type="selectionEntry" targetId="5d4b-756c-2229-3dd9">
+      <entryLinks>
+        <entryLink import="true" name="Reinforced" hidden="false" id="826e-bc5f-8e03-a2c0" type="selectionEntry" targetId="1b37-82b8-c062-eb82"/>
+        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="1d0c-3b3c-5695-7ef0" type="selectionEntryGroup" targetId="9b0d-58b7-8982-2128"/>
+        <entryLink import="true" name="Paths" hidden="false" id="6818-044b-327d-68f3" type="selectionEntryGroup" targetId="517c-3059-2a24-89dc"/>
+        <entryLink import="true" name="Renown" hidden="false" id="383f-8e77-6025-34e2" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+      </entryLinks>
+      <modifiers>
+        <modifier type="multiply" value="2" field="points">
+          <conditions>
+            <condition type="atLeast" value="1" field="selections" scope="self" childId="1b37-82b8-c062-eb82" shared="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="set" value="true" field="hidden">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="db3a-7199-c92e-f3cf" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <costs>
+        <cost name="pts" typeId="points" value="130"/>
+      </costs>
+    </entryLink>
+    <entryLink import="true" name="Icefall Yhetees" hidden="false" id="92ef-3f35-c07d-5d50" type="selectionEntry" targetId="5fed-90de-715-e720">
+      <entryLinks>
+        <entryLink import="true" name="Reinforced" hidden="false" id="1199-29d7-21f0-a7c9" type="selectionEntry" targetId="1b37-82b8-c062-eb82"/>
+        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="ea40-5d14-f295-b732" type="selectionEntryGroup" targetId="9b0d-58b7-8982-2128"/>
+        <entryLink import="true" name="Paths" hidden="false" id="8e0d-b0b1-55de-0820" type="selectionEntryGroup" targetId="517c-3059-2a24-89dc"/>
+        <entryLink import="true" name="Renown" hidden="false" id="b0e5-2817-307d-25f0" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+      </entryLinks>
+      <modifiers>
+        <modifier type="multiply" value="2" field="points">
+          <conditions>
+            <condition type="atLeast" value="1" field="selections" scope="self" childId="1b37-82b8-c062-eb82" shared="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="set" value="true" field="hidden">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="db3a-7199-c92e-f3cf" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <costs>
+        <cost name="pts" typeId="points" value="120"/>
+      </costs>
+    </entryLink>
+    <entryLink import="true" name="Leadbelchers" hidden="false" id="96ee-3e88-f022-9f5a" type="selectionEntry" targetId="15cd-469c-4ed6-afef">
+      <entryLinks>
+        <entryLink import="true" name="Reinforced" hidden="false" id="fe19-7963-30ce-cab8" type="selectionEntry" targetId="1b37-82b8-c062-eb82"/>
+        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="83a7-9bca-abbd-4eff" type="selectionEntryGroup" targetId="9b0d-58b7-8982-2128"/>
+        <entryLink import="true" name="Paths" hidden="false" id="9b70-05ce-d9e7-ec26" type="selectionEntryGroup" targetId="517c-3059-2a24-89dc"/>
+        <entryLink import="true" name="Renown" hidden="false" id="2287-5c7b-8898-27bc" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+      </entryLinks>
+      <modifiers>
+        <modifier type="multiply" value="2" field="points">
+          <conditions>
+            <condition type="atLeast" value="1" field="selections" scope="self" childId="1b37-82b8-c062-eb82" shared="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="set" value="true" field="hidden">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="db3a-7199-c92e-f3cf" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <costs>
+        <cost name="pts" typeId="points" value="140"/>
+      </costs>
+    </entryLink>
+    <entryLink import="true" name="Maneaters" hidden="false" id="c90-9fd3-ed17-5903" type="selectionEntry" targetId="f4ef-9156-1fd1-4b91">
+      <entryLinks>
+        <entryLink import="true" name="Reinforced" hidden="false" id="676c-3037-f5dc-2f20" type="selectionEntry" targetId="1b37-82b8-c062-eb82"/>
+        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="980c-c7e4-8333-fb73" type="selectionEntryGroup" targetId="9b0d-58b7-8982-2128"/>
+        <entryLink import="true" name="Paths" hidden="false" id="6a61-7821-41fd-46fa" type="selectionEntryGroup" targetId="517c-3059-2a24-89dc"/>
+        <entryLink import="true" name="Renown" hidden="false" id="708c-cabd-421f-fe50" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+      </entryLinks>
+      <modifiers>
+        <modifier type="multiply" value="2" field="points">
+          <conditions>
+            <condition type="atLeast" value="1" field="selections" scope="self" childId="1b37-82b8-c062-eb82" shared="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="set" value="true" field="hidden">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="db3a-7199-c92e-f3cf" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <costs>
+        <cost name="pts" typeId="points" value="180"/>
+      </costs>
+    </entryLink>
+    <entryLink import="true" name="Mournfang Pack" hidden="false" id="b077-f94b-b711-c147" type="selectionEntry" targetId="b91b-cba6-89af-7225">
+      <entryLinks>
+        <entryLink import="true" name="Reinforced" hidden="false" id="6995-2ecc-e512-e33f" type="selectionEntry" targetId="1b37-82b8-c062-eb82"/>
+        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="3ed8-e9cf-27d4-708d" type="selectionEntryGroup" targetId="9b0d-58b7-8982-2128"/>
+        <entryLink import="true" name="Paths" hidden="false" id="18cc-1e6b-da5f-2724" type="selectionEntryGroup" targetId="517c-3059-2a24-89dc"/>
+        <entryLink import="true" name="Renown" hidden="false" id="82ab-7274-def1-fb5f" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+      </entryLinks>
+      <modifiers>
+        <modifier type="multiply" value="2" field="points">
+          <conditions>
+            <condition type="atLeast" value="1" field="selections" scope="self" childId="1b37-82b8-c062-eb82" shared="true"/>
+          </conditions>
+        </modifier>
+        <modifier type="set" value="true" field="hidden">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="db3a-7199-c92e-f3cf" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <costs>
+        <cost name="pts" typeId="points" value="200"/>
+      </costs>
+    </entryLink>
+    <entryLink import="true" name="Great Mawpot" hidden="false" id="ea7b-cee5-4266-bbb9" type="selectionEntry" targetId="2586-d28e-7404-b64e">
+      <costs>
+        <cost name="pts" typeId="points" value="20"/>
+      </costs>
+    </entryLink>
   </entryLinks>
   <selectionEntries>
     <selectionEntry type="upgrade" import="true" name="Prayer Lore" hidden="true" id="67bf-bf00-ee96-f894" defaultAmount="1">

--- a/Ogor Mawtribes.cat
+++ b/Ogor Mawtribes.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="6353-cb84-ac7f-9a15" name="Ogor Mawtribes" gameSystemId="e51d-b1a3-75fc-dc3g" gameSystemRevision="2" revision="33" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="false" id="6353-cb84-ac7f-9a15" name="Ogor Mawtribes" gameSystemId="e51d-b1a3-75fc-dc3g" gameSystemRevision="2" revision="34" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <sharedSelectionEntryGroups>
     <selectionEntryGroup name="Spell Lores" id="daa3-d823-9bac-b8d" hidden="false" flatten="true">
       <selectionEntries>
@@ -2188,7 +2188,6 @@ Then, the unit using this ability can make a pile-in move. If the target of this
           <modifiers>
             <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.5c0d-5e93-d71f-f0da"/>
             <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.139a-e1a2-a79a-6fce"/>
-            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.1f2a-58a9-839b-59b0"/>
             <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.7b4c-9343-e884-9b28"/>
             <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.3a87-b1c8-8528-7efd"/>
           </modifiers>
@@ -2253,7 +2252,7 @@ Then, the unit using this ability can make a pile-in move. If the target of this
         </modifierGroup>
         <modifierGroup type="and">
           <modifiers>
-            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.1a3d-33f9-c4cc-fe0"/>
+            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.410d-6b15-3cf4-88d0"/>
           </modifiers>
           <conditions>
             <condition type="instanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
@@ -2301,11 +2300,7 @@ Then, the unit using this ability can make a pile-in move. If the target of this
       <modifierGroups>
         <modifierGroup type="and">
           <modifiers>
-            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.5c0d-5e93-d71f-f0da"/>
-            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.139a-e1a2-a79a-6fce"/>
-            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.1f2a-58a9-839b-59b0"/>
-            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.7b4c-9343-e884-9b28"/>
-            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.3a87-b1c8-8528-7efd"/>
+            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.b50b-6a98-f92a-c99c"/>
           </modifiers>
           <conditions>
             <condition type="instanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>

--- a/Ogor Mawtribes.cat
+++ b/Ogor Mawtribes.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="6353-cb84-ac7f-9a15" name="Ogor Mawtribes" gameSystemId="e51d-b1a3-75fc-dc3g" gameSystemRevision="2" revision="32" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="false" id="6353-cb84-ac7f-9a15" name="Ogor Mawtribes" gameSystemId="e51d-b1a3-75fc-dc3g" gameSystemRevision="2" revision="33" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <sharedSelectionEntryGroups>
     <selectionEntryGroup name="Spell Lores" id="daa3-d823-9bac-b8d" hidden="false" flatten="true">
       <selectionEntries>
@@ -910,11 +910,24 @@ Then, the unit using this ability can make a pile-in move. If the target of this
         <modifierGroup type="and">
           <modifiers>
             <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.743-1bd8-e3d-ced2"/>
-            <modifier type="add" value="8f4b-1fa6-3128-8405" field="category" scope="force" affects="self.entries.recursive.3941-ff89-5c42-9230"/>
           </modifiers>
           <conditions>
             <condition type="instanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
           </conditions>
+        </modifierGroup>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="bf4e-4b1b-7055-2ec8" field="category"/>
+          </modifiers>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
         </modifierGroup>
       </modifierGroups>
     </entryLink>
@@ -972,11 +985,33 @@ Then, the unit using this ability can make a pile-in move. If the target of this
       <modifierGroups>
         <modifierGroup type="and">
           <modifiers>
-            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.5c0d-5e93-d71f-f0da"/>
+            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.410d-6b15-3cf4-88d0"/>
           </modifiers>
           <conditions>
             <condition type="instanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
           </conditions>
+        </modifierGroup>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.75d6-6995-dfcc-3898"/>
+          </modifiers>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
+          </conditions>
+        </modifierGroup>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="bf4e-4b1b-7055-2ec8" field="category"/>
+          </modifiers>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
         </modifierGroup>
       </modifierGroups>
     </entryLink>
@@ -1020,11 +1055,8 @@ Then, the unit using this ability can make a pile-in move. If the target of this
       <modifierGroups>
         <modifierGroup type="and">
           <modifiers>
-            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.5c0d-5e93-d71f-f0da"/>
-            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.139a-e1a2-a79a-6fce"/>
-            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.1f2a-58a9-839b-59b0"/>
-            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.7b4c-9343-e884-9b28"/>
-            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.3a87-b1c8-8528-7efd"/>
+            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.75d6-6995-dfcc-3898"/>
+            <modifier type="add" value="8f4b-1fa6-3128-8405" field="category" scope="force" affects="self.entries.recursive.bf4e-4b1b-7055-2ec8"/>
           </modifiers>
           <conditions>
             <condition type="instanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
@@ -1224,21 +1256,8 @@ Then, the unit using this ability can make a pile-in move. If the target of this
       <modifierGroups>
         <modifierGroup type="and">
           <modifiers>
-            <modifier type="add" value="bf4e-4b1b-7055-2ec8" field="category"/>
-          </modifiers>
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true"/>
-                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifierGroup>
-        <modifierGroup type="and">
-          <modifiers>
-            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.1a3d-33f9-c4cc-fe0"/>
+            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.743-1bd8-e3d-ced2"/>
+            <modifier type="add" value="8f4b-1fa6-3128-8405" field="category" scope="force" affects="self.entries.recursive.bf4e-4b1b-7055-2ec8"/>
           </modifiers>
           <conditions>
             <condition type="instanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
@@ -1288,21 +1307,8 @@ Then, the unit using this ability can make a pile-in move. If the target of this
       <modifierGroups>
         <modifierGroup type="and">
           <modifiers>
-            <modifier type="add" value="bf4e-4b1b-7055-2ec8" field="category"/>
-          </modifiers>
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true"/>
-                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifierGroup>
-        <modifierGroup type="and">
-          <modifiers>
-            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.1a3d-33f9-c4cc-fe0"/>
+            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.743-1bd8-e3d-ced2"/>
+            <modifier type="add" value="8f4b-1fa6-3128-8405" field="category" scope="force" affects="self.entries.recursive.bf4e-4b1b-7055-2ec8"/>
           </modifiers>
           <conditions>
             <condition type="instanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
@@ -1352,21 +1358,7 @@ Then, the unit using this ability can make a pile-in move. If the target of this
       <modifierGroups>
         <modifierGroup type="and">
           <modifiers>
-            <modifier type="add" value="bf4e-4b1b-7055-2ec8" field="category"/>
-          </modifiers>
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
-                <condition type="atLeast" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true"/>
-                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifierGroup>
-        <modifierGroup type="and">
-          <modifiers>
-            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.1a3d-33f9-c4cc-fe0"/>
+            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.743-1bd8-e3d-ced2"/>
           </modifiers>
           <conditions>
             <condition type="instanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
@@ -1408,6 +1400,7 @@ Then, the unit using this ability can make a pile-in move. If the target of this
         <modifierGroup type="and">
           <modifiers>
             <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.743-1bd8-e3d-ced2"/>
+            <modifier type="add" value="8f4b-1fa6-3128-8405" field="category" scope="force" affects="self.entries.recursive.bf4e-4b1b-7055-2ec8"/>
           </modifiers>
           <conditions>
             <condition type="instanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
@@ -1858,7 +1851,15 @@ Then, the unit using this ability can make a pile-in move. If the target of this
         </modifierGroup>
         <modifierGroup type="and">
           <modifiers>
-            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.1a3d-33f9-c4cc-fe0"/>
+            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.410d-6b15-3cf4-88d0"/>
+          </modifiers>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
+          </conditions>
+        </modifierGroup>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.75d6-6995-dfcc-3898"/>
           </modifiers>
           <conditions>
             <condition type="instanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
@@ -1873,6 +1874,40 @@ Then, the unit using this ability can make a pile-in move. If the target of this
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="c9ee-c9c8-32cf-d5c0" type="selectionEntryGroup" targetId="9b0d-58b7-8982-2128"/>
       </entryLinks>
+      <modifiers>
+        <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="lessThan" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true" includeChildForces="true"/>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="set" value="true" field="hidden">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <modifierGroups>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.743-1bd8-e3d-ced2"/>
+            <modifier type="add" value="8f4b-1fa6-3128-8405" field="category" scope="force" affects="self.entries.recursive.bf4e-4b1b-7055-2ec8"/>
+          </modifiers>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
+          </conditions>
+        </modifierGroup>
+      </modifierGroups>
     </entryLink>
     <entryLink import="true" name="Grell Firefist" hidden="false" id="29ec-3583-c704-1e15" type="selectionEntry" targetId="3fb5-d2d7-81b4-6a19">
       <costs>
@@ -1881,6 +1916,53 @@ Then, the unit using this ability can make a pile-in move. If the target of this
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="4dcc-5b5f-e726-1d0a" type="selectionEntryGroup" targetId="9b0d-58b7-8982-2128"/>
       </entryLinks>
+      <modifiers>
+        <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="lessThan" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true" includeChildForces="true"/>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="set" value="true" field="hidden">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <modifierGroups>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.743-1bd8-e3d-ced2"/>
+          </modifiers>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
+          </conditions>
+        </modifierGroup>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="bf4e-4b1b-7055-2ec8" field="category"/>
+          </modifiers>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifierGroup>
+      </modifierGroups>
     </entryLink>
     <entryLink import="true" name="Redd the Maw, High Slaughtermaster" hidden="false" id="ccf2-f7fd-a8ae-c8ae" type="selectionEntry" targetId="63b1-7b0e-39da-a18f">
       <costs>
@@ -1889,6 +1971,40 @@ Then, the unit using this ability can make a pile-in move. If the target of this
       <entryLinks>
         <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="2589-f0cd-82e6-1536" type="selectionEntryGroup" targetId="9b0d-58b7-8982-2128"/>
       </entryLinks>
+      <modifiers>
+        <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="lessThan" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true" includeChildForces="true"/>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="set" value="true" field="hidden">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <modifierGroups>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.743-1bd8-e3d-ced2"/>
+            <modifier type="add" value="8f4b-1fa6-3128-8405" field="category" scope="force" affects="self.entries.recursive.bf4e-4b1b-7055-2ec8"/>
+          </modifiers>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
+          </conditions>
+        </modifierGroup>
+      </modifierGroups>
     </entryLink>
     <entryLink import="true" name="Tyrant on Glutthorn" hidden="false" id="0d98-17de-fdc4-9899" type="selectionEntry" targetId="9e4e-efb1-3f18-b23d">
       <entryLinks>
@@ -1905,6 +2021,40 @@ Then, the unit using this ability can make a pile-in move. If the target of this
       <costs>
         <cost name="pts" typeId="points" value="400"/>
       </costs>
+      <modifiers>
+        <modifier type="set-primary" value="d1f3-921c-b403-1106" field="category" scope="root-entry">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="lessThan" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true" includeChildForces="true"/>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="set" value="true" field="hidden">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition type="instanceOf" value="1" field="selections" scope="ancestor" childId="376a-6b97-8699-dd59" shared="true"/>
+                <condition type="atLeast" value="1" field="selections" scope="force" childId="d1f3-921c-b403-1106" shared="true" includeChildSelections="true"/>
+                <condition type="notInstanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <modifierGroups>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="add" value="db3a-7199-c92e-f3cf" field="category" scope="force" affects="self.entries.recursive.743-1bd8-e3d-ced2"/>
+            <modifier type="add" value="8f4b-1fa6-3128-8405" field="category" scope="force" affects="self.entries.recursive.bf4e-4b1b-7055-2ec8"/>
+          </modifiers>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="self" childId="d1f3-921c-b403-1106" shared="true"/>
+          </conditions>
+        </modifierGroup>
+      </modifierGroups>
     </entryLink>
     <entryLink import="true" name="Maulbeast Cavalry" hidden="false" id="29f5-da35-9731-81b2" type="selectionEntry" targetId="4781-28ae-2385-ff02">
       <entryLinks>
@@ -2408,7 +2558,7 @@ Then, the unit using this ability can make a pile-in move. If the target of this
     </selectionEntry>
   </selectionEntries>
   <categoryEntries>
-    <categoryEntry name="Voice of the Everwinter" id="bf4e-4b1b-7055-2ec8" hidden="false">
+    <categoryEntry name="Maw Nomad" id="bf4e-4b1b-7055-2ec8" hidden="false">
       <modifiers>
         <modifier type="set" value="1" field="559f-7afb-324c-765b">
           <conditionGroups>

--- a/Regiments of Renown.cat
+++ b/Regiments of Renown.cat
@@ -4650,6 +4650,104 @@
         <constraint type="min" value="0" field="selections" scope="force" shared="true" id="aa65-caf4-f546-d56e" automatic="true"/>
       </constraints>
     </entryLink>
+    <entryLink import="true" name="Huskard on Stonehorn" hidden="true" id="2342-b49b-5361-f66b" type="selectionEntry" targetId="8bfb-791d-158b-35a2">
+      <categoryLinks>
+        <categoryLink name="Restrict General" hidden="false" id="cbfc-f7e2-7cc2-987f" targetId="abcb-73d0-2b6c-4f17" primary="false"/>
+      </categoryLinks>
+      <constraints>
+        <constraint type="min" value="0" field="selections" scope="force" shared="true" id="5288-95c7-0f7b-be12" automatic="true"/>
+        <constraint type="max" value="0" field="selections" scope="force" shared="true" id="b857-f412-7552-8dff" automatic="true"/>
+      </constraints>
+      <modifierGroups>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="set" value="1" field="5288-95c7-0f7b-be12"/>
+            <modifier type="set" value="1" field="b857-f412-7552-8dff"/>
+            <modifier type="set" value="false" field="hidden"/>
+          </modifiers>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="force" childId="7199-3205-3f4e-5567" shared="true"/>
+          </conditions>
+        </modifierGroup>
+      </modifierGroups>
+      <entryLinks>
+        <entryLink import="true" name="Paths" hidden="false" id="7c94-99b5-32a3-5489" type="selectionEntryGroup" targetId="1a3f-5432-a929-6cb8"/>
+        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="b104-aef0-6827-20e7" type="selectionEntryGroup" targetId="592c-d2b8-c3fb-73ff"/>
+        <entryLink import="true" name="Renown" hidden="false" id="1f6d-822c-38d4-0eac" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+      </entryLinks>
+    </entryLink>
+    <entryLink import="true" name="Thundertusk Beastriders" hidden="true" id="eccf-56b9-b452-87e8" type="selectionEntry" targetId="e5a2-5b7c-b7af-8da6">
+      <constraints>
+        <constraint type="min" value="0" field="selections" scope="force" shared="true" id="b983-f14a-901a-0335" automatic="true"/>
+        <constraint type="max" value="0" field="selections" scope="force" shared="true" id="76f0-b184-7ffe-d7db" automatic="true"/>
+      </constraints>
+      <modifierGroups>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="set" value="1" field="b983-f14a-901a-0335"/>
+            <modifier type="set" value="1" field="76f0-b184-7ffe-d7db"/>
+            <modifier type="set" value="false" field="hidden"/>
+          </modifiers>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="force" childId="7199-3205-3f4e-5567" shared="true"/>
+          </conditions>
+        </modifierGroup>
+      </modifierGroups>
+      <entryLinks>
+        <entryLink import="true" name="Paths" hidden="false" id="4fef-92b4-75df-6fbd" type="selectionEntryGroup" targetId="1a3f-5432-a929-6cb8"/>
+        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="b56a-cda9-37c4-493f" type="selectionEntryGroup" targetId="592c-d2b8-c3fb-73ff"/>
+        <entryLink import="true" name="Renown" hidden="false" id="787f-ef57-7e72-84ee" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+      </entryLinks>
+    </entryLink>
+    <entryLink import="true" name="Tyrant on Glutthorn" hidden="true" id="e230-eb79-dbf7-06ca" type="selectionEntry" targetId="9e4e-efb1-3f18-b23d">
+      <categoryLinks>
+        <categoryLink name="Restrict General" hidden="false" id="2a79-b035-f046-6397" targetId="abcb-73d0-2b6c-4f17" primary="false"/>
+      </categoryLinks>
+      <constraints>
+        <constraint type="min" value="0" field="selections" scope="force" shared="true" id="e6c2-fd39-a166-b3fc" automatic="true"/>
+        <constraint type="max" value="0" field="selections" scope="force" shared="true" id="20b3-2f30-d745-9d9c" automatic="true"/>
+      </constraints>
+      <modifierGroups>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="set" value="1" field="e6c2-fd39-a166-b3fc"/>
+            <modifier type="set" value="1" field="20b3-2f30-d745-9d9c"/>
+            <modifier type="set" value="false" field="hidden"/>
+          </modifiers>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="force" childId="71ed-0753-4dbb-c952" shared="true"/>
+          </conditions>
+        </modifierGroup>
+      </modifierGroups>
+      <entryLinks>
+        <entryLink import="true" name="Paths" hidden="false" id="3ade-cd17-391e-ac78" type="selectionEntryGroup" targetId="1a3f-5432-a929-6cb8"/>
+        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="af83-9728-7f11-789a" type="selectionEntryGroup" targetId="592c-d2b8-c3fb-73ff"/>
+        <entryLink import="true" name="Renown" hidden="false" id="5eaf-5a36-179a-5669" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+      </entryLinks>
+    </entryLink>
+    <entryLink import="true" name="Maulbeast Cavalry" hidden="true" id="3b7b-b8e4-a3b1-c1db" type="selectionEntry" targetId="4781-28ae-2385-ff02">
+      <constraints>
+        <constraint type="min" value="0" field="selections" scope="force" shared="true" id="a157-21a8-dc4f-587f" automatic="true"/>
+        <constraint type="max" value="0" field="selections" scope="force" shared="true" id="8eb9-5d68-61af-d14e" automatic="true"/>
+      </constraints>
+      <modifierGroups>
+        <modifierGroup type="and">
+          <modifiers>
+            <modifier type="set" value="2" field="a157-21a8-dc4f-587f"/>
+            <modifier type="set" value="2" field="8eb9-5d68-61af-d14e"/>
+            <modifier type="set" value="false" field="hidden"/>
+          </modifiers>
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="force" childId="71ed-0753-4dbb-c952" shared="true"/>
+          </conditions>
+        </modifierGroup>
+      </modifierGroups>
+      <entryLinks>
+        <entryLink import="true" name="Paths" hidden="false" id="ae2e-b1cf-b21f-5a7a" type="selectionEntryGroup" targetId="1a3f-5432-a929-6cb8"/>
+        <entryLink import="true" name="Battle Wounds + Scars" hidden="false" id="6363-98ef-0ce2-072a" type="selectionEntryGroup" targetId="592c-d2b8-c3fb-73ff"/>
+        <entryLink import="true" name="Renown" hidden="false" id="f60e-8f15-dc52-b45e" type="selectionEntry" targetId="e7d5-5062-46d5-38dd"/>
+      </entryLinks>
+    </entryLink>
   </entryLinks>
   <catalogueLinks>
     <catalogueLink type="catalogue" name="Soulblight Gravelords - Library" id="4d19-406d-3ac6-a882" targetId="dff3-13f8-82b5-3347"/>
@@ -9291,6 +9389,96 @@ If you picked a **Dreadful Visage** or **Wheels of Excruciation**, set it up who
         <modifier type="set" value="false" field="hidden">
           <conditions>
             <condition type="instanceOf" value="1" field="selections" scope="force" childId="bb82-173a-f3b3-d48c" shared="true" includeChildForces="true" includeChildSelections="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+    </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Regiment of Renown: Okar&apos;s Torrbad" hidden="true" id="5075-d3a2-5ff0-1b91" defaultAmount="0" publicationId="1ac6-e227-a186-12">
+      <categoryLinks>
+        <categoryLink name="Reference" hidden="false" id="21f9-9c8c-4b86-b058" targetId="3360-1158-e879-9606" primary="true"/>
+      </categoryLinks>
+      <constraints>
+        <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="af39-c88c-0d3f-fe3d" includeChildSelections="true" includeChildForces="true"/>
+      </constraints>
+      <profiles>
+        <profile name="Along the Icepaths" typeId="5946-234-d7b4-6195" typeName="Ability (Prayer)" hidden="false" id="d45a-1bfa-4982-af3a">
+          <characteristics>
+            <characteristic name="Timing" typeId="76bf-8126-64d4-c709">Your Hero Phase</characteristic>
+            <characteristic name="Chanting Value" typeId="f192-6780-8138-9cef">4</characteristic>
+            <characteristic name="Declare" typeId="284c-90b2-245b-adf3">Pick the **Huskard on Stonehorn** in this Regiment of Renown to chant this prayer, pick up to 3 visible friendly units wholly within 12&quot; of them to be the targets, then make a chanting roll of D6. Add 1 to the roll if the friendly **Thundertusk Beastriders** unit in this Regiment of Renown is wholly within 12&quot; of this unit.</characteristic>
+            <characteristic name="Effect" typeId="6219-6fcc-5ae2-a6b7">Until the start of your next turn:
+• Add 3 to run rolls for each target.
+• Each target can use **^^Charge^^** abilities even if it used a **^^Retreat^^** ability in the same turn.
+• Each time a target uses a **^^Retreat^^** ability, no mortal damage is inflicted on it.</characteristic>
+            <characteristic name="Keywords" typeId="e3d8-f58b-e4e0-8e9d">**^^Prayer^^**</characteristic>
+          </characteristics>
+          <attributes>
+            <attribute typeId="7564-4bf0-b34a-b143" name="Color">Yellow</attribute>
+            <attribute typeId="c63c-196d-34a7-cec3" name="Type">Special</attribute>
+            <attribute name="Parent Node" typeId="5d25-63d6-3935-9312"/>
+          </attributes>
+        </profile>
+        <profile name="Cling On Tight" typeId="907f-a48-6a04-f788" typeName="Ability (Passive)" hidden="false" id="76c2-fb34-9c10-621f">
+          <characteristics>
+            <characteristic name="Keywords" typeId="b977-7c5e-33b2-428e"/>
+            <characteristic name="Effect" typeId="fd7f-888d-3257-a12b">Each time the **Thundertusk Beastriders** unit in this Regiment of Renown uses the &apos;Plough the Icepath&apos; ability, you can pick a friendly **^^Infantry^^** unit that has not been reinforced, is wholly within 6&quot; of that **Thundertusk Beastriders** unit and has not been set up this turn to be the target instead of a friendly **^^Ogor Mawtribes Infantry^^** unit.</characteristic>
+          </characteristics>
+          <attributes>
+            <attribute typeId="50fe-4f29-6bc3-dcc6" name="Color">Gray</attribute>
+            <attribute typeId="bf11-4e10-3ab1-06f4" name="Type">Movement</attribute>
+            <attribute name="Parent Node" typeId="e2e1-15ca-d345-22b8"/>
+          </attributes>
+        </profile>
+      </profiles>
+      <modifiers>
+        <modifier type="set" value="false" field="hidden">
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="force" childId="7199-3205-3f4e-5567" shared="true" includeChildSelections="true" includeChildForces="true"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+    </selectionEntry>
+    <selectionEntry type="upgrade" import="true" name="Regiment of Renown: Urrgar&apos;s Maulerguts" hidden="true" id="6c17-d75a-5b24-c11c" defaultAmount="0" publicationId="1ac6-e227-a186-12">
+      <categoryLinks>
+        <categoryLink name="Reference" hidden="false" id="7fc0-b77c-7b5c-4f09" targetId="3360-1158-e879-9606" primary="true"/>
+      </categoryLinks>
+      <constraints>
+        <constraint type="max" value="1" field="selections" scope="roster" shared="true" id="6c00-3e41-3f9e-5932" includeChildSelections="true" includeChildForces="true"/>
+      </constraints>
+      <profiles>
+        <profile name="We'll Be There - If the Pay's Right" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="1d1f-61f0-cda2-1c4f">
+          <characteristics>
+            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Battle (Army), Deployment Phase</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick each unit in this Regiment of Renown to be the targets if none of them have been deployed.</characteristic>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Set up the targets in reserve **preparing a flank attack**. They have now been deployed.</characteristic>
+            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f">**^^Deploy^^**</characteristic>
+            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+          </characteristics>
+          <attributes>
+            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Black</attribute>
+            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Special</attribute>
+            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+          </attributes>
+        </profile>
+        <profile name="The Horns Hit Home" typeId="59b6-d47a-a68a-5dcc" typeName="Ability (Activated)" hidden="false" id="1731-588a-8ef0-8aab">
+          <characteristics>
+            <characteristic name="Timing" typeId="652c-3d84-4e7-14f4">Once Per Battle (Army), Your Movement Phase</characteristic>
+            <characteristic name="Declare" typeId="bad3-f9c5-ba46-18cb">Pick each friendly unit that is **preparing a flank attack** to be the targets.</characteristic>
+            <characteristic name="Effect" typeId="b6f1-ba36-6cd-3b03">Set up the targets on the battlefield, wholly within 6&quot; of each other, wholly within 9&quot; of a battlefield edge and more than 9&quot; from all enemy units.</characteristic>
+            <characteristic name="Keywords" typeId="12e8-3214-7d8f-1d0f"/>
+            <characteristic name="Used By" typeId="1b32-c9d6-3106-166b"/>
+          </characteristics>
+          <attributes>
+            <attribute typeId="5a11-eab3-180c-ddf5" name="Color">Gray</attribute>
+            <attribute typeId="6d16-c86b-2698-85a4" name="Type">Movement</attribute>
+            <attribute name="Parent Node" typeId="2d74-4dcd-8468-87fa"/>
+          </attributes>
+        </profile>
+      </profiles>
+      <modifiers>
+        <modifier type="set" value="false" field="hidden">
+          <conditions>
+            <condition type="instanceOf" value="1" field="selections" scope="force" childId="71ed-0753-4dbb-c952" shared="true" includeChildSelections="true" includeChildForces="true"/>
           </conditions>
         </modifier>
       </modifiers>

--- a/Regiments of Renown.cat
+++ b/Regiments of Renown.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue library="false" id="1ed8-2e23-1563-c119" name="۞ Regiments of Renown" gameSystemId="e51d-b1a3-75fc-dc3g" gameSystemRevision="2" revision="64" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue library="false" id="1ed8-2e23-1563-c119" name="۞ Regiments of Renown" gameSystemId="e51d-b1a3-75fc-dc3g" gameSystemRevision="2" revision="65" battleScribeVersion="2.03" type="catalogue" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink import="true" name="Neferata, Mortarch of Blood" hidden="true" id="69dd-9ab3-ca73-65c" type="selectionEntry" targetId="ca26-c079-31bc-38a8">
       <constraints>

--- a/Regiments of Renown.cat
+++ b/Regiments of Renown.cat
@@ -4733,8 +4733,8 @@
       <modifierGroups>
         <modifierGroup type="and">
           <modifiers>
-            <modifier type="set" value="2" field="a157-21a8-dc4f-587f"/>
-            <modifier type="set" value="2" field="8eb9-5d68-61af-d14e"/>
+            <modifier type="set" value="1" field="a157-21a8-dc4f-587f"/>
+            <modifier type="set" value="1" field="8eb9-5d68-61af-d14e"/>
             <modifier type="set" value="false" field="hidden"/>
           </modifiers>
           <conditions>


### PR DESCRIPTION
Two related corrections for the Ogor Mawtribes units covered by the **Battletome Supplement** (moving to Warhammer Legends on 1 June 2027).

### 1. Warscroll profiles (Battletome Supplement)
Updates the 10 supplement warscrolls to their new profiles:

| Warscroll | Change |
|---|---|
| Slaughtermaster | Mawseekers (was Gutbusters), Ward (6+), Control 3, Stump Blades only, rewritten Fill the Pot / Great Cauldron |
| Icebrow Hunter | Control 3, Culling Club Dmg 2, single "Great Throwing Spear and Crossbow" 12"/2/4+/3+/-/D3 |
| Mournfang Pack | Tusks Dmg 1 + Charge (+1 Damage); dropped Ironlock Pistol and Lumpen Wall of Flesh |
| Firebelly | Control 3 |
| Frost Sabres | added Gutless; Tusks and Claws Companion |
| Gnoblars | added Gutless |
| Leadbelchers | Leadbelcher Gun Attacks 2 |
| Maneaters | Pistols or Throwing Weapons Damage 2 |
| Icefall Yhetees | removed Ward (6+) (not on the new warscroll) |
| Great Mawpot | unchanged (already correct) |

### 2. Regiment options (Aug 2026 Battle Profiles)
Three Legends heroes still carried their old regiment options:
- **Slaughtermaster**: now **Any Mawseekers** (was the old Gutbusters-caster regiment)
- **Firebelly**: dropped **Gorger Mawpack** (not in the profile)
- **Icebrow Hunter**: now **Any Beastclaw** (was the stale "Beastclaw Raiders" category)

Draft pending review.